### PR TITLE
Bugfix & Active Directory LDAP compatibility

### DIFF
--- a/webhomer/class/auth/ldap/auth.php
+++ b/webhomer/class/auth/ldap/auth.php
@@ -68,8 +68,8 @@ class HomerAuthentication extends Authentication {
                           if (@ldap_bind( $ds, $result[0]['dn'], $password) ) {
                               if($result[0] != NULL) {
                                     //if (LDAP_GROUPDN != NULL) {
-                                     if (defined(LDAP_GROUPDN)) {
-                                        if (!$this->check_filegroup_membership($ds,$username)) {
+                                     if (defined("LDAP_GROUPDN")) {
+                                        if (!$this->check_filegroup_membership($ds,$result[0]['dn'])) {
                                             return false;
                                         }
                                     }
@@ -97,7 +97,7 @@ class HomerAuthentication extends Authentication {
   /* posixGroup schema, rfc2307 */
   function check_filegroup_membership($ds, $uid) {
     $dn = LDAP_GROUPDN;
-    $attr = "memberUid";
+    $attr = LDAP_GROUP_ATTRIBUTE;
 
     $result = @ldap_compare($ds, $dn, $attr, $uid);
 


### PR DESCRIPTION
Line 71:  Bugfix: defined requires args to be in quotes
Line 72:  Compat: This works for Active Directory, but might horribly break other directory services.  Creating a constant in preferences called "ACTIVE_DIRECTORY" and checking that and determining whether to pass $username or $result[0]['dn'] would be better.
Line 100:  Compat: memberUid is meaningless in AD.  So, allow the user to specify their own LDAP_GROUP_ATTRIBUTE.  There is a corresponding change in settings.