### PR TITLE
Active Directory Compatibility Setting

### DIFF
--- a/webhomer/class/auth/ldap/settings.php
+++ b/webhomer/class/auth/ldap/settings.php
@@ -18,6 +18,7 @@ define('LDAP_ADMIN_USER',"user1,user2,user3,user4");
 # define('LDAP_VERSION', "3");
 // Require membership of group to login
 #define('LDAP_GROUPDN',"cn=groupname,dc=example,dc=com");
+#define('LDAP_GROUP_ATTRIBUTE',"member")
 
 // If you need to authenticate conections with the ldap uncoment these
 #define('LDAP_BIND_USER', "uid=ldapuserauth,ou=users,dc=example,dc=com");


### PR DESCRIPTION
Line 21: Added LDAP_GROUP_ATTRIBUTE constant so that Active Directory users could specify the attribute to search in.