### PR TITLE
Remove default CloudShark API token.

### DIFF
--- a/webhomer/preferences_example.php
+++ b/webhomer/preferences_example.php
@@ -83,10 +83,11 @@ define('SERVICE_SMTP_PORT', 25);
 define('SERVICE_SSH_PORT', 22);
 define('SERVICE_SIP_PORT', 5060);
 
-/* PCAP Exporting: Set to '0' for Local Shark, '1' for Cloud Shark  */
+/* PCAP Exporting: Set to '0' for Local Shark, '1' for CloudShark  */
+/* CloudShark REQUIRES a free account and API token to upload. Sign up at https://www.cloudshark.org */
 /* WARNING: Internet routes or proxy defaults REQUIRED to use CloudShark */
 define('CSHARK', 0);
-define('CSHARK_API', "2468738734d4f9db0d4b65db0c5daa3d"); /* Homer generic key, request yours if needed */
+define('CSHARK_API', "");
 define('CSHARK_URI', "https://www.cloudshark.org");
 
 /* SKIP AUTH for CFLOW/PCAP */


### PR DESCRIPTION
CloudShark now requires that any upload be done from a personal account and we're deactivating this API token.

CloudShark accounts are free and can be signed up for at https://www.cloudshark.org.