### PR TITLE
FIX: build RPM failure (captagent missing, Perl script missing)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,6 +9,5 @@ sql_DATA = \
 	sql/create_sipcapture.sql
 
 SUBDIRS = \
-	captagent \
 	scripts \
 	webhomer

--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,6 @@ AC_ARG_WITH([lighttpd],
 
 AC_CONFIG_FILES([
     Makefile
-    captagent/Makefile
     webhomer/Makefile
     scripts/Makefile
 ])

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -1,4 +1,3 @@
 dist_libexec_SCRIPTS = \
 	partrotate_unixtimestamp.pl \
-	statistic.pl \
 	clear_callflow.sh


### PR DESCRIPTION
With this patch web-homer can be built as an RPM package without catagent, which is a separate module.