### PR TITLE
fix(sip): wire aleg_ids and custom_headers into zero-copy parser

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -23,5 +23,6 @@ Field names follow the `mapstructure` tags on [`Config` in `src/config/config.go
 ## References
 
 - Loader: `config.Load` — `SetEnvPrefix("HOMER")`, `SetEnvKeyReplacer(".", "_")`, `AutomaticEnv()` ([source](../src/config/config.go)).
+- SIP ingest (`ingest.sip`): `aleg_ids`, `custom_headers`, `force_aleg_id`; see [LUA_CORRELATION.md](LUA_CORRELATION.md#sip-header-lists-writer-ingest) (CID / correlation).
 - Tiered storage fields: [`docs/STORAGE_POLICIES.md`](STORAGE_POLICIES.md) (conceptual); same paths appear under `storage.ducklake.storage_policy` and `node.ducklake` in JSON — mirror them as `HOMER_*` as above.
 - Example with variables declared inline in Compose: [`examples/docker/docker-compose.yml`](../examples/docker/docker-compose.yml) (`homer.environment`).

--- a/docs/LUA_CORRELATION.md
+++ b/docs/LUA_CORRELATION.md
@@ -16,6 +16,16 @@ re-queries the data layer.
 - CRUD UI: **Settings → Scripts** (`src/ui/src/settings/ScriptsPanel.tsx`)
 - Package README (developer-facing): `src/scripting/correlation/README.md`
 
+## SIP header lists (writer ingest)
+
+SIP messages are parsed on the **zero-copy** path (`sipparser.ParseMsgZeroCopy`). The writer / modular `ingest.sip` settings are:
+
+- **`ingest.sip.aleg_ids`**: list of SIP header names (case-insensitive). The **first** header in **message order** that matches any configured name sets `SipMsg.XCallID`. The decoder uses that for the HEP **CID** when the HEP chunk carries no CID (`src/decoder/sip.go`).
+- **`ingest.sip.custom_headers`**: optional header names; matching values go into `SipMsg.CustomHeader` and into DuckLake `data_extra.custom_headers` JSON (`src/storage/ducklake/hep_adapter.go`).
+- **`ingest.sip.force_aleg_id`**: when true, replaces an existing HEP CID with `XCallID` when `XCallID` is non-empty.
+
+This path uses the **full** header value only (no regex capture). Environment overrides use indexed keys such as `HOMER_INGEST_SIP_ALEG_IDS_0`, `HOMER_INGEST_SIP_CUSTOM_HEADERS_0`, etc.; see [ENVIRONMENT_VARIABLES.md](ENVIRONMENT_VARIABLES.md).
+
 ---
 
 ## 1. How it works

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -675,9 +675,11 @@ type HEPConfig struct {
 type SIPConfig struct {
 	CensorMethods  []string `json:"censored_methods" mapstructure:"censored_methods"`
 	DiscardMethods []string `json:"discard_methods" mapstructure:"discard_methods"`
-	AlegIDs        []string `json:"aleg_ids" mapstructure:"aleg_ids"`
-	CustomHeaders  []string `json:"custom_headers" mapstructure:"custom_headers"`
-	ForceALegID    bool     `json:"force_aleg_id" mapstructure:"force_aleg_id" default:"false"`
+	// AlegIDs lists SIP header names (case-insensitive). The first matching header in wire order sets XCallID; used for HEP CID when the chunk has no CID (see sipparser.ParseMsgZeroCopy).
+	AlegIDs []string `json:"aleg_ids" mapstructure:"aleg_ids"`
+	// CustomHeaders lists optional SIP header names copied into data_extra.custom_headers in storage.
+	CustomHeaders []string `json:"custom_headers" mapstructure:"custom_headers"`
+	ForceALegID   bool     `json:"force_aleg_id" mapstructure:"force_aleg_id" default:"false"`
 }
 
 // CoordinatorHTTPServerConfig configures the Coordinator API server

--- a/src/decoder/decoder.go
+++ b/src/decoder/decoder.go
@@ -67,7 +67,9 @@ type DecoderConfig struct {
 	Deduplicate    bool
 
 	// SIP settings
-	AlegIDs        []string
+	// AlegIDs: SIP header names (case-insensitive); first matching header in wire order fills XCallID during zero-copy parse (see sipparser.ZeroCopyOpts).
+	AlegIDs []string
+	// CustomHeaders: optional SIP header names whose values are stored in CustomHeader / data_extra.custom_headers.
 	CustomHeaders  []string
 	ForceALegID    bool
 	CensorMethods  []string

--- a/src/decoder/sip.go
+++ b/src/decoder/sip.go
@@ -30,16 +30,28 @@ func stob(s string) []byte {
 	return unsafe.Slice(unsafe.StringData(s), len(s))
 }
 
+// parseSIP decodes the SIP payload. When ingest lists aleg_ids / custom_headers,
+// they are passed into ParseMsgZeroCopy so XCallID and CustomHeader are filled
+// before CID selection (see sipparser.ZeroCopyOpts).
 func (h *HEP) parseSIP() error {
 	var forceALegID bool
+	var zcOpts *sipparser.ZeroCopyOpts
 
 	if h.decoder != nil && h.decoder.config != nil {
-		forceALegID = h.decoder.config.ForceALegID
+		cfg := h.decoder.config
+		forceALegID = cfg.ForceALegID
+		if len(cfg.AlegIDs) > 0 || len(cfg.CustomHeaders) > 0 {
+			zcOpts = &sipparser.ZeroCopyOpts{AlegIDs: cfg.AlegIDs, CustomHeaders: cfg.CustomHeaders}
+		}
 	} else if homerconfig.MainConfig != nil {
-		forceALegID = homerconfig.MainConfig.Setting.SIP_SETTINGS.ForceALegID
+		sip := homerconfig.MainConfig.Setting.SIP_SETTINGS
+		forceALegID = sip.ForceALegID
+		if len(sip.AlegIDs) > 0 || len(sip.CustomHeaders) > 0 {
+			zcOpts = &sipparser.ZeroCopyOpts{AlegIDs: sip.AlegIDs, CustomHeaders: sip.CustomHeaders}
+		}
 	}
 
-	h.SIP = sipparser.ParseMsgZeroCopy(stob(h.Payload))
+	h.SIP = sipparser.ParseMsgZeroCopy(stob(h.Payload), zcOpts)
 
 	if h.SIP.Error != nil {
 		return h.SIP.Error

--- a/src/homerconfig/dataconfig.go
+++ b/src/homerconfig/dataconfig.go
@@ -212,13 +212,15 @@ type HomerServerSettings struct {
 		} `json:"flight_server" mapstructure:"flight_server"`
 	} `json:"server_settings" mapstructure:"server_settings"`
 
-	// hep settings
+	// hep / SIP capture tuning (legacy homerconfig)
 	SIP_SETTINGS struct {
 		CensorMethod   []string `json:"censored_methods" mapstructure:"censored_methods" default:"[]"`
 		DiscardMethods []string `json:"discard_methods" mapstructure:"discard_methods" default:"[]"`
-		AlegIDs        []string `json:"aleg_ids" mapstructure:"aleg_ids" default:"[]"`
-		CustomHeaders  []string `json:"custom_headers" mapstructure:"custom_headers" default:"[]"`
-		//ForceALegID
+		// AlegIDs: header names whose first wire-order match fills XCallID (see sipparser.ZeroCopyOpts).
+		AlegIDs []string `json:"aleg_ids" mapstructure:"aleg_ids" default:"[]"`
+		// CustomHeaders: extra header names stored in SipMsg.CustomHeader / data_extra.
+		CustomHeaders []string `json:"custom_headers" mapstructure:"custom_headers" default:"[]"`
+		// ForceALegID: when true, decoder prefers XCallID over an existing HEP CID when XCallID is set.
 		ForceALegID bool `json:"force_aleg_id" mapstructure:"force_aleg_id" default:"false"`
 	} `json:"sip_settings" mapstructure:"sip_settings"`
 

--- a/src/sipparser/parser.go
+++ b/src/sipparser/parser.go
@@ -134,6 +134,10 @@ type SipMsg struct {
 	//Supported          []string
 	//Warning            *Warning
 	//WWWAuthenticate    *Authorization
+
+	// zcHdrOpts is only set during ParseMsgZeroCopy for optional aleg_ids /
+	// custom_headers matching; it is not read after parsing finishes.
+	zcHdrOpts *ZeroCopyOpts
 }
 
 func (s *SipMsg) run() {

--- a/src/sipparser/zerocopy.go
+++ b/src/sipparser/zerocopy.go
@@ -17,8 +17,23 @@ package sipparser
 
 import (
 	"errors"
+	"strings"
 	"unsafe"
 )
+
+// ZeroCopyOpts configures optional SIP header extraction for ParseMsgZeroCopy.
+// Nil opts or both slices empty: no extra matching (same as legacy callers).
+//
+// AlegIDs lists SIP header names (case-insensitive). While scanning headers top
+// to bottom, the first line whose name matches any entry sets SipMsg.XCallID;
+// later lines do not overwrite a non-empty XCallID.
+//
+// CustomHeaders lists extra header names to copy into SipMsg.CustomHeader; map
+// keys are the configured strings (stable for data_extra JSON).
+type ZeroCopyOpts struct {
+	AlegIDs       []string
+	CustomHeaders []string
+}
 
 // btos converts []byte to string without copying.
 func btos(b []byte) string {
@@ -30,10 +45,12 @@ var (
 	errTooShort = errors.New("ParseMsgZeroCopy: message too short")
 )
 
-// ParseMsgZeroCopy parses a SIP message from raw bytes with minimal heap allocations.
-// All string fields point into the original data buffer via unsafe.
-// The caller must keep data alive while the returned SipMsg is in use.
-func ParseMsgZeroCopy(data []byte) *SipMsg {
+// ParseMsgZeroCopy parses a SIP message from raw bytes with minimal allocations.
+// String fields reference the original buffer via unsafe; keep data alive while
+// using the returned SipMsg.
+// If opts is non-nil and lists are non-empty, AlegIDs and CustomHeaders populate
+// XCallID and CustomHeader respectively.
+func ParseMsgZeroCopy(data []byte, opts *ZeroCopyOpts) *SipMsg {
 	if len(data) < 16 {
 		return &SipMsg{Error: errTooShort}
 	}
@@ -47,8 +64,9 @@ func ParseMsgZeroCopy(data []byte) *SipMsg {
 	}
 
 	s := &SipMsg{
-		Msg: btos(data),
-		eof: headersEnd,
+		Msg:       btos(data),
+		eof:       headersEnd,
+		zcHdrOpts: opts,
 	}
 
 	if bodyStart := headersEnd + 4; bodyStart < len(data) {
@@ -57,6 +75,51 @@ func ParseMsgZeroCopy(data []byte) *SipMsg {
 
 	zcParseHeaders(data[:headersEnd+2], s)
 	return s
+}
+
+// ParseMsgZeroCopyLegacy is equivalent to ParseMsgZeroCopy(data, nil).
+func ParseMsgZeroCopyLegacy(data []byte) *SipMsg {
+	return ParseMsgZeroCopy(data, nil)
+}
+
+// zcApplyAlegCustomHeaders applies ingest aleg_ids and custom_headers for one header line.
+func zcApplyAlegCustomHeaders(name, val []byte, s *SipMsg) {
+	o := s.zcHdrOpts
+	if o == nil {
+		return
+	}
+	if len(o.AlegIDs) == 0 && len(o.CustomHeaders) == 0 {
+		return
+	}
+	nameStr := btos(name)
+	valStr := btos(zcTrimWS(val))
+
+	if len(o.AlegIDs) > 0 && s.XCallID == "" {
+		for _, id := range o.AlegIDs {
+			if id == "" {
+				continue
+			}
+			if strings.EqualFold(nameStr, id) {
+				s.XCallID = valStr
+				break
+			}
+		}
+	}
+	if len(o.CustomHeaders) == 0 {
+		return
+	}
+	for _, h := range o.CustomHeaders {
+		if h == "" {
+			continue
+		}
+		if strings.EqualFold(nameStr, h) {
+			if s.CustomHeader == nil {
+				s.CustomHeader = make(map[string]string)
+			}
+			s.CustomHeader[h] = valStr
+			break
+		}
+	}
 }
 
 func zcFindLastCRLF(data []byte) int {
@@ -284,6 +347,7 @@ func zcParseHeaderLine(line []byte, s *SipMsg) {
 			s.RTPStatVal = btos(zcTrimWS(val))
 		}
 	}
+	zcApplyAlegCustomHeaders(name, val, s)
 }
 
 // zcParseFromTo extracts user, host, tag from From/To header value.

--- a/src/sipparser/zerocopy_opts_test.go
+++ b/src/sipparser/zerocopy_opts_test.go
@@ -1,0 +1,124 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sipparser
+
+import (
+	"strings"
+	"testing"
+)
+
+// minimalSIP returns a minimal valid INVITE with extra header lines after CSeq.
+func minimalSIP(extraLines string) []byte {
+	const core = "INVITE sip:a@b SIP/2.0\r\n" +
+		"Via: SIP/2.0/UDP 10.0.0.1;branch=z9hG4bK1\r\n" +
+		"From: <sip:a@b>;tag=ft\r\n" +
+		"To: <sip:c@d>\r\n" +
+		"Call-ID: cid-one@host\r\n" +
+		"CSeq: 1 INVITE\r\n"
+	return []byte(core + extraLines + "\r\n")
+}
+
+func TestParseMsgZeroCopy_AlegIDs(t *testing.T) {
+	raw := minimalSIP("X-Custom-Call: correl-xyz")
+	opts := &ZeroCopyOpts{AlegIDs: []string{"X-Custom-Call"}}
+	s := ParseMsgZeroCopy(raw, opts)
+	if s.Error != nil {
+		t.Fatalf("parse: %v", s.Error)
+	}
+	if s.XCallID != "correl-xyz" {
+		t.Fatalf("XCallID: want correl-xyz, got %q", s.XCallID)
+	}
+	if s.CallID != "cid-one@host" {
+		t.Fatalf("CallID: %q", s.CallID)
+	}
+}
+
+func TestParseMsgZeroCopy_AlegIDsCaseInsensitive(t *testing.T) {
+	raw := minimalSIP("x-custom-call: lower-val")
+	opts := &ZeroCopyOpts{AlegIDs: []string{"X-Custom-Call"}}
+	s := ParseMsgZeroCopy(raw, opts)
+	if s.Error != nil {
+		t.Fatalf("parse: %v", s.Error)
+	}
+	if s.XCallID != "lower-val" {
+		t.Fatalf("XCallID: want lower-val, got %q", s.XCallID)
+	}
+}
+
+func TestParseMsgZeroCopy_AlegIDsFirstWireHeaderWins(t *testing.T) {
+	raw := minimalSIP("X-A: first\r\nX-B: second")
+	opts := &ZeroCopyOpts{AlegIDs: []string{"X-B", "X-A"}}
+	s := ParseMsgZeroCopy(raw, opts)
+	if s.Error != nil {
+		t.Fatalf("parse: %v", s.Error)
+	}
+	if s.XCallID != "first" {
+		t.Fatalf("XCallID: want first (first matching line in message), got %q", s.XCallID)
+	}
+}
+
+func TestParseMsgZeroCopy_CustomHeaders(t *testing.T) {
+	raw := minimalSIP("X-Extra: hello")
+	opts := &ZeroCopyOpts{CustomHeaders: []string{"X-Extra"}}
+	s := ParseMsgZeroCopy(raw, opts)
+	if s.Error != nil {
+		t.Fatalf("parse: %v", s.Error)
+	}
+	if s.CustomHeader == nil || s.CustomHeader["X-Extra"] != "hello" {
+		t.Fatalf("CustomHeader: %#v", s.CustomHeader)
+	}
+}
+
+func TestParseMsgZeroCopy_CustomHeadersNonX(t *testing.T) {
+	raw := minimalSIP("P-Charging-Vector: icid=abc")
+	opts := &ZeroCopyOpts{CustomHeaders: []string{"P-Charging-Vector"}}
+	s := ParseMsgZeroCopy(raw, opts)
+	if s.Error != nil {
+		t.Fatalf("parse: %v", s.Error)
+	}
+	if s.CustomHeader == nil || !strings.Contains(s.CustomHeader["P-Charging-Vector"], "icid=abc") {
+		t.Fatalf("CustomHeader: %#v", s.CustomHeader)
+	}
+}
+
+func TestParseMsgZeroCopy_NilOptsIgnoresExtraHeaders(t *testing.T) {
+	raw := minimalSIP("X-Orphan: ignored")
+	s := ParseMsgZeroCopy(raw, nil)
+	if s.Error != nil {
+		t.Fatalf("parse: %v", s.Error)
+	}
+	if s.XCallID != "" {
+		t.Fatalf("XCallID: want empty, got %q", s.XCallID)
+	}
+	if len(s.CustomHeader) != 0 {
+		t.Fatalf("CustomHeader: want empty, got %#v", s.CustomHeader)
+	}
+}
+
+func TestParseMsgZeroCopyLegacy(t *testing.T) {
+	raw := minimalSIP("X-Orphan: x")
+	s := ParseMsgZeroCopyLegacy(raw)
+	if s.Error != nil {
+		t.Fatalf("parse: %v", s.Error)
+	}
+	if s.XCallID != "" {
+		t.Fatalf("legacy wrapper: unexpected XCallID %q", s.XCallID)
+	}
+}
+
+func TestParseMsgZeroCopy_XRTPStatPlusCustom(t *testing.T) {
+	raw := minimalSIP("X-RTP-Stat: stats\r\nX-Extra: e")
+	opts := &ZeroCopyOpts{CustomHeaders: []string{"X-Extra"}}
+	s := ParseMsgZeroCopy(raw, opts)
+	if s.Error != nil {
+		t.Fatalf("parse: %v", s.Error)
+	}
+	if s.RTPStatVal != "stats" {
+		t.Fatalf("RTPStatVal: %q", s.RTPStatVal)
+	}
+	if s.CustomHeader == nil || s.CustomHeader["X-Extra"] != "e" {
+		t.Fatalf("CustomHeader: %#v", s.CustomHeader)
+	}
+}


### PR DESCRIPTION
ParseMsgZeroCopy accepts ZeroCopyOpts; decoder passes ingest or homerconfig SIP lists. Restores XCallID/CID correlation (github.com/sipcapture/homer/issues/728). Add sipparser tests, English docs and comments.