### PR TITLE
Alarm system with via host IP

### DIFF
--- a/configs/kamailio.cfg
+++ b/configs/kamailio.cfg
@@ -218,6 +218,8 @@ onreply_route {
                 sip_capture("$var(a)");
                 drop;
         }
+        
+        route(PARSE_STATS_IP);
 
         $sht(b=>$rs::$cs::$rm::$ci) = 1;
 

--- a/configs/kamailio.cfg
+++ b/configs/kamailio.cfg
@@ -218,8 +218,6 @@ onreply_route {
                 sip_capture("$var(a)");
                 drop;
         }
-        
-        route(PARSE_STATS_IP);
 
         $sht(b=>$rs::$cs::$rm::$ci) = 1;
 
@@ -356,6 +354,8 @@ route[TIMER_STATS] {
            $var(i) = $var(i) + 1;
         }   
     }
+
+    route(PARSE_STATS_IP);
 
     #413
     if($sht(a=>alarm::413) >  $avp(413)) {

--- a/configs/kamailio.cfg
+++ b/configs/kamailio.cfg
@@ -46,6 +46,7 @@ loadmodule "siputils.so"
 
 modparam("htable", "htable", "a=>size=8;autoexpire=400")
 modparam("htable", "htable", "b=>size=8;autoexpire=31")
+modparam("htable", "htable", "c=>size=15;autoexpire=400")
 
 modparam("rtimer", "timer", "name=ta;interval=60;mode=1;")
 modparam("rtimer", "exec", "timer=ta;route=TIMER_STATS")
@@ -232,30 +233,33 @@ onreply_route {
                 $sht(a=>alarm::483) = $sht(a=>alarm::483) + 1;
 
         }
-        # loops
+        # 482 Loop Detected
         else if(status == "482") {
                 if($sht(a=>alarm::482) == $null) $sht(a=>alarm::482) = 0;
                 $sht(a=>alarm::482) = $sht(a=>alarm::482) + 1;
 
         }
-        # 400
+        # 400 Bad Request
         else if(status == "400") {
                 if($sht(a=>alarm::400) == $null) $sht(a=>alarm::400) = 0;
                 $sht(a=>alarm::400) = $sht(a=>alarm::400) + 1;
+                route(STATS_BY_IP);
 
         }
 
-        # 500
+        # 500 Server Internal Error
         else if(status == "500") {
                 if($sht(a=>alarm::500) == $null) $sht(a=>alarm::500) = 0;
                 $sht(a=>alarm::500) = $sht(a=>alarm::500) + 1;
+                route(STATS_BY_IP);
         }
-        # 503
+        # 503 Service Unavailable
         else if(status == "503") {
                 if($sht(a=>alarm::503) == $null) $sht(a=>alarm::503) = 0;
                 $sht(a=>alarm::503) = $sht(a=>alarm::503) + 1;
+                route(STATS_BY_IP);
         }
-        # 403
+        # 403 Forbidden
         else if(status == "403") {
                 if($sht(a=>alarm::403) == $null) $sht(a=>alarm::403) = 0;
                 $sht(a=>alarm::403) = $sht(a=>alarm::403) + 1;
@@ -283,11 +287,12 @@ onreply_route {
                         if($sht(a=>stats::sd) == $null) $sht(a=>stats::sd) = 0;
                         $sht(a=>stats::sd) = $sht(a=>stats::sd) + 1;
                 }
-
+                # 407 Proxy Authentication Required
                 if(status == "407") {
                         if($sht(a=>response::407::invite) == $null) $sht(a=>response::407::invite)= 0;
                         $sht(a=>response::407::invite) = $sht(a=>response::407::invite) + 1;
                 }
+                #401 Unauthorized
                 else if(status == "401") {
                         if($sht(a=>response::401::invite) == $null) $sht(a=>response::401::invite)= 0;
                         $sht(a=>response::401::invite) = $sht(a=>response::401::invite) + 1;
@@ -318,6 +323,24 @@ onreply_route {
         drop;
 }
 
+route[STATS_BY_IP] {
+        if($sht(c=>$rs::$sel(via[1].host)) == $null) $sht(c=>$rs::$sel(via[1].host)) = 0;
+        $sht(c=>$rs::$sel(via[1].host)) = $sht(c=>$rs::$sel(via[1].host)) + 1;
+}
+
+route[PARSE_STATS_IP] {
+        sht_iterator_start("i1", "c");
+        while(sht_iterator_next("i1")) {
+                $var(sipcode) = $(shtitkey(i1){s.select,0,:});
+                $var(ip) = $(shtitkey(i1){s.select,2,:});
+                
+                if($shtitval(i1) > $avp($var(sipcode))) {
+                        sql_query("cb", "INSERT INTO alarm_data (create_date, type, total, source_ip, description) VALUES(NOW(), 'Too Many $var(sipcode)', $shtitval(i1), '$var(ip)', 'Too Many $var(sipcode)')");
+                }
+        }
+        sht_iterator_end("i1");
+        sht_rm_name_re("c=>.*");
+}
 
 route[TIMER_STATS] {
 


### PR DESCRIPTION
Ex:

1) Hacker (1.1.1.1) == ATTACK==> Provider SBC (2.2.2.2)
2) Provider SBC (2.2.2.2) ==5XX==> Hacker (1.1.1.1)

If reply request (5XX, 4XX) are greater than alarm thresholds, push alarm with Hacker IP and not source IP of reply request.

Kevin is going to change webhomer to help at search in alarm web page.