### PR TITLE
Checks rtcpobj creation

### DIFF
--- a/webhomer/js/homer.js
+++ b/webhomer/js/homer.js
@@ -797,6 +797,7 @@ function showRtcpStats(corr_id, from_time, to_time, apiurl, winid, codec, loc) {
                                    //table += val.msg+'<BR>');
                                    
                                    var rtcpobj = jQuery.parseJSON( val.msg );
+                                   if (!rtcpobj) { return 1; }
                                    var ts;
                                    var totalpkts;
 				   var si = rtcpobj.sender_information;


### PR DESCRIPTION
Avoid getting a blank page instead of RTCP Infos if "rtcpobj" creation fails.