### PR TITLE
Legend columns number

### DIFF
--- a/webhomer/modules/IP/index_data.php
+++ b/webhomer/modules/IP/index_data.php
@@ -134,6 +134,7 @@ $from_date = date("Y-m-d H:i:s", time() - ( $hours * 3600 ) );
         	},
 	        legend: {
         	    show: true,
+        	    noColumns: 2,
 	            labelFormatter: function(label, series) {
                 	 return ' ' + label.slice(0,30) + ' ('+Math.round(series.percent)+'%)';
 	                }
@@ -164,6 +165,7 @@ $from_date = date("Y-m-d H:i:s", time() - ( $hours * 3600 ) );
                 },
 	        legend: {
         	    show: true,
+        	    noColumns: 2,
 	            labelFormatter: function(label, series) {
                 	 return ' ' + label.slice(0,30) + ' ('+Math.round(series.percent)+'%)';
 	                }


### PR DESCRIPTION
Split IP graphs legend in two columns, instead of one (useful if you have more than a few entries...)