### PR TITLE
feat(line-protocol): optional ingest into hep_proto_1_call

### DIFF
--- a/docs/LINE_PROTOCOL.md
+++ b/docs/LINE_PROTOCOL.md
@@ -110,6 +110,8 @@ If **`allow_hep_sip_call`** is `false` (default) and the client sends **`?hep_ta
 
 **Column mapping:** tags and fields are merged (Influx-sanitised identifiers). Use **quoted** strings for text fields (`caller="alice"`). **`timestamp`** can be the line-ending epoch (as in normal LP), a tag/field `timestamp` with RFC3339 / `YYYY-MM-DD HH:MM:SS` / epoch integer, or falls back to wall clock if absent. **`date`**: optional tag/field `date="YYYY-MM-DD"`; if omitted, **`date` is set from the resolved `timestamp` (UTC calendar day)** — that value is what DuckLake uses for **`date=…`** partitioning. Ports and `protocol` should be integer fields (`5060i`, `17i`). Optional **`data_extra`** must be a JSON **object** string (e.g. `data_extra="{}"`); if omitted, `{}` is stored. The LP **measurement** name is ignored when `hep_table=call`.
 
+**Line layout (Influx LP):** `measurement,tag_key=tag_val,... field_key=field_val,... timestamp` — the **first unescaped space** separates **tags** (comma-separated) from **fields** (comma-separated). There is **no** comma between the last tag and the first field.
+
 Example (partition `date` is inferred from the line timestamp — here 2023-11-14 UTC):
 
 ```bash

--- a/docs/LINE_PROTOCOL.md
+++ b/docs/LINE_PROTOCOL.md
@@ -108,14 +108,23 @@ If **`allow_hep_sip_call`** is `false` (default) and the client sends **`?hep_ta
 
 **Security:** an exposed LP port with `allow_hep_sip_call=true` allows unauthenticated append to the call table unless you use network controls or mTLS (`cacert`).
 
-**Column mapping:** tags and fields are merged (Influx-sanitised identifiers). Use **quoted** strings for text fields (`caller="alice"`). Ports and `protocol` should be integer fields (`5060i`, `17i`). Optional **`data_extra`** must be a JSON **object** string (e.g. `data_extra="{}"`); if omitted, `{}` is stored. The LP **measurement** name is ignored when `hep_table=call`.
+**Column mapping:** tags and fields are merged (Influx-sanitised identifiers). Use **quoted** strings for text fields (`caller="alice"`). **`timestamp`** can be the line-ending epoch (as in normal LP), a tag/field `timestamp` with RFC3339 / `YYYY-MM-DD HH:MM:SS` / epoch integer, or falls back to wall clock if absent. **`date`**: optional tag/field `date="YYYY-MM-DD"`; if omitted, **`date` is set from the resolved `timestamp` (UTC calendar day)** — that value is what DuckLake uses for **`date=…`** partitioning. Ports and `protocol` should be integer fields (`5060i`, `17i`). Optional **`data_extra`** must be a JSON **object** string (e.g. `data_extra="{}"`); if omitted, `{}` is stored. The LP **measurement** name is ignored when `hep_table=call`.
 
-Example:
+Example (partition `date` is inferred from the line timestamp — here 2023-11-14 UTC):
 
 ```bash
 curl -i -X POST "http://127.0.0.1:8086/write?hep_table=call&precision=ns" \
   --data-binary 'sip,method=INVITE,session_id=abc caller="alice",callee="bob",src_ip="10.0.0.1",dst_ip="10.0.0.2",src_port=5060i,dst_port=5060i,protocol=17i,payload="INVITE sip:b SIP/2.0" 1700000000000000000'
 ```
+
+Example with **explicit `date`** as a **tag** (partition `date=2023-11-14/…`; keep it consistent with `timestamp`):
+
+```bash
+curl -i -X POST "http://127.0.0.1:8086/write?hep_table=call&precision=ns" \
+  --data-binary 'sip,method=INVITE,session_id=abc,date=2023-11-14 caller="alice",callee="bob",src_ip="10.0.0.1",dst_ip="10.0.0.2",src_port=5060i,dst_port=5060i,protocol=17i,payload="INVITE sip:b SIP/2.0" 1700000000000000000'
+```
+
+You can also send **`date` as a string field** (quoted): `...,date="2023-11-14"` in the field set.
 
 ### Query parameters
 

--- a/docs/LINE_PROTOCOL.md
+++ b/docs/LINE_PROTOCOL.md
@@ -58,6 +58,7 @@ process will not start this listener.
       "default_precision": "ns",
       "default_db": "",
       "table_prefix": "lp_",
+      "allow_hep_sip_call": false,
       "read_timeout_sec": 30,
       "write_timeout_sec": 30,
       "cert": "",
@@ -76,6 +77,7 @@ process will not start this listener.
 | `default_precision`  | `ns`        | Used when the client doesn't pass `?precision=`. Valid: `ns`, `us`, `ms`, `s`.                    |
 | `default_db`         | empty       | Used when the client doesn't pass `?db=` / `?bucket=`. Empty ⇒ DuckDB's default schema (`main`). |
 | `table_prefix`       | `lp_`       | Prepended to the (sanitised) measurement name to form the table name. Keeps LP data namespaced.   |
+| `allow_hep_sip_call` | `false`     | When `true`, allows `?hep_table=call` to insert into `{lake}.main.hep_proto_1_call` (see below). When `false`, any `?hep_table=` request returns **400**. |
 | `read/write_timeout_sec` | `30`    | HTTP server timeouts.                                                                             |
 | `cert` / `key`       | empty       | Optional TLS material; both empty disables HTTPS.                                                 |
 | `cacert`             | empty       | If set together with `cert`+`key`, mTLS is enforced.                                              |
@@ -98,6 +100,23 @@ Same convention as the rest of homer-core:
 | GET    | `/ping`               | InfluxDB v1 health probe |
 | GET    | `/health`             | InfluxDB v2 health probe |
 
+### Optional: `hep_proto_1_call` (SIP call table)
+
+When **`ingest.line_protocol.allow_hep_sip_call`** is `true`, add **`?hep_table=call`** to a write request. Each parsed LP line becomes one row in **`{lakeName}.main.hep_proto_1_call`** (same layout as SIP call rows from HEP). In this mode **`?db=` / `?bucket=`** do not change the destination table.
+
+If **`allow_hep_sip_call`** is `false` (default) and the client sends **`?hep_table=`** with any value, the server returns **400** before ingesting.
+
+**Security:** an exposed LP port with `allow_hep_sip_call=true` allows unauthenticated append to the call table unless you use network controls or mTLS (`cacert`).
+
+**Column mapping:** tags and fields are merged (Influx-sanitised identifiers). Use **quoted** strings for text fields (`caller="alice"`). Ports and `protocol` should be integer fields (`5060i`, `17i`). Optional **`data_extra`** must be a JSON **object** string (e.g. `data_extra="{}"`); if omitted, `{}` is stored. The LP **measurement** name is ignored when `hep_table=call`.
+
+Example:
+
+```bash
+curl -i -X POST "http://127.0.0.1:8086/write?hep_table=call&precision=ns" \
+  --data-binary 'sip,method=INVITE,session_id=abc caller="alice",callee="bob",src_ip="10.0.0.1",dst_ip="10.0.0.2",src_port=5060i,dst_port=5060i,protocol=17i,payload="INVITE sip:b SIP/2.0" 1700000000000000000'
+```
+
 ### Query parameters
 
 | Param         | v1 / v2     | Meaning                                                                                |
@@ -106,6 +125,7 @@ Same convention as the rest of homer-core:
 | `bucket`      | v2          | Same as `db`. v2 clients use this; v1 clients use `db`.                                |
 | `org`         | v2          | Accepted for compatibility, ignored.                                                   |
 | `precision`   | both        | `ns` / `us` / `ms` / `s`. Falls back to `default_precision`.                           |
+| `hep_table`   | both        | `call` — write into `hep_proto_1_call` when `allow_hep_sip_call` is true; otherwise **400**. |
 | `rp`          | v1          | Accepted for compatibility, ignored (DuckLake handles retention separately).           |
 
 ### Body format
@@ -127,7 +147,7 @@ must be backslash-escaped, exactly as in InfluxDB.
 | Code | When                                                                       |
 |------|----------------------------------------------------------------------------|
 | `204 No Content` | All points written successfully.                                  |
-| `400 Bad Request` | Parse error, invalid precision, or zero parseable points.        |
+| `400 Bad Request` | Parse error, invalid precision, `hep_table` rejected (feature off or unknown value), mapping error (e.g. invalid `data_extra`), or zero parseable points. |
 | `405 Method Not Allowed` | Wrong HTTP verb on `/write*`.                              |
 | `413 Request Entity Too Large` | Body exceeded `max_body_bytes`.                      |
 | `500 Internal Server Error` | DuckLake DDL or INSERT failed (see `homer_lp_write_errors_total`). |

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -169,6 +169,11 @@ type LineProtoConfig struct {
 	// separate from HEP / OTLP tables.
 	TablePrefix string `json:"table_prefix" mapstructure:"table_prefix" default:"lp_"`
 
+	// AllowHepSipCall enables ?hep_table=call on LP write endpoints so
+	// points can be inserted into hep_proto_1_call (SIP call table).
+	// When false, ?hep_table= is rejected with HTTP 400.
+	AllowHepSipCall bool `json:"allow_hep_sip_call" mapstructure:"allow_hep_sip_call" default:"false"`
+
 	// ReadTimeoutSec / WriteTimeoutSec apply to the HTTP server.
 	ReadTimeoutSec  int `json:"read_timeout_sec" mapstructure:"read_timeout_sec" default:"30"`
 	WriteTimeoutSec int `json:"write_timeout_sec" mapstructure:"write_timeout_sec" default:"30"`
@@ -1242,6 +1247,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("ingest.line_protocol.default_precision", "ns")
 	v.SetDefault("ingest.line_protocol.default_db", "")
 	v.SetDefault("ingest.line_protocol.table_prefix", "lp_")
+	v.SetDefault("ingest.line_protocol.allow_hep_sip_call", false)
 	v.SetDefault("ingest.line_protocol.read_timeout_sec", 30)
 	v.SetDefault("ingest.line_protocol.write_timeout_sec", 30)
 	v.SetDefault("coordinator.hep_stream.enable", true)

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -549,6 +549,26 @@ func TestLoad_LineProtoIngestDefaultsHonoured(t *testing.T) {
 		t.Errorf("ingest.line_protocol timeouts: want 30/30, got %d/%d",
 			lp.ReadTimeoutSec, lp.WriteTimeoutSec)
 	}
+	if lp.AllowHepSipCall {
+		t.Errorf("ingest.line_protocol.allow_hep_sip_call: want false (default), got true")
+	}
+}
+
+// TestLoad_LineProtoIngestAllowHepSipCallOverride checks explicit
+// allow_hep_sip_call in JSON.
+func TestLoad_LineProtoIngestAllowHepSipCallOverride(t *testing.T) {
+	path := writeTmpConfig(t, `{
+  "ingest": {
+    "line_protocol": { "enable": true, "allow_hep_sip_call": true }
+  }
+}`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if !cfg.Ingest.LineProto.AllowHepSipCall {
+		t.Fatalf("allow_hep_sip_call: want true, got false")
+	}
 }
 
 // TestLoad_LineProtoIngestPartialEnableKeepsTagDefaults mirrors the

--- a/src/go.mod
+++ b/src/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/gopacket v1.1.19
+	github.com/google/uuid v1.6.0
 	github.com/guptarohit/asciigraph v0.7.3
 	github.com/hugr-lab/airport-go v0.2.1
 	github.com/ijt/go-anytime/v2 v2.1.1
@@ -72,7 +73,6 @@ require (
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/flatbuffers v25.12.19+incompatible // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/src/lineprotoreceiver/hep_sip_call_lp.go
+++ b/src/lineprotoreceiver/hep_sip_call_lp.go
@@ -1,0 +1,261 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package lineprotoreceiver
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sipcapture/homer-core/src/storage/ducklake"
+)
+
+// lineProtoPointToSIPCallRow maps one LP point (tags + fields) into a
+// hep_proto_1_call row slice matching ducklake.SIPCallInsertColumnNames order.
+func lineProtoPointToSIPCallRow(p *LineProtoPoint) ([]interface{}, error) {
+	if p == nil {
+		return nil, fmt.Errorf("nil point")
+	}
+	m := make(map[string]interface{}, len(p.Tags)+len(p.Fields))
+	for k, v := range p.Tags {
+		m[SanitizeIdent(k)] = v
+	}
+	for k, v := range p.Fields {
+		m[SanitizeIdent(k)] = v
+	}
+
+	ts, err := resolveSIPCallTimestamp(p, m)
+	if err != nil {
+		return nil, err
+	}
+
+	dateStr, err := resolveSIPCallDate(m, ts)
+	if err != nil {
+		return nil, err
+	}
+
+	uuidStr := stringField(m, "uuid")
+	if uuidStr == "" {
+		uuidStr = uuid.NewString()
+	}
+
+	extra, err := resolveDataExtra(m)
+	if err != nil {
+		return nil, err
+	}
+
+	cols := ducklake.SIPCallInsertColumnNames()
+	if len(cols) == 0 {
+		return nil, fmt.Errorf("sip call column list unavailable")
+	}
+
+	vals := map[string]interface{}{
+		"uuid":          uuidStr,
+		"date":          dateStr,
+		"timestamp":     ts,
+		"session_id":    stringField(m, "session_id"),
+		"caller":        stringField(m, "caller"),
+		"callee":        stringField(m, "callee"),
+		"src_ip":        stringField(m, "src_ip"),
+		"dst_ip":        stringField(m, "dst_ip"),
+		"src_port":      uint32Field(m, "src_port"),
+		"dst_port":      uint32Field(m, "dst_port"),
+		"method":        stringField(m, "method"),
+		"response_code": stringField(m, "response_code"),
+		"cseq_method":   stringField(m, "cseq_method"),
+		"protocol":      uint32Field(m, "protocol"),
+		"node_id":       stringField(m, "node_id"),
+		"cid":           stringField(m, "cid"),
+		"payload":       stringField(m, "payload"),
+		"data_extra":    extra,
+	}
+
+	row := make([]interface{}, len(cols))
+	for i, col := range cols {
+		v, ok := vals[col]
+		if !ok {
+			return nil, fmt.Errorf("internal: missing binding for column %q", col)
+		}
+		row[i] = v
+	}
+	return row, nil
+}
+
+func stringField(m map[string]interface{}, key string) string {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return ""
+	}
+	switch x := v.(type) {
+	case string:
+		return x
+	case []byte:
+		return string(x)
+	default:
+		return fmt.Sprint(x)
+	}
+}
+
+func uint32Field(m map[string]interface{}, key string) uint32 {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return 0
+	}
+	switch x := v.(type) {
+	case uint32:
+		return x
+	case uint64:
+		if x > math.MaxUint32 {
+			return math.MaxUint32
+		}
+		return uint32(x)
+	case int:
+		if x < 0 {
+			return 0
+		}
+		if x > math.MaxUint32 {
+			return math.MaxUint32
+		}
+		return uint32(x)
+	case int64:
+		if x < 0 {
+			return 0
+		}
+		if x > math.MaxUint32 {
+			return math.MaxUint32
+		}
+		return uint32(x)
+	case float64:
+		if x < 0 || math.IsNaN(x) || math.IsInf(x, 0) {
+			return 0
+		}
+		if x > float64(math.MaxUint32) {
+			return math.MaxUint32
+		}
+		return uint32(x)
+	case string:
+		n, err := strconv.ParseUint(strings.TrimSpace(x), 10, 32)
+		if err != nil {
+			return 0
+		}
+		return uint32(n)
+	default:
+		return 0
+	}
+}
+
+func resolveSIPCallTimestamp(p *LineProtoPoint, m map[string]interface{}) (time.Time, error) {
+	if _, ok := m["timestamp"]; ok {
+		v := m["timestamp"]
+		if t, ok := parseFlexibleTime(v); ok {
+			return t.UTC(), nil
+		}
+		return time.Time{}, fmt.Errorf("timestamp: could not parse value of type %T", v)
+	}
+
+	tsNs := p.TimestampNs
+	if tsNs == 0 {
+		tsNs = time.Now().UnixNano()
+	}
+	return time.Unix(0, tsNs).UTC(), nil
+}
+
+func resolveSIPCallDate(m map[string]interface{}, ts time.Time) (string, error) {
+	if _, ok := m["date"]; ok {
+		s := strings.TrimSpace(stringField(m, "date"))
+		if s != "" {
+			if _, err := time.Parse("2006-01-02", s); err != nil {
+				return "", fmt.Errorf("date: expected YYYY-MM-DD, got %q", s)
+			}
+			return s, nil
+		}
+	}
+	return ts.UTC().Format("2006-01-02"), nil
+}
+
+func resolveDataExtra(m map[string]interface{}) (string, error) {
+	raw := strings.TrimSpace(stringField(m, "data_extra"))
+	if raw == "" {
+		return "{}", nil
+	}
+	if !json.Valid([]byte(raw)) {
+		return "", fmt.Errorf("data_extra: invalid JSON")
+	}
+	var probe interface{}
+	if err := json.Unmarshal([]byte(raw), &probe); err != nil {
+		return "", fmt.Errorf("data_extra: invalid JSON: %w", err)
+	}
+	if _, ok := probe.(map[string]interface{}); !ok {
+		return "", fmt.Errorf("data_extra: must be a JSON object")
+	}
+	return raw, nil
+}
+
+func parseFlexibleTime(v interface{}) (time.Time, bool) {
+	switch x := v.(type) {
+	case time.Time:
+		return x, true
+	case string:
+		s := strings.TrimSpace(x)
+		if s == "" {
+			return time.Time{}, false
+		}
+		layouts := []string{
+			time.RFC3339Nano,
+			time.RFC3339,
+			"2006-01-02 15:04:05.999999999",
+			"2006-01-02 15:04:05.999999",
+			"2006-01-02 15:04:05",
+			"2006-01-02T15:04:05",
+		}
+		for _, ly := range layouts {
+			if t, err := time.Parse(ly, s); err == nil {
+				return t, true
+			}
+		}
+		if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return unixIntToTime(n), true
+		}
+		return time.Time{}, false
+	case int:
+		return unixIntToTime(int64(x)), true
+	case int64:
+		return unixIntToTime(x), true
+	case uint64:
+		if x > math.MaxInt64 {
+			return time.Unix(0, int64(math.MaxInt64)).UTC(), true
+		}
+		return unixIntToTime(int64(x)), true
+	case float64:
+		if math.IsNaN(x) || math.IsInf(x, 0) {
+			return time.Time{}, false
+		}
+		sec, frac := math.Modf(x)
+		return time.Unix(int64(sec), int64(frac*1e9)).UTC(), true
+	default:
+		return time.Time{}, false
+	}
+}
+
+func unixIntToTime(n int64) time.Time {
+	abs := n
+	if n < 0 {
+		abs = -n
+	}
+	switch {
+	case abs >= 1_000_000_000_000_000_000: // ns
+		return time.Unix(0, n).UTC()
+	case abs >= 1_000_000_000_000: // µs
+		return time.Unix(0, n*1000).UTC()
+	case abs >= 1_000_000_000: // ms
+		return time.Unix(0, n*1_000_000).UTC()
+	default:
+		return time.Unix(n, 0).UTC()
+	}
+}

--- a/src/lineprotoreceiver/http.go
+++ b/src/lineprotoreceiver/http.go
@@ -139,6 +139,23 @@ func (h *httpServer) handleWrite(w http.ResponseWriter, r *http.Request, endpoin
 		metrics.RecordLineProtoRequest(endpoint, "method_not_allowed")
 		return
 	}
+
+	hepTable := strings.TrimSpace(strings.ToLower(queryParam(r, "hep_table", "")))
+	if hepTable != "" {
+		if !h.cfg.AllowHepSipCall {
+			writeJSONError(w, http.StatusBadRequest, "hep_table ingest is disabled (set ingest.line_protocol.allow_hep_sip_call to true)")
+			metrics.RecordLineProtoRequest(endpoint, "hep_table_disabled")
+			return
+		}
+		switch hepTable {
+		case "call":
+		default:
+			writeJSONError(w, http.StatusBadRequest, "unknown hep_table value (supported: call)")
+			metrics.RecordLineProtoRequest(endpoint, "hep_table_unknown")
+			return
+		}
+	}
+
 	body, reason, ok := h.readBody(w, r)
 	if !ok {
 		metrics.RecordLineProtoRequest(endpoint, reason)
@@ -150,13 +167,14 @@ func (h *httpServer) handleWrite(w http.ResponseWriter, r *http.Request, endpoin
 		return
 	}
 	precision := ParsePrecision(queryParam(r, "precision", h.cfg.DefaultPrecision))
-	n, err := h.ing.Ingest(r.Context(), dbName, body, precision)
+	n, err := h.ing.Ingest(r.Context(), dbName, body, precision, hepTable)
 	if err != nil {
 		// Differentiate parse-vs-write so dashboards / metrics can
 		// tell client misbehaviour from server-side problems.
 		status := http.StatusInternalServerError
 		outcome := "write_error"
-		if strings.Contains(err.Error(), "parse error") {
+		if strings.Contains(err.Error(), "parse error") ||
+			strings.HasPrefix(err.Error(), "point ") {
 			status = http.StatusBadRequest
 			outcome = "parse_error"
 		}

--- a/src/lineprotoreceiver/http_test.go
+++ b/src/lineprotoreceiver/http_test.go
@@ -30,7 +30,7 @@ func newTestServer(t *testing.T) (*httptest.Server, string) {
 		ReadTimeoutSec:   10,
 		WriteTimeoutSec:  10,
 	}
-	ing := NewIngester(db, lake, cfg.TablePrefix)
+	ing := NewIngester(db, lake, cfg)
 	hs, err := newHTTPServer(cfg, ing)
 	if err != nil {
 		t.Fatalf("newHTTPServer: %v", err)
@@ -196,7 +196,7 @@ func TestHTTP_BodyTooLarge(t *testing.T) {
 		ReadTimeoutSec:  10,
 		WriteTimeoutSec: 10,
 	}
-	ing := NewIngester(db, lake, "lp_")
+	ing := NewIngester(db, lake, cfg)
 	hs, err := newHTTPServer(cfg, ing)
 	if err != nil {
 		t.Fatalf("newHTTPServer: %v", err)
@@ -212,5 +212,75 @@ func TestHTTP_BodyTooLarge(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusRequestEntityTooLarge {
 		t.Fatalf("status: got %d, want 413", resp.StatusCode)
+	}
+}
+
+func TestHTTP_WriteHepCall(t *testing.T) {
+	db, lake := newLPDB(t)
+	createTestHepCallTable(t, db, lake)
+	cfg := &config.LineProtoConfig{
+		Enable:           true,
+		Listen:           ":0",
+		MaxBodyBytes:     8 * 1024 * 1024,
+		DefaultPrecision: "ns",
+		TablePrefix:      "lp_",
+		ReadTimeoutSec:   10,
+		WriteTimeoutSec:  10,
+		AllowHepSipCall:  true,
+	}
+	ing := NewIngester(db, lake, cfg)
+	hs, err := newHTTPServer(cfg, ing)
+	if err != nil {
+		t.Fatalf("newHTTPServer: %v", err)
+	}
+	srv := httptest.NewServer(hs.server.Handler)
+	defer srv.Close()
+
+	lp := `sip,method=BYE,session_id=s1 caller="alice",callee="bob",src_ip="10.0.0.1",dst_ip="10.0.0.2",src_port=5060i,dst_port=5060i,protocol=17i,payload="BYE sip:x SIP/2.0" 1700000000000000000`
+	resp, err := http.Post(srv.URL+"/write?hep_table=call&precision=ns", "text/plain", strings.NewReader(lp))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d body=%s", resp.StatusCode, string(body))
+	}
+	var n int
+	if err := db.QueryRow("SELECT count(*) FROM test_lake.main.hep_proto_1_call").Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("rows in hep_proto_1_call: want 1, got %d", n)
+	}
+}
+
+func TestHTTP_WriteHepTableDisabled(t *testing.T) {
+	db, lake := newLPDB(t)
+	cfg := &config.LineProtoConfig{
+		Enable:           true,
+		Listen:           ":0",
+		MaxBodyBytes:     8 * 1024 * 1024,
+		DefaultPrecision: "ns",
+		TablePrefix:      "lp_",
+		ReadTimeoutSec:   10,
+		WriteTimeoutSec:  10,
+		AllowHepSipCall:  false,
+	}
+	ing := NewIngester(db, lake, cfg)
+	hs, err := newHTTPServer(cfg, ing)
+	if err != nil {
+		t.Fatalf("newHTTPServer: %v", err)
+	}
+	srv := httptest.NewServer(hs.server.Handler)
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/write?hep_table=call", "text/plain", strings.NewReader("cpu v=1i"))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", resp.StatusCode)
 	}
 }

--- a/src/lineprotoreceiver/ingest.go
+++ b/src/lineprotoreceiver/ingest.go
@@ -16,6 +16,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sipcapture/homer-core/src/config"
+	"github.com/sipcapture/homer-core/src/storage/ducklake"
 	"github.com/sipcapture/homer-core/src/utils/metrics"
 )
 
@@ -31,9 +33,10 @@ const defaultTablePrefix = "lp_"
 // HTTP handlers. The underlying *sql.DB and lakeName come from the
 // writer's primary DuckLake shard (see writer.GetDuckLakeManager).
 type Ingester struct {
-	db          *sql.DB
-	lakeName    string
-	tablePrefix string
+	db              *sql.DB
+	lakeName        string
+	tablePrefix     string
+	allowHepSipCall bool
 
 	tablesMu    sync.Mutex
 	tablesState map[string]map[string]string // fqTable → col → SQL type
@@ -44,17 +47,23 @@ type Ingester struct {
 
 // NewIngester returns a ready-to-use Ingester. lakeName is the DuckLake
 // catalog identifier ("homer_lake" by default) used to qualify table
-// names. tablePrefix defaults to "lp_" when empty.
-func NewIngester(db *sql.DB, lakeName, tablePrefix string) *Ingester {
-	if tablePrefix == "" {
-		tablePrefix = defaultTablePrefix
+// names. cfg may be nil (defaults: lp_ prefix, hep sip call ingest off).
+func NewIngester(db *sql.DB, lakeName string, cfg *config.LineProtoConfig) *Ingester {
+	tp := defaultTablePrefix
+	allow := false
+	if cfg != nil {
+		if cfg.TablePrefix != "" {
+			tp = cfg.TablePrefix
+		}
+		allow = cfg.AllowHepSipCall
 	}
 	return &Ingester{
-		db:             db,
-		lakeName:       lakeName,
-		tablePrefix:    tablePrefix,
-		tablesState:    make(map[string]map[string]string),
-		schemasCreated: make(map[string]bool),
+		db:              db,
+		lakeName:        lakeName,
+		tablePrefix:     tp,
+		allowHepSipCall: allow,
+		tablesState:     make(map[string]map[string]string),
+		schemasCreated:  make(map[string]bool),
 	}
 }
 
@@ -64,10 +73,19 @@ func NewIngester(db *sql.DB, lakeName, tablePrefix string) *Ingester {
 // (mirrors the InfluxDB v1 / gigapi `?db=…` semantics).
 //
 // Returns (rowsWritten, error). On a parse error, no rows are written.
-func (i *Ingester) Ingest(ctx context.Context, dbName string, body []byte, precision LineProtoPrecision) (int, error) {
+// hepTable must be empty for standard LP tables, or "call" when writing
+// into hep_proto_1_call (requires allowHepSipCall on the ingester).
+func (i *Ingester) Ingest(ctx context.Context, dbName string, body []byte, precision LineProtoPrecision, hepTable string) (int, error) {
 	if i == nil || i.db == nil {
 		return 0, fmt.Errorf("line-proto ingester: not initialised")
 	}
+	if hepTable == "call" {
+		if !i.allowHepSipCall {
+			return 0, fmt.Errorf("hep_table sip call ingest is disabled")
+		}
+		return i.ingestHepSIPCallLP(ctx, body, precision)
+	}
+
 	pts, badIdx, err := ParseLineProtocol(body, precision)
 	if err != nil {
 		metrics.RecordLineProtoWriteError("parse")
@@ -96,6 +114,36 @@ func (i *Ingester) Ingest(ctx context.Context, dbName string, body []byte, preci
 		}
 	}
 	return total, nil
+}
+
+func (i *Ingester) ingestHepSIPCallLP(ctx context.Context, body []byte, precision LineProtoPrecision) (int, error) {
+	pts, badIdx, err := ParseLineProtocol(body, precision)
+	if err != nil {
+		metrics.RecordLineProtoWriteError("parse")
+		return 0, fmt.Errorf("parse error at line %d: %w", badIdx+1, err)
+	}
+	if len(pts) == 0 {
+		return 0, nil
+	}
+	key := ducklake.TableKey{ProtoType: ducklake.ProtoTypeSIP, SubType: ducklake.SIPTypeCall}
+	rows := make([][]interface{}, 0, len(pts))
+	for li := range pts {
+		row, err := lineProtoPointToSIPCallRow(&pts[li])
+		if err != nil {
+			metrics.RecordLineProtoWriteError("hep_sip_call_map")
+			return 0, fmt.Errorf("point %d: %w", li+1, err)
+		}
+		rows = append(rows, row)
+	}
+	sql, err := ducklake.BuildInsertMultiValues(i.lakeName, key, rows)
+	if err != nil {
+		return 0, err
+	}
+	if _, err := i.db.ExecContext(ctx, sql); err != nil {
+		metrics.RecordLineProtoWriteError("hep_sip_call_write")
+		return 0, fmt.Errorf("write hep_proto_1_call: %w", err)
+	}
+	return len(rows), nil
 }
 
 // ensureSchema creates "<lakeName>.<schema>" on first use and memoises

--- a/src/lineprotoreceiver/ingest_test.go
+++ b/src/lineprotoreceiver/ingest_test.go
@@ -8,9 +8,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"testing"
 
 	_ "github.com/duckdb/duckdb-go/v2"
+	"github.com/sipcapture/homer-core/src/config"
+	"github.com/sipcapture/homer-core/src/storage/ducklake"
 )
 
 // newLPDB opens a fresh in-memory DuckDB and attaches a second in-memory
@@ -32,16 +35,34 @@ func newLPDB(t *testing.T) (*sql.DB, string) {
 	return db, lake
 }
 
+func createTestHepCallTable(t *testing.T, db *sql.DB, lake string) {
+	t.Helper()
+	key := ducklake.TableKey{ProtoType: ducklake.ProtoTypeSIP, SubType: ducklake.SIPTypeCall}
+	sc := ducklake.GetTableSchemas()[key]
+	if sc == nil {
+		t.Fatal("sip call schema missing")
+	}
+	fqn := fmt.Sprintf("%s.main.hep_proto_%s", lake, sc.TableSuffix)
+	ddl := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (%s);", fqn, strings.TrimSpace(sc.CreateSQL))
+	if _, err := db.Exec(ddl); err != nil {
+		t.Fatalf("create hep call table: %v", err)
+	}
+}
+
+func lpTestCfg() *config.LineProtoConfig {
+	return &config.LineProtoConfig{TablePrefix: "lp_"}
+}
+
 func TestIngester_InsertsRowsPerMeasurement(t *testing.T) {
 	db, lake := newLPDB(t)
-	ing := NewIngester(db, lake, "lp_")
+	ing := NewIngester(db, lake, lpTestCfg())
 
 	body := []byte(`
 cpu,host=srv1 usage=0.42,active=t 1700000000000000000
 cpu,host=srv2 usage=0.77,active=f 1700000001000000000
 mem,host=srv1 used=1024i 1700000002000000000
 `)
-	n, err := ing.Ingest(context.Background(), "", body, PrecisionNanoseconds)
+	n, err := ing.Ingest(context.Background(), "", body, PrecisionNanoseconds, "")
 	if err != nil {
 		t.Fatalf("ingest error: %v", err)
 	}
@@ -74,14 +95,14 @@ mem,host=srv1 used=1024i 1700000002000000000
 
 func TestIngester_PerDBSchema(t *testing.T) {
 	db, lake := newLPDB(t)
-	ing := NewIngester(db, lake, "lp_")
+	ing := NewIngester(db, lake, lpTestCfg())
 
 	body := []byte(`
 weather,location=us-midwest temperature=82
 weather,location=us-east temperature=80
 weather,location=us-west temperature=99
 `)
-	n, err := ing.Ingest(context.Background(), "mydb", body, PrecisionNanoseconds)
+	n, err := ing.Ingest(context.Background(), "mydb", body, PrecisionNanoseconds, "")
 	if err != nil {
 		t.Fatalf("ingest: %v", err)
 	}
@@ -106,14 +127,14 @@ weather,location=us-west temperature=99
 
 func TestIngester_IsolatesDBs(t *testing.T) {
 	db, lake := newLPDB(t)
-	ing := NewIngester(db, lake, "lp_")
+	ing := NewIngester(db, lake, lpTestCfg())
 
 	if _, err := ing.Ingest(context.Background(), "a",
-		[]byte("metric,x=1 v=1i"), PrecisionNanoseconds); err != nil {
+		[]byte("metric,x=1 v=1i"), PrecisionNanoseconds, ""); err != nil {
 		t.Fatalf("db=a: %v", err)
 	}
 	if _, err := ing.Ingest(context.Background(), "b",
-		[]byte("metric,x=2 v=2i"), PrecisionNanoseconds); err != nil {
+		[]byte("metric,x=2 v=2i"), PrecisionNanoseconds, ""); err != nil {
 		t.Fatalf("db=b: %v", err)
 	}
 	var a, b int64
@@ -130,9 +151,9 @@ func TestIngester_IsolatesDBs(t *testing.T) {
 
 func TestIngester_SanitizesDBName(t *testing.T) {
 	db, lake := newLPDB(t)
-	ing := NewIngester(db, lake, "lp_")
+	ing := NewIngester(db, lake, lpTestCfg())
 	if _, err := ing.Ingest(context.Background(), "my-weird db",
-		[]byte("m,x=1 v=1i"), PrecisionNanoseconds); err != nil {
+		[]byte("m,x=1 v=1i"), PrecisionNanoseconds, ""); err != nil {
 		t.Fatalf("ingest: %v", err)
 	}
 	var cnt int
@@ -146,9 +167,9 @@ func TestIngester_SanitizesDBName(t *testing.T) {
 
 func TestIngester_AutoExtendsColumns(t *testing.T) {
 	db, lake := newLPDB(t)
-	ing := NewIngester(db, lake, "lp_")
+	ing := NewIngester(db, lake, lpTestCfg())
 
-	n1, err := ing.Ingest(context.Background(), "", []byte("metric,region=a value=1i"), PrecisionNanoseconds)
+	n1, err := ing.Ingest(context.Background(), "", []byte("metric,region=a value=1i"), PrecisionNanoseconds, "")
 	if err != nil {
 		t.Fatalf("first ingest: %v", err)
 	}
@@ -156,7 +177,7 @@ func TestIngester_AutoExtendsColumns(t *testing.T) {
 		t.Fatalf("expected 1 row, got %d", n1)
 	}
 	n2, err := ing.Ingest(context.Background(), "",
-		[]byte("metric,region=b,zone=east value=2i,extra=\"xyz\""), PrecisionNanoseconds)
+		[]byte("metric,region=b,zone=east value=2i,extra=\"xyz\""), PrecisionNanoseconds, "")
 	if err != nil {
 		t.Fatalf("second ingest: %v", err)
 	}
@@ -181,9 +202,9 @@ func TestIngester_AutoExtendsColumns(t *testing.T) {
 
 func TestIngester_ParseErrorIsReported(t *testing.T) {
 	db, lake := newLPDB(t)
-	ing := NewIngester(db, lake, "lp_")
+	ing := NewIngester(db, lake, lpTestCfg())
 	_, err := ing.Ingest(context.Background(), "",
-		[]byte("good v=1\nbroken_no_field"), PrecisionNanoseconds)
+		[]byte("good v=1\nbroken_no_field"), PrecisionNanoseconds, "")
 	if err == nil {
 		t.Fatalf("expected parse error, got nil")
 	}
@@ -191,9 +212,9 @@ func TestIngester_ParseErrorIsReported(t *testing.T) {
 
 func TestIngester_PrecisionMilliseconds(t *testing.T) {
 	db, lake := newLPDB(t)
-	ing := NewIngester(db, lake, "lp_")
+	ing := NewIngester(db, lake, lpTestCfg())
 	n, err := ing.Ingest(context.Background(), "",
-		[]byte("events v=1 1700000000000"), PrecisionMilliseconds)
+		[]byte("events v=1 1700000000000"), PrecisionMilliseconds, "")
 	if err != nil {
 		t.Fatalf("ingest: %v", err)
 	}
@@ -206,6 +227,50 @@ func TestIngester_PrecisionMilliseconds(t *testing.T) {
 	}
 	if ts != "2023-11-14 22:13:20" {
 		t.Errorf("ts: got %q, want 2023-11-14 22:13:20", ts)
+	}
+}
+
+func TestIngester_HepSipCallLP(t *testing.T) {
+	db, lake := newLPDB(t)
+	createTestHepCallTable(t, db, lake)
+	cfg := &config.LineProtoConfig{TablePrefix: "lp_", AllowHepSipCall: true}
+	ing := NewIngester(db, lake, cfg)
+
+	body := []byte(`sip,method=INVITE,session_id=call-1 caller="alice",callee="bob",src_ip="10.0.0.1",dst_ip="10.0.0.2",src_port=5060i,dst_port=5060i,protocol=17i,payload="INVITE sip:b SIP/2.0" 1700000000000000000`)
+	n, err := ing.Ingest(context.Background(), "ignored_db", body, PrecisionNanoseconds, "call")
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("rows: want 1, got %d", n)
+	}
+	var method, session string
+	if err := db.QueryRow("SELECT method, session_id FROM test_lake.main.hep_proto_1_call LIMIT 1").Scan(&method, &session); err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	if method != "INVITE" || session != "call-1" {
+		t.Errorf("method=%q session_id=%q", method, session)
+	}
+}
+
+func TestIngester_HepSipCallLP_Disabled(t *testing.T) {
+	db, lake := newLPDB(t)
+	createTestHepCallTable(t, db, lake)
+	ing := NewIngester(db, lake, lpTestCfg())
+	_, err := ing.Ingest(context.Background(), "", []byte(`m a=1 1`), PrecisionNanoseconds, "call")
+	if err == nil {
+		t.Fatal("expected error when hep sip call disabled")
+	}
+}
+
+func TestIngester_HepSipCallLP_InvalidDataExtra(t *testing.T) {
+	db, lake := newLPDB(t)
+	createTestHepCallTable(t, db, lake)
+	cfg := &config.LineProtoConfig{AllowHepSipCall: true}
+	ing := NewIngester(db, lake, cfg)
+	_, err := ing.Ingest(context.Background(), "", []byte(`sip,data_extra="not-json" x=1i 1700000000000000000`), PrecisionNanoseconds, "call")
+	if err == nil {
+		t.Fatal("expected error for invalid data_extra JSON")
 	}
 }
 

--- a/src/lineprotoreceiver/module.go
+++ b/src/lineprotoreceiver/module.go
@@ -36,7 +36,7 @@ func New(cfg *config.LineProtoConfig, db *sql.DB, lakeName string) (*Module, err
 	if db == nil {
 		return nil, fmt.Errorf("line-proto receiver: db is required")
 	}
-	ing := NewIngester(db, lakeName, cfg.TablePrefix)
+	ing := NewIngester(db, lakeName, cfg)
 	hs, err := newHTTPServer(cfg, ing)
 	if err != nil {
 		return nil, fmt.Errorf("line-proto http: %w", err)

--- a/src/lineprotoreceiver/parser.go
+++ b/src/lineprotoreceiver/parser.go
@@ -20,7 +20,8 @@
 //   - GET  /health             — InfluxDB v2 health probe
 //
 // Recognised query parameters: ?precision=ns|us|ms|s, ?db=<name>,
-// ?bucket=<name> (synonym for db).
+// ?bucket=<name> (synonym for db), ?hep_table=call (optional; see
+// docs/LINE_PROTOCOL.md — requires ingest.line_protocol.allow_hep_sip_call).
 package lineprotoreceiver
 
 import (

--- a/src/storage/ducklake/sql_lake_insert.go
+++ b/src/storage/ducklake/sql_lake_insert.go
@@ -67,6 +67,18 @@ func insertColumnNames(schema *TableSchema) []string {
 	return parts
 }
 
+// SIPCallInsertColumnNames returns the INSERT column order for
+// hep_proto_1_call, derived from the canonical TableSchema (must stay
+// aligned with InsertSQL in tables.go).
+func SIPCallInsertColumnNames() []string {
+	key := TableKey{ProtoType: ProtoTypeSIP, SubType: SIPTypeCall}
+	s := GetTableSchemas()[key]
+	if s == nil {
+		return nil
+	}
+	return insertColumnNames(s)
+}
+
 func formatSQLLiteral(v interface{}) (string, error) {
 	switch x := v.(type) {
 	case nil:


### PR DESCRIPTION
- Add ingest.line_protocol.allow_hep_sip_call and ?hep_table=call on LP write endpoints; reject hep_table when feature disabled (400).
- Map LP tags/fields to SIP call columns; data_extra must be JSON object.
- Add ducklake.SIPCallInsertColumnNames for schema-aligned column order.
- Tests and LINE_PROTOCOL.md documentation.