### PR TITLE
feat(coordinator): virtual fields in fields_mapping for data_extra se…

### DIFF
--- a/examples/mappings/fields_sip_call.json
+++ b/examples/mappings/fields_sip_call.json
@@ -233,5 +233,33 @@
       "path": "to_tag",
       "match": "like"
     }
+  },
+  {
+    "id": "no_to_tag",
+    "name": "No To-tag (e.g. first INVITE)",
+    "type": "string",
+    "index": "none",
+    "form_type": "checkbox",
+    "position": 19,
+    "hide": true,
+    "virtual": {
+      "kind": "data_extra_json",
+      "path": "to_tag",
+      "match": "absent"
+    }
+  },
+  {
+    "id": "has_to_tag",
+    "name": "Has To-tag",
+    "type": "string",
+    "index": "none",
+    "form_type": "checkbox",
+    "position": 20,
+    "hide": true,
+    "virtual": {
+      "kind": "data_extra_json",
+      "path": "to_tag",
+      "match": "present"
+    }
   }
 ]

--- a/examples/mappings/fields_sip_call.json
+++ b/examples/mappings/fields_sip_call.json
@@ -205,5 +205,33 @@
     "form_type": "input",
     "position": 16,
     "hide": true
+  },
+  {
+    "id": "from_tag",
+    "name": "From tag (JSON)",
+    "type": "string",
+    "index": "none",
+    "form_type": "input",
+    "position": 17,
+    "hide": true,
+    "virtual": {
+      "kind": "data_extra_json",
+      "path": "from_tag",
+      "match": "like"
+    }
+  },
+  {
+    "id": "to_tag",
+    "name": "To tag (JSON)",
+    "type": "string",
+    "index": "none",
+    "form_type": "input",
+    "position": 18,
+    "hide": true,
+    "virtual": {
+      "kind": "data_extra_json",
+      "path": "to_tag",
+      "match": "like"
+    }
   }
 ]

--- a/src/coordinator/coordinator.go
+++ b/src/coordinator/coordinator.go
@@ -179,7 +179,8 @@ func (c *Coordinator) setupRoutes() {
 	viewTokenSvc := services.NewTransactionViewTokenService(c.settingsDB)
 	aliasSvc := services.NewAliasService(c.settingsDB, time.Duration(c.config.IPAliasCacheTTLSec)*time.Second)
 	authTokenSvc := services.NewAuthTokenService(c.settingsDB)
-	searchHandler := handlers.NewSearchHandler(c.flightService, aliasSvc, &c.config.MCP, shareExportSvc, viewTokenSvc, c.config.TransactionViewMaxOpens)
+	mapSvc := services.NewMappingService(c.settingsDB)
+	searchHandler := handlers.NewSearchHandler(c.flightService, aliasSvc, &c.config.MCP, shareExportSvc, viewTokenSvc, c.config.TransactionViewMaxOpens, mapSvc)
 	if c.correlation != nil {
 		searchHandler.SetCorrelator(correlatorAdapter{engine: c.correlation})
 	}
@@ -200,7 +201,7 @@ func (c *Coordinator) setupRoutes() {
 	usersHandler := handlers.NewUsersHandler(userService)
 	userSettingsHandler := handlers.NewUserSettingsHandler(userSettingsService, userMappingService)
 	dashboardsHandler := handlers.NewDashboardsHandler(services.NewDashboardService(c.settingsDB))
-	mappingsHandler := handlers.NewMappingsHandler(services.NewMappingService(c.settingsDB), userMappingService)
+	mappingsHandler := handlers.NewMappingsHandler(mapSvc, userMappingService)
 	hepsubsHandler := handlers.NewHepsubsHandler(services.NewHepsubService(c.settingsDB))
 	aliasesHandler := handlers.NewAliasesHandler(aliasSvc)
 	authTokensHandler := handlers.NewAuthTokensHandler(authTokenSvc)

--- a/src/coordinator/handlers/mcp_llm_test.go
+++ b/src/coordinator/handlers/mcp_llm_test.go
@@ -70,7 +70,7 @@ func newLLMTestHandler(t *testing.T, llmHandler http.HandlerFunc, apiKey string)
 	}
 
 	fs := services.NewFlightService(nil, 0)
-	h := NewSearchHandler(fs, nil, cfg, nil, nil, 0)
+	h := NewSearchHandler(fs, nil, cfg, nil, nil, 0, nil)
 	return h, ts.Close
 }
 
@@ -155,7 +155,7 @@ func TestTryLLMStructured_DisabledReturnsZeroResult(t *testing.T) {
 	cfg := &config.MCPConfig{}
 	cfg.LLM = config.MCPLLMConfig{Enable: false}
 	fs := services.NewFlightService(nil, 0)
-	h := NewSearchHandler(fs, nil, cfg, nil, nil, 0)
+	h := NewSearchHandler(fs, nil, cfg, nil, nil, 0, nil)
 
 	req, res := h.tryLLMStructured(context.Background(), "anything", 0, 0, 0)
 	if req != nil {
@@ -246,7 +246,7 @@ func TestV4MCPLLMStatus_OllamaPingNoAPIKey(t *testing.T) {
 		TimeoutSec: 2,
 	}
 	fs := services.NewFlightService(nil, 0)
-	h := NewSearchHandler(fs, nil, cfg, nil, nil, 0)
+	h := NewSearchHandler(fs, nil, cfg, nil, nil, 0, nil)
 
 	e := echo.New()
 	rec := httptest.NewRecorder()
@@ -290,7 +290,7 @@ func TestNewSearchHandler_LLMDisabledMeansNilClient(t *testing.T) {
 	cfg := &config.MCPConfig{}
 	cfg.LLM = config.MCPLLMConfig{Enable: false}
 	fs := services.NewFlightService(nil, 0)
-	h := NewSearchHandler(fs, nil, cfg, nil, nil, 0)
+	h := NewSearchHandler(fs, nil, cfg, nil, nil, 0, nil)
 	if h.llm != nil {
 		t.Fatalf("expected nil LLM client when Enable=false, got %#v", h.llm)
 	}

--- a/src/coordinator/handlers/search.go
+++ b/src/coordinator/handlers/search.go
@@ -70,11 +70,13 @@ type SearchHandler struct {
 	// correlation runs Lua-based session_id expansion inside /transactions/messages.
 	// nil means correlation is disabled; handlers must nil-check.
 	correlation Correlator
+	// mappingService loads mapping_schema rows for fields_mapping virtual filters (optional).
+	mappingService *services.MappingService
 }
 
 // NewSearchHandler creates a new search handler.
 // aliasSvc may be nil; transaction rows will not get aliasSrc/aliasDst in that case.
-func NewSearchHandler(fs *services.FlightService, aliasSvc *services.AliasService, mcpCfg *config.MCPConfig, share *services.ShareExportService, viewTok *services.TransactionViewTokenService, transactionViewMaxOpens int) *SearchHandler {
+func NewSearchHandler(fs *services.FlightService, aliasSvc *services.AliasService, mcpCfg *config.MCPConfig, share *services.ShareExportService, viewTok *services.TransactionViewTokenService, transactionViewMaxOpens int, mappingSvc *services.MappingService) *SearchHandler {
 	if transactionViewMaxOpens <= 0 {
 		transactionViewMaxOpens = 3
 	}
@@ -95,6 +97,7 @@ func NewSearchHandler(fs *services.FlightService, aliasSvc *services.AliasServic
 		shareExports:            share,
 		viewTokens:              viewTok,
 		transactionViewMaxOpens: transactionViewMaxOpens,
+		mappingService:          mappingSvc,
 	}
 }
 

--- a/src/coordinator/handlers/transactions_sql_test.go
+++ b/src/coordinator/handlers/transactions_sql_test.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"strings"
 	"testing"
+
+	"github.com/sipcapture/homer-core/src/coordinator/services"
 )
 
 func TestBuildSearchSQLV4_CaptureID(t *testing.T) {
@@ -11,7 +13,7 @@ func TestBuildSearchSQLV4_CaptureID(t *testing.T) {
 	req.Filter.EventType = "call"
 	req.Filter.CaptureID = 42
 
-	sql, err := buildSearchSQLV4("homer_lake", &req)
+	sql, err := buildSearchSQLV4("homer_lake", &req, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +31,7 @@ func TestBuildSearchSQLV4_SIPDefaultUsesDataExtraHosts(t *testing.T) {
 	req.Filter.EventType = "default"
 	req.Filter.FromUser = "alice.net"
 
-	sql, err := buildSearchSQLV4("homer_lake", &req)
+	sql, err := buildSearchSQLV4("homer_lake", &req, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +49,7 @@ func TestBuildSearchSQLV4_SIPRegistrationUsesAOR(t *testing.T) {
 	req.Filter.EventType = "registration"
 	req.Filter.Aor = "bob@"
 
-	sql, err := buildSearchSQLV4("homer_lake", &req)
+	sql, err := buildSearchSQLV4("homer_lake", &req, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +64,7 @@ func TestBuildSearchSQLV4_UserAgentRegistrationColumn(t *testing.T) {
 	req.Filter.EventType = "registration"
 	req.Filter.UserAgent = "Polycom"
 
-	sql, err := buildSearchSQLV4("homer_lake", &req)
+	sql, err := buildSearchSQLV4("homer_lake", &req, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +82,7 @@ func TestBuildSearchSQLV4_SIPMethodAndResponseMultiFilter(t *testing.T) {
 	req.Filter.ResponseCode = "200"
 	req.Filter.ResponseCodes = []string{"486", "603"}
 
-	sql, err := buildSearchSQLV4("homer_lake", &req)
+	sql, err := buildSearchSQLV4("homer_lake", &req, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +101,7 @@ func TestBuildSearchSQLV4_SIPMethodDedupe(t *testing.T) {
 	req.Filter.Method = "INVITE"
 	req.Filter.Methods = []string{"INVITE", "ACK"}
 
-	sql, err := buildSearchSQLV4("homer_lake", &req)
+	sql, err := buildSearchSQLV4("homer_lake", &req, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,7 +141,7 @@ func TestBuildSearchSQLV4_LPRoutesToTimeColumn(t *testing.T) {
 	req.Timestamp.To = 1714403600000
 	req.Param.Limit = 100
 
-	sql, err := buildSearchSQLV4("homer_lake", &req)
+	sql, err := buildSearchSQLV4("homer_lake", &req, nil)
 	if err != nil {
 		t.Fatalf("buildSearchSQLV4 LP: %v", err)
 	}
@@ -199,7 +201,7 @@ func TestBuildSearchSQLV4_OTLPTracesByTraceID(t *testing.T) {
 	req.Timestamp.From = 1714400000000
 	req.Timestamp.To = 1714403600000
 
-	sql, err := buildSearchSQLV4("homer_lake", &req)
+	sql, err := buildSearchSQLV4("homer_lake", &req, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +225,7 @@ func TestBuildSearchSQLV4_OTLPLogsBodyAndService(t *testing.T) {
 	req.Filter.Payload = "panic"
 	req.Filter.UserAgent = "checkout-svc"
 
-	sql, err := buildSearchSQLV4("homer_lake", &req)
+	sql, err := buildSearchSQLV4("homer_lake", &req, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -246,7 +248,7 @@ func TestBuildSearchSQLV4_OTLPMetricsByName(t *testing.T) {
 	req.Filter.ProtoType = otlpHepIDMetrics
 	req.Filter.SessionID = "http.server.duration"
 
-	sql, err := buildSearchSQLV4("homer_lake", &req)
+	sql, err := buildSearchSQLV4("homer_lake", &req, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -264,7 +266,7 @@ func TestBuildSearchSQLV4_OTLPMetricsExplicitNameEquality(t *testing.T) {
 	req.Filter.Name = "queue.depth"
 	req.Filter.SessionID = "ignored-when-name-set"
 
-	sql, err := buildSearchSQLV4("homer_lake", &req)
+	sql, err := buildSearchSQLV4("homer_lake", &req, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -283,7 +285,7 @@ func TestBuildSearchSQLV4_OTLPMetricsTypeInAndServiceName(t *testing.T) {
 	req.Filter.Types = []string{"gauge", "sum"}
 	req.Filter.ServiceName = "checkout"
 
-	sql, err := buildSearchSQLV4("homer_lake", &req)
+	sql, err := buildSearchSQLV4("homer_lake", &req, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -357,5 +359,72 @@ func TestTransactionMessagesSelectSQL_SIPUsesSessionID(t *testing.T) {
 	}
 	if strings.Contains(q, "LIMIT 5000") {
 		t.Fatalf("SIP query must not apply OTLP span limit, got:\n%s", q)
+	}
+}
+
+func TestBuildSearchSQLV4_VirtualDataExtra(t *testing.T) {
+	req := SearchObjectV4{}
+	req.Filter.ProtoType = 1
+	req.Filter.EventType = "call"
+	req.Filter.Virtual = map[string]string{"to_tag": "abc7"}
+
+	rules := map[string]services.VirtualFieldRule{
+		"to_tag": {
+			Kind:  services.VirtualKindDataExtraJSON,
+			Path:  "to_tag",
+			Match: services.VirtualMatchLike,
+		},
+	}
+
+	sql, err := buildSearchSQLV4("homer_lake", &req, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(sql, "json_extract(data_extra, '$.to_tag')") {
+		t.Fatalf("expected virtual to_tag extract, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "abc7") {
+		t.Fatalf("expected filter value in SQL, got:\n%s", sql)
+	}
+}
+
+func TestBuildSearchSQLV4_VirtualDataExtraEquals(t *testing.T) {
+	req := SearchObjectV4{}
+	req.Filter.ProtoType = 1
+	req.Filter.EventType = "call"
+	req.Filter.Virtual = map[string]string{"branch": "z9hG4bK1"}
+
+	rules := map[string]services.VirtualFieldRule{
+		"branch": {
+			Kind:  services.VirtualKindDataExtraJSON,
+			Path:  "branch",
+			Match: services.VirtualMatchEquals,
+		},
+	}
+
+	sql, err := buildSearchSQLV4("homer_lake", &req, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(sql, "json_extract(data_extra, '$.branch')") {
+		t.Fatalf("expected branch extract, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "= 'z9hG4bK1'") {
+		t.Fatalf("expected equals clause, got:\n%s", sql)
+	}
+}
+
+func TestBuildSearchSQLV4_VirtualUnknownKeyIgnored(t *testing.T) {
+	req := SearchObjectV4{}
+	req.Filter.ProtoType = 1
+	req.Filter.EventType = "call"
+	req.Filter.Virtual = map[string]string{"not_in_rules": "x"}
+
+	sql, err := buildSearchSQLV4("homer_lake", &req, map[string]services.VirtualFieldRule{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(sql, "not_in_rules") {
+		t.Fatalf("unknown virtual key must be ignored, got:\n%s", sql)
 	}
 }

--- a/src/coordinator/handlers/transactions_sql_test.go
+++ b/src/coordinator/handlers/transactions_sql_test.go
@@ -414,17 +414,55 @@ func TestBuildSearchSQLV4_VirtualDataExtraEquals(t *testing.T) {
 	}
 }
 
-func TestBuildSearchSQLV4_VirtualUnknownKeyIgnored(t *testing.T) {
+func TestBuildSearchSQLV4_VirtualAbsentToTag(t *testing.T) {
 	req := SearchObjectV4{}
 	req.Filter.ProtoType = 1
 	req.Filter.EventType = "call"
-	req.Filter.Virtual = map[string]string{"not_in_rules": "x"}
+	req.Filter.Method = "INVITE"
+	req.Filter.VirtualAbsent = []string{"no_to_tag"}
 
-	sql, err := buildSearchSQLV4("homer_lake", &req, map[string]services.VirtualFieldRule{})
+	rules := map[string]services.VirtualFieldRule{
+		"no_to_tag": {
+			Kind:  services.VirtualKindDataExtraJSON,
+			Path:  "to_tag",
+			Match: services.VirtualMatchAbsent,
+		},
+	}
+
+	sql, err := buildSearchSQLV4("homer_lake", &req, rules)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(sql, "not_in_rules") {
-		t.Fatalf("unknown virtual key must be ignored, got:\n%s", sql)
+	if !strings.Contains(sql, "method IN ('INVITE')") {
+		t.Fatalf("expected INVITE filter, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "json_extract(data_extra, '$.to_tag')") {
+		t.Fatalf("expected to_tag extract for absent, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "IS NULL") {
+		t.Fatalf("expected IS NULL for absent, got:\n%s", sql)
+	}
+}
+
+func TestBuildSearchSQLV4_VirtualPresentToTag(t *testing.T) {
+	req := SearchObjectV4{}
+	req.Filter.ProtoType = 1
+	req.Filter.EventType = "call"
+	req.Filter.VirtualPresent = []string{"has_to_tag"}
+
+	rules := map[string]services.VirtualFieldRule{
+		"has_to_tag": {
+			Kind:  services.VirtualKindDataExtraJSON,
+			Path:  "to_tag",
+			Match: services.VirtualMatchPresent,
+		},
+	}
+
+	sql, err := buildSearchSQLV4("homer_lake", &req, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(sql, "IS NOT NULL") {
+		t.Fatalf("expected IS NOT NULL for present, got:\n%s", sql)
 	}
 }

--- a/src/coordinator/handlers/transactions_v4.go
+++ b/src/coordinator/handlers/transactions_v4.go
@@ -168,6 +168,10 @@ type SearchObjectV4 struct {
 		// Virtual carries structured-search values for fields_mapping[].virtual (data_extra JSON, etc.).
 		// Keys are field ids; only keys declared in the active mapping row are applied.
 		Virtual map[string]string `json:"virtual,omitempty"`
+		// VirtualAbsent lists field ids (mapping virtual.match=absent) when the UI checkbox is on.
+		VirtualAbsent []string `json:"virtual_absent,omitempty"`
+		// VirtualPresent lists field ids (mapping virtual.match=present) when the UI checkbox is on.
+		VirtualPresent []string `json:"virtual_present,omitempty"`
 	} `json:"filter"`
 	Param struct {
 		Limit   int    `json:"limit"`
@@ -1907,8 +1911,17 @@ func buildMCPRawSQL(lakeName string, req *SearchObjectV4) string {
 	return sql
 }
 
-func appendVirtualDataExtraConditions(conditions []string, values map[string]string, rules map[string]services.VirtualFieldRule) []string {
-	if len(values) == 0 || len(rules) == 0 {
+func appendVirtualDataExtraConditions(conditions []string, req *SearchObjectV4, rules map[string]services.VirtualFieldRule) []string {
+	if len(rules) == 0 {
+		return conditions
+	}
+	conditions = appendVirtualValueConditions(conditions, req.Filter.Virtual, rules)
+	conditions = appendVirtualAbsentPresentConditions(conditions, req.Filter.VirtualAbsent, req.Filter.VirtualPresent, rules)
+	return conditions
+}
+
+func appendVirtualValueConditions(conditions []string, values map[string]string, rules map[string]services.VirtualFieldRule) []string {
+	if len(values) == 0 {
 		return conditions
 	}
 	keys := make([]string, 0, len(values))
@@ -1919,6 +1932,9 @@ func appendVirtualDataExtraConditions(conditions []string, values map[string]str
 	for _, id := range keys {
 		rule, ok := rules[id]
 		if !ok {
+			continue
+		}
+		if rule.Match == services.VirtualMatchAbsent || rule.Match == services.VirtualMatchPresent {
 			continue
 		}
 		raw := strings.TrimSpace(values[id])
@@ -1942,9 +1958,50 @@ func appendVirtualDataExtraConditions(conditions []string, values map[string]str
 	return conditions
 }
 
+func appendVirtualAbsentPresentConditions(conditions []string, absentIDs, presentIDs []string, rules map[string]services.VirtualFieldRule) []string {
+	normalizeIDs := func(ids []string) []string {
+		seen := make(map[string]struct{})
+		out := make([]string, 0, len(ids))
+		for _, raw := range ids {
+			id := strings.TrimSpace(raw)
+			if id == "" {
+				continue
+			}
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			out = append(out, id)
+		}
+		sort.Strings(out)
+		return out
+	}
+	for _, id := range normalizeIDs(absentIDs) {
+		rule, ok := rules[id]
+		if !ok || rule.Kind != services.VirtualKindDataExtraJSON || rule.Match != services.VirtualMatchAbsent {
+			continue
+		}
+		jp := services.DuckJSONPath(rule.Path)
+		inner := fmt.Sprintf("trim(CAST(json_extract(data_extra, '%s') AS VARCHAR))", jp)
+		clause := fmt.Sprintf("(json_extract(data_extra, '%s') IS NULL OR %s = '' OR lower(%s) = 'null')", jp, inner, inner)
+		conditions = append(conditions, clause)
+	}
+	for _, id := range normalizeIDs(presentIDs) {
+		rule, ok := rules[id]
+		if !ok || rule.Kind != services.VirtualKindDataExtraJSON || rule.Match != services.VirtualMatchPresent {
+			continue
+		}
+		jp := services.DuckJSONPath(rule.Path)
+		inner := fmt.Sprintf("trim(CAST(json_extract(data_extra, '%s') AS VARCHAR))", jp)
+		clause := fmt.Sprintf("(json_extract(data_extra, '%s') IS NOT NULL AND %s <> '' AND lower(%s) <> 'null')", jp, inner, inner)
+		conditions = append(conditions, clause)
+	}
+	return conditions
+}
+
 // loadVirtualRulesForReq resolves fields_mapping virtual rules for structured search.
 func (h *SearchHandler) loadVirtualRulesForReq(ctx context.Context, req *SearchObjectV4) map[string]services.VirtualFieldRule {
-	if h.mappingService == nil || len(req.Filter.Virtual) == 0 {
+	if h.mappingService == nil || (len(req.Filter.Virtual) == 0 && len(req.Filter.VirtualAbsent) == 0 && len(req.Filter.VirtualPresent) == 0) {
 		return nil
 	}
 	proto := req.Filter.ProtoType
@@ -2128,7 +2185,7 @@ func buildSearchSQLV4(lakeName string, req *SearchObjectV4, virtualRules map[str
 	if req.Filter.Payload != "" {
 		conditions = append(conditions, fmt.Sprintf("payload LIKE '%%%s%%'", sqlvalidator.SafeString(req.Filter.Payload)))
 	}
-	conditions = appendVirtualDataExtraConditions(conditions, req.Filter.Virtual, virtualRules)
+	conditions = appendVirtualDataExtraConditions(conditions, req, virtualRules)
 
 	// Validate and use custom SELECT columns/aggregations or default to SELECT *
 	selectClause := "*"

--- a/src/coordinator/handlers/transactions_v4.go
+++ b/src/coordinator/handlers/transactions_v4.go
@@ -15,12 +15,14 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/ijt/go-anytime/v2"
 	"github.com/labstack/echo/v4"
+	"github.com/sipcapture/homer-core/src/coordinator/services"
 	"github.com/sipcapture/homer-core/src/coordinator/sqlvalidator"
 	"github.com/sipcapture/homer-core/src/pcapwriter"
 	logger "github.com/sipcapture/homer-core/src/utils/logging"
@@ -163,6 +165,9 @@ type SearchObjectV4 struct {
 		Type        string   `json:"type,omitempty"`         // single OTLP metric kind (gauge, sum, …)
 		Types       []string `json:"types,omitempty"`        // multi-select → IN ("type", …)
 		ServiceName string   `json:"service_name,omitempty"` // LIKE on service_name (narrowing)
+		// Virtual carries structured-search values for fields_mapping[].virtual (data_extra JSON, etc.).
+		// Keys are field ids; only keys declared in the active mapping row are applied.
+		Virtual map[string]string `json:"virtual,omitempty"`
 	} `json:"filter"`
 	Param struct {
 		Limit   int    `json:"limit"`
@@ -481,7 +486,8 @@ func (h *SearchHandler) V4TransactionsSearch(c echo.Context) error {
 		return writeError(c, http.StatusBadRequest, "Bad Request", "Invalid request body")
 	}
 
-	sql, err := buildSearchSQLV4(h.flightService.LakeName(), &req)
+	virtualRules := h.loadVirtualRulesForReq(c.Request().Context(), &req)
+	sql, err := buildSearchSQLV4(h.flightService.LakeName(), &req, virtualRules)
 	if err != nil {
 		logger.Error(fmt.Sprintf("V4TransactionsSearch: SQL validation failed: %v", err))
 		return writeError(c, http.StatusBadRequest, "Bad Request", fmt.Sprintf("SQL validation failed: %v", err))
@@ -1502,7 +1508,8 @@ func (h *SearchHandler) runMCPAsStructured(c echo.Context, req *MCPQueryRequest)
 		searchReq.Timestamp.To = fallbackTo
 	}
 
-	sql, err := buildSearchSQLV4(h.flightService.LakeName(), &searchReq)
+	virtualRules := h.loadVirtualRulesForReq(c.Request().Context(), &searchReq)
+	sql, err := buildSearchSQLV4(h.flightService.LakeName(), &searchReq, virtualRules)
 	if err != nil {
 		return writeError(c, http.StatusBadRequest, "Bad Request", fmt.Sprintf("SQL validation failed: %v", err))
 	}
@@ -1900,7 +1907,78 @@ func buildMCPRawSQL(lakeName string, req *SearchObjectV4) string {
 	return sql
 }
 
-func buildSearchSQLV4(lakeName string, req *SearchObjectV4) (string, error) {
+func appendVirtualDataExtraConditions(conditions []string, values map[string]string, rules map[string]services.VirtualFieldRule) []string {
+	if len(values) == 0 || len(rules) == 0 {
+		return conditions
+	}
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, id := range keys {
+		rule, ok := rules[id]
+		if !ok {
+			continue
+		}
+		raw := strings.TrimSpace(values[id])
+		if raw == "" {
+			continue
+		}
+		if rule.Kind != services.VirtualKindDataExtraJSON {
+			continue
+		}
+		jp := services.DuckJSONPath(rule.Path)
+		esc := sqlvalidator.SafeString(raw)
+		var clause string
+		switch rule.Match {
+		case services.VirtualMatchEquals:
+			clause = fmt.Sprintf("CAST(json_extract(data_extra, '%s') AS VARCHAR) = '%s'", jp, esc)
+		default:
+			clause = fmt.Sprintf("CAST(json_extract(data_extra, '%s') AS VARCHAR) LIKE '%%%s%%'", jp, esc)
+		}
+		conditions = append(conditions, clause)
+	}
+	return conditions
+}
+
+// loadVirtualRulesForReq resolves fields_mapping virtual rules for structured search.
+func (h *SearchHandler) loadVirtualRulesForReq(ctx context.Context, req *SearchObjectV4) map[string]services.VirtualFieldRule {
+	if h.mappingService == nil || len(req.Filter.Virtual) == 0 {
+		return nil
+	}
+	proto := req.Filter.ProtoType
+	if proto == 0 {
+		proto = 1
+	}
+	if isOTLPProtoType(proto) || isLPProtoType(proto) {
+		return nil
+	}
+	profile := strings.TrimSpace(req.Filter.EventType)
+	if profile == "" {
+		if proto == 1 {
+			profile = "call"
+		} else {
+			profile = "default"
+		}
+	}
+	m, err := h.mappingService.GetMappingByProfile(ctx, proto, profile)
+	if err != nil {
+		logger.Warn("virtual search: mapping load failed", "error", err.Error())
+		return nil
+	}
+	if m == nil {
+		return nil
+	}
+	rules, err := services.VirtualRulesFromFieldsMapping(m.FieldsMapping)
+	if err != nil {
+		logger.Warn("virtual search: fields_mapping virtual parse failed", "error", err.Error())
+		return nil
+	}
+	return rules
+}
+
+func buildSearchSQLV4(lakeName string, req *SearchObjectV4, virtualRules map[string]services.VirtualFieldRule) (string, error) {
 	protoType := req.Filter.ProtoType
 	if protoType == 0 {
 		protoType = 1
@@ -2050,6 +2128,7 @@ func buildSearchSQLV4(lakeName string, req *SearchObjectV4) (string, error) {
 	if req.Filter.Payload != "" {
 		conditions = append(conditions, fmt.Sprintf("payload LIKE '%%%s%%'", sqlvalidator.SafeString(req.Filter.Payload)))
 	}
+	conditions = appendVirtualDataExtraConditions(conditions, req.Filter.Virtual, virtualRules)
 
 	// Validate and use custom SELECT columns/aggregations or default to SELECT *
 	selectClause := "*"

--- a/src/coordinator/handlers/transactions_v4_correlation_test.go
+++ b/src/coordinator/handlers/transactions_v4_correlation_test.go
@@ -128,7 +128,7 @@ func newTestSearchHandler(t *testing.T, rowsPerCall [][]map[string]interface{}, 
 	_ = fs.ConnectAll()
 	fs.SetLakeName("homer_lake")
 
-	h := NewSearchHandler(fs, nil, &config.MCPConfig{}, nil, nil, 0)
+	h := NewSearchHandler(fs, nil, &config.MCPConfig{}, nil, nil, 0, nil)
 
 	return h, func() {
 		srv.Close()

--- a/src/coordinator/services/fields_virtual.go
+++ b/src/coordinator/services/fields_virtual.go
@@ -1,0 +1,127 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	// VirtualKindDataExtraJSON extracts a value from the DuckLake data_extra JSON column.
+	VirtualKindDataExtraJSON = "data_extra_json"
+)
+
+// VirtualMatchLike wraps the value with SQL LIKE '%value%' (escaped).
+// VirtualMatchEquals uses exact equality after trim.
+const (
+	VirtualMatchLike   = "like"
+	VirtualMatchEquals = "equals"
+)
+
+var virtualPathSegmentRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// VirtualFieldRule is a validated rule derived from fields_mapping[].virtual.
+type VirtualFieldRule struct {
+	Kind  string
+	Path  string // logical JSON path without leading $. (e.g. to_tag or nested foo_bar)
+	Match string // like | equals
+}
+
+// fieldMappingVirtualRaw is the optional virtual block on a mapping field row.
+type fieldMappingVirtualRaw struct {
+	Kind  string `json:"kind"`
+	Path  string `json:"path"`
+	Match string `json:"match,omitempty"`
+}
+
+// fieldMappingEntryRaw matches one element of fields_mapping JSON arrays.
+type fieldMappingEntryRaw struct {
+	ID      string                  `json:"id"`
+	Virtual *fieldMappingVirtualRaw `json:"virtual,omitempty"`
+}
+
+// VirtualRulesFromFieldsMapping parses fields_mapping JSON and returns virtual
+// rules keyed by field id. Non-virtual rows are skipped.
+func VirtualRulesFromFieldsMapping(raw json.RawMessage) (map[string]VirtualFieldRule, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var entries []fieldMappingEntryRaw
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil, fmt.Errorf("fields_mapping: %w", err)
+	}
+	out := make(map[string]VirtualFieldRule)
+	for _, e := range entries {
+		if e.Virtual == nil || strings.TrimSpace(e.ID) == "" {
+			continue
+		}
+		rule, err := validateVirtualRule(e.ID, e.Virtual)
+		if err != nil {
+			return nil, fmt.Errorf("field %q: %w", e.ID, err)
+		}
+		out[e.ID] = rule
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+func validateVirtualRule(fieldID string, v *fieldMappingVirtualRaw) (VirtualFieldRule, error) {
+	if v == nil {
+		return VirtualFieldRule{}, fmt.Errorf("virtual spec is nil")
+	}
+	kind := strings.TrimSpace(v.Kind)
+	if kind != VirtualKindDataExtraJSON {
+		return VirtualFieldRule{}, fmt.Errorf("unsupported virtual.kind %q", v.Kind)
+	}
+	path := strings.TrimSpace(v.Path)
+	if path == "" {
+		return VirtualFieldRule{}, fmt.Errorf("virtual.path is required")
+	}
+	if err := validateVirtualJSONPath(path); err != nil {
+		return VirtualFieldRule{}, err
+	}
+	match := strings.TrimSpace(v.Match)
+	if match == "" {
+		match = VirtualMatchLike
+	}
+	if match != VirtualMatchLike && match != VirtualMatchEquals {
+		return VirtualFieldRule{}, fmt.Errorf("unsupported virtual.match %q", v.Match)
+	}
+	_ = fieldID // reserved for future aliasing
+	return VirtualFieldRule{Kind: kind, Path: path, Match: match}, nil
+}
+
+func validateVirtualJSONPath(path string) error {
+	parts := strings.Split(path, ".")
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			return fmt.Errorf("invalid virtual.path %q", path)
+		}
+		if !virtualPathSegmentRe.MatchString(p) {
+			return fmt.Errorf("invalid path segment %q in %q", p, path)
+		}
+	}
+	return nil
+}
+
+// DuckJSONPath returns a DuckDB JSON path literal like '$.to_tag' or '$.a.b'.
+func DuckJSONPath(logicalPath string) string {
+	parts := strings.Split(logicalPath, ".")
+	escaped := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		escaped = append(escaped, p)
+	}
+	return "$." + strings.Join(escaped, ".")
+}

--- a/src/coordinator/services/fields_virtual.go
+++ b/src/coordinator/services/fields_virtual.go
@@ -18,9 +18,12 @@ const (
 
 // VirtualMatchLike wraps the value with SQL LIKE '%value%' (escaped).
 // VirtualMatchEquals uses exact equality after trim.
+// VirtualMatchAbsent / VirtualMatchPresent are driven by filter.virtual_absent / virtual_present (checkboxes), not filter.virtual values.
 const (
-	VirtualMatchLike   = "like"
-	VirtualMatchEquals = "equals"
+	VirtualMatchLike    = "like"
+	VirtualMatchEquals  = "equals"
+	VirtualMatchAbsent  = "absent"
+	VirtualMatchPresent = "present"
 )
 
 var virtualPathSegmentRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
@@ -29,7 +32,7 @@ var virtualPathSegmentRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 type VirtualFieldRule struct {
 	Kind  string
 	Path  string // logical JSON path without leading $. (e.g. to_tag or nested foo_bar)
-	Match string // like | equals
+	Match string // like | equals | absent | present
 }
 
 // fieldMappingVirtualRaw is the optional virtual block on a mapping field row.
@@ -91,7 +94,7 @@ func validateVirtualRule(fieldID string, v *fieldMappingVirtualRaw) (VirtualFiel
 	if match == "" {
 		match = VirtualMatchLike
 	}
-	if match != VirtualMatchLike && match != VirtualMatchEquals {
+	if match != VirtualMatchLike && match != VirtualMatchEquals && match != VirtualMatchAbsent && match != VirtualMatchPresent {
 		return VirtualFieldRule{}, fmt.Errorf("unsupported virtual.match %q", v.Match)
 	}
 	_ = fieldID // reserved for future aliasing

--- a/src/coordinator/services/fields_virtual_test.go
+++ b/src/coordinator/services/fields_virtual_test.go
@@ -40,8 +40,19 @@ func TestVirtualRulesFromFieldsMapping_InvalidKind(t *testing.T) {
 	}
 }
 
-func TestDuckJSONPath(t *testing.T) {
-	if got := services.DuckJSONPath("foo.bar"); got != "$.foo.bar" {
-		t.Fatalf("got %q", got)
+func TestVirtualRulesAbsentPresent(t *testing.T) {
+	raw := json.RawMessage(`[
+		{"id": "no_to_tag", "virtual": {"kind": "data_extra_json", "path": "to_tag", "match": "absent"}},
+		{"id": "has_to_tag", "virtual": {"kind": "data_extra_json", "path": "to_tag", "match": "present"}}
+	]`)
+	rules, err := services.VirtualRulesFromFieldsMapping(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rules["no_to_tag"].Match != services.VirtualMatchAbsent {
+		t.Fatalf("no_to_tag: %+v", rules["no_to_tag"])
+	}
+	if rules["has_to_tag"].Match != services.VirtualMatchPresent {
+		t.Fatalf("has_to_tag: %+v", rules["has_to_tag"])
 	}
 }

--- a/src/coordinator/services/fields_virtual_test.go
+++ b/src/coordinator/services/fields_virtual_test.go
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package services_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/sipcapture/homer-core/src/coordinator/services"
+)
+
+func TestVirtualRulesFromFieldsMapping(t *testing.T) {
+	raw := json.RawMessage(`[
+		{"id": "call_id", "name": "Call-ID"},
+		{"id": "to_tag", "name": "To tag", "virtual": {"kind": "data_extra_json", "path": "to_tag", "match": "like"}}
+	]`)
+	rules, err := services.VirtualRulesFromFieldsMapping(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(rules))
+	}
+	r, ok := rules["to_tag"]
+	if !ok {
+		t.Fatal("missing to_tag rule")
+	}
+	if r.Kind != services.VirtualKindDataExtraJSON || r.Path != "to_tag" || r.Match != services.VirtualMatchLike {
+		t.Fatalf("unexpected rule: %+v", r)
+	}
+}
+
+func TestVirtualRulesFromFieldsMapping_InvalidKind(t *testing.T) {
+	raw := json.RawMessage(`[{"id": "x", "virtual": {"kind": "drop_table", "path": "a"}}]`)
+	_, err := services.VirtualRulesFromFieldsMapping(raw)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestDuckJSONPath(t *testing.T) {
+	if got := services.DuckJSONPath("foo.bar"); got != "$.foo.bar" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/src/coordinator/services/mapping_seed.go
+++ b/src/coordinator/services/mapping_seed.go
@@ -14,7 +14,7 @@ import (
 // SIP / RTCP / DNS / LOG field lists align with storage/ducklake/tables.go and
 // filter keys in buildSearchSQLV4 (coordinator/handlers/transactions_v4.go).
 // Optional fields_mapping[].virtual declares JSON data_extra filters — see
-// services.VirtualRulesFromFieldsMapping.
+// services.VirtualRulesFromFieldsMapping (match: like | equals | absent | present).
 
 //go:embed seeds/fields_sip_call.json
 var fieldsMappingSIPCall []byte

--- a/src/coordinator/services/mapping_seed.go
+++ b/src/coordinator/services/mapping_seed.go
@@ -13,6 +13,8 @@ import (
 
 // SIP / RTCP / DNS / LOG field lists align with storage/ducklake/tables.go and
 // filter keys in buildSearchSQLV4 (coordinator/handlers/transactions_v4.go).
+// Optional fields_mapping[].virtual declares JSON data_extra filters — see
+// services.VirtualRulesFromFieldsMapping.
 
 //go:embed seeds/fields_sip_call.json
 var fieldsMappingSIPCall []byte

--- a/src/coordinator/services/seeds/fields_sip_call.json
+++ b/src/coordinator/services/seeds/fields_sip_call.json
@@ -233,5 +233,33 @@
       "path": "to_tag",
       "match": "like"
     }
+  },
+  {
+    "id": "no_to_tag",
+    "name": "No To-tag (e.g. first INVITE)",
+    "type": "string",
+    "index": "none",
+    "form_type": "checkbox",
+    "position": 19,
+    "hide": true,
+    "virtual": {
+      "kind": "data_extra_json",
+      "path": "to_tag",
+      "match": "absent"
+    }
+  },
+  {
+    "id": "has_to_tag",
+    "name": "Has To-tag",
+    "type": "string",
+    "index": "none",
+    "form_type": "checkbox",
+    "position": 20,
+    "hide": true,
+    "virtual": {
+      "kind": "data_extra_json",
+      "path": "to_tag",
+      "match": "present"
+    }
   }
 ]

--- a/src/coordinator/services/seeds/fields_sip_call.json
+++ b/src/coordinator/services/seeds/fields_sip_call.json
@@ -205,5 +205,33 @@
     "form_type": "input",
     "position": 16,
     "hide": true
+  },
+  {
+    "id": "from_tag",
+    "name": "From tag (JSON)",
+    "type": "string",
+    "index": "none",
+    "form_type": "input",
+    "position": 17,
+    "hide": true,
+    "virtual": {
+      "kind": "data_extra_json",
+      "path": "from_tag",
+      "match": "like"
+    }
+  },
+  {
+    "id": "to_tag",
+    "name": "To tag (JSON)",
+    "type": "string",
+    "index": "none",
+    "form_type": "input",
+    "position": 18,
+    "hide": true,
+    "virtual": {
+      "kind": "data_extra_json",
+      "path": "to_tag",
+      "match": "like"
+    }
   }
 ]

--- a/src/ui/src/dashboard/widgets/SearchPanel.tsx
+++ b/src/ui/src/dashboard/widgets/SearchPanel.tsx
@@ -402,6 +402,18 @@ export default function SearchPanel({ config, onConfigChange, widgetId }) {
         const val = form[f.id]
         if (val === undefined || val === null || val === '') return
 
+        // Virtual fields (fields_mapping.virtual): values go under filter.virtual[id]
+        if (f.virtual && typeof f.virtual === 'object' && f.virtual.kind) {
+          if (!filter.virtual) filter.virtual = {}
+          if (Array.isArray(val)) {
+            if (val.length === 0) return
+            filter.virtual[f.id] = val.length === 1 ? val[0] : val.join(',')
+          } else {
+            filter.virtual[f.id] = val
+          }
+          return
+        }
+
         // Handle multiselect arrays
         if (Array.isArray(val)) {
           if (val.length === 0) return

--- a/src/ui/src/dashboard/widgets/SearchPanel.tsx
+++ b/src/ui/src/dashboard/widgets/SearchPanel.tsx
@@ -399,10 +399,27 @@ export default function SearchPanel({ config, onConfigChange, widgetId }) {
       const eventType = config.protocol_profile ?? ''
       filter = { proto_type: Number(protoType), event_type: eventType }
       configuredFields.forEach((f) => {
+        // Virtual absent/present: checkbox only — handle before empty-value skip
+        if (f.virtual && typeof f.virtual === 'object' && f.virtual.kind) {
+          const vm = String(f.virtual.match || 'like').toLowerCase()
+          if (vm === 'absent' || vm === 'present') {
+            const checked = form[f.id] === true || form[f.id] === '1'
+            if (!checked) return
+            if (vm === 'absent') {
+              if (!filter.virtual_absent) filter.virtual_absent = []
+              filter.virtual_absent.push(f.id)
+            } else {
+              if (!filter.virtual_present) filter.virtual_present = []
+              filter.virtual_present.push(f.id)
+            }
+            return
+          }
+        }
+
         const val = form[f.id]
         if (val === undefined || val === null || val === '') return
 
-        // Virtual fields (fields_mapping.virtual): values go under filter.virtual[id]
+        // Virtual string fields (like / equals): values go under filter.virtual[id]
         if (f.virtual && typeof f.virtual === 'object' && f.virtual.kind) {
           if (!filter.virtual) filter.virtual = {}
           if (Array.isArray(val)) {
@@ -519,6 +536,22 @@ export default function SearchPanel({ config, onConfigChange, widgetId }) {
   // Render a single dynamic field from fields_mapping metadata
   const renderDynamicField = (field) => {
     const { id, name, form_type, selector, type } = field
+    const vMatch = field.virtual?.match != null ? String(field.virtual.match).toLowerCase() : ''
+    if (field.virtual?.kind && (vMatch === 'absent' || vMatch === 'present')) {
+      const checked = form[id] === true || form[id] === '1'
+      return (
+        <div className="flex items-center gap-2 py-0.5" key={id}>
+          <Checkbox
+            id={`sp-${id}`}
+            checked={checked}
+            onCheckedChange={(v) => handleChange(id, v === true)}
+          />
+          <Label htmlFor={`sp-${id}`} className="cursor-pointer text-[11px] text-muted-foreground">
+            {name}
+          </Label>
+        </div>
+      )
+    }
     if (config?.preset === 'otlp_metrics' && id === 'name') {
       return (
         <div className="grid gap-1" key={id}>


### PR DESCRIPTION
…arch

- Parse optional fields_mapping[].virtual (kind=data_extra_json, path, match)
- POST /transactions/search: filter.virtual[id] + mapping-driven SQL clauses
- Wire MappingService into SearchHandler; reuse single instance in routes
- UI Protocol Search sends virtual field values under filter.virtual
- Seed from_tag/to_tag examples (new installs only; guid-based seed skip)