### PR TITLE
Added docker compose for s3 only and s3+local storage installation.

### DIFF
--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -1,34 +1,54 @@
 # Homer + RustFS (Compose)
 
-Docker Compose stack for **Homer** with **RustFS** as S3-compatible **cold** storage.
+This folder contains two Docker Compose variants for running Homer with RustFS-backed storage.
 
-**All Homer configuration is in [`docker-compose.yml`](docker-compose.yml)** under the `homer` service `environment` map (`HOMER_*`). RustFS settings are under `rustfs.environment`. Naming rules: [`docs/ENVIRONMENT_VARIABLES.md`](../../docs/ENVIRONMENT_VARIABLES.md). Tiering concepts: [`docs/STORAGE_POLICIES.md`](../../docs/STORAGE_POLICIES.md).
+- `docker-compose.yaml` — Homer with **local Parquet hot storage** plus **RustFS S3 cold storage**.
+- `docker-compose_s3direct.yaml` — Homer with **S3-only storage** on RustFS.
 
-## Storage layout
+All Homer configuration is in the `homer` service `environment` map (`HOMER_*`). RustFS settings are configured under `rustfs.environment`. Naming rules: [`docs/ENVIRONMENT_VARIABLES.md`](../../docs/ENVIRONMENT_VARIABLES.md). Tiering concepts: [`docs/STORAGE_POLICIES.md`](../../docs/STORAGE_POLICIES.md).
+
+## Storage layouts
+
+### `docker-compose.yaml`
 
 | Tier | Where | Role |
 |------|--------|------|
-| **Hot** | Local `/data/homer/parquet` (`homer_data` volume) | New writes. |
-| **Cold** | `s3://homer-cold/data/` on RustFS (`http://rustfs:9000`) | Older partitions per `HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_*`. |
+| **Hot** | Local `/data/homer/parquet` (`homer_data` volume) | New writes and recent partitions. |
+| **Cold** | `s3://homer-data-cold` on RustFS (`http://rustfs:9000`) | Older partitions moved by Homer tiering policies. |
+
+### `docker-compose_s3direct.yaml`
+
+| Tier | Where | Role |
+|------|--------|------|
+| **Cold only** | `s3://homer-data-cold` on RustFS (`http://rustfs:9000`) | All Homer data is written directly to S3-compatible storage. |
 
 ## Quick start
 
 ```bash
 cd examples/docker
-docker compose up -d
+docker compose -f docker-compose.yaml up -d
 ```
 
-Edit **`docker-compose.yml`** to change ports, image (`ghcr.io/sipcapture/homer:latest`), secrets, or tiering knobs—no separate `.env` file required.
+Or use the S3-only stack:
 
-- **Coordinator UI:** http://localhost:8080  
-- **HEP / HTTP ingest:** UDP/TCP `9060`, HTTP `9080`  
-- **RustFS S3 API:** http://localhost:9000 (`rustfs:9000` in the stack)  
-- **RustFS console:** http://localhost:9001  
-- **Prometheus:** http://localhost:9090/metrics  
+```bash
+cd examples/docker
+docker compose -f docker-compose_s3direct.yaml up -d
+```
 
-RustFS keys in `rustfs.environment` must match the Homer cold-tier `HOMER_*_S3_ACCESS_KEY_ID` / `HOMER_*_S3_SECRET_ACCESS_KEY` entries (default `rustfsadmin`). Create bucket **`homer-cold`** if cold-tier writes fail until it exists.
+Edit the chosen compose file to change ports, image (`ghcr.io/sipcapture/homer:latest`), secrets, or storage settings—no separate `.env` file is required.
+
+## Endpoints
+
+- **Coordinator UI:** http://localhost:8080
+- **HEP / HTTP ingest:** UDP/TCP `9060`, HTTP `9080`
+- **RustFS S3 API:** http://localhost:9000 (`rustfs:9000` inside the stack)
+- **RustFS console:** http://localhost:9001
+- **Prometheus:** http://localhost:9090/metrics
+
+RustFS keys in `rustfs.environment` must match the Homer S3 access key/secret entries. The default credentials are `rustfsadmin` / `rustfsadmin`.
 
 ## References
 
-- Env naming: [`docs/ENVIRONMENT_VARIABLES.md`](../../docs/ENVIRONMENT_VARIABLES.md)  
-- Tiered storage: [`docs/STORAGE_POLICIES.md`](../../docs/STORAGE_POLICIES.md)  
+- Env naming: [`docs/ENVIRONMENT_VARIABLES.md`](../../docs/ENVIRONMENT_VARIABLES.md)
+- Tiered storage: [`docs/STORAGE_POLICIES.md`](../../docs/STORAGE_POLICIES.md)

--- a/examples/docker/docker-compose.yaml
+++ b/examples/docker/docker-compose.yaml
@@ -12,6 +12,7 @@ services:
 
   rustfs:
     image: rustfs/rustfs:latest
+    container_name: rustfs
     security_opt:
       - "no-new-privileges:true"
     environment:
@@ -47,6 +48,23 @@ services:
     networks:
       - homer-compose
     restart: unless-stopped
+
+
+  rustfs-init-volume:
+    image: rustfs/rc:latest
+    container_name: rc-rustfs-init
+    depends_on:
+      rustfs:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      until (/usr/bin/rc alias set rustfs http://rustfs:9000 rustfsadmin rustfsadmin) do echo '...waiting...' && sleep 1; done;
+      /usr/bin/rc mb rustfs/homer-data-cold;
+      echo 'RustFS initialization complete';
+      "
+    restart: "no"
+    networks:
+      - homer-compose
 
   homer:
     image: ghcr.io/sipcapture/homer:latest
@@ -87,13 +105,10 @@ services:
       HOMER_INGEST_HTTP_PORT: "9080"
       HOMER_INGEST_HTTP_READ_TIMEOUT: "30"
       HOMER_INGEST_HTTP_WRITE_TIMEOUT: "30"
-      HOMER_INGEST_HTTP_MAX_REQUEST_BODY_SIZE: "67108864"
       HOMER_INGEST_HTTP_WEBSOCKET_ENABLE: "false"
       HOMER_INGEST_HTTPS_ENABLE: "false"
-      HOMER_INGEST_HEP_HEPV2_ENABLE: "true"
       HOMER_INGEST_HEP_HEPV3_ENABLE: "true"
       HOMER_INGEST_HEP_PROTOBUF_ENABLE: "true"
-      HOMER_INGEST_HEP_DEDUPLICATE: "false"
 
       HOMER_STORAGE_DUCKLAKE_CATALOG_TYPE: sqlite
       HOMER_STORAGE_DUCKLAKE_CATALOG_PATH: /data/homer/homer_catalog.sqlite
@@ -115,18 +130,18 @@ services:
       HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_TTL_MOVE_INTERVAL_SEC: "3600"
       HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_MOVE_FACTOR: "0.8"
       HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_CONCURRENT_MOVES: "2"
-      HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_MOVE_ON_STARTUP: "false"
+      HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_MOVE_ON_STARTUP: "true"
 
       HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_0_NAME: hot
       HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_0_TYPE: local
       HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_0_PATH: /data/homer/parquet
       HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_0_PRIORITY: "0"
-      HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_0_MAX_DATA_AGE_DAYS: "7"
+      HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_0_MAX_DATA_AGE_DAYS: "2" # Move data older than 1 day from hot to cold (>= 1 day)
       HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_0_MAX_SIZE_GB: "100"
 
       HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_1_NAME: cold
       HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_1_TYPE: s3
-      HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_1_PATH: s3://homer-cold/data/
+      HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_1_PATH: s3://homer-data-cold
       HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_1_PRIORITY: "1"
       HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_1_MAX_DATA_AGE_DAYS: "0"
       HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_1_S3_REGION: us-east-1
@@ -153,7 +168,7 @@ services:
       HOMER_NODE_DUCKLAKE_VOLUMES_1_TYPE: s3
       HOMER_NODE_DUCKLAKE_VOLUMES_1_CATALOG_TYPE: sqlite
       HOMER_NODE_DUCKLAKE_VOLUMES_1_CATALOG_PATH: /data/homer/homer_catalog_cold.sqlite
-      HOMER_NODE_DUCKLAKE_VOLUMES_1_PATH: s3://homer-cold/data/
+      HOMER_NODE_DUCKLAKE_VOLUMES_1_PATH: s3://homer-data-cold
       HOMER_NODE_DUCKLAKE_VOLUMES_1_S3_REGION: us-east-1
       HOMER_NODE_DUCKLAKE_VOLUMES_1_S3_ACCESS_KEY_ID: rustfsadmin
       HOMER_NODE_DUCKLAKE_VOLUMES_1_S3_SECRET_ACCESS_KEY: rustfsadmin

--- a/examples/docker/docker-compose_s3direct.yaml
+++ b/examples/docker/docker-compose_s3direct.yaml
@@ -1,0 +1,202 @@
+# Homer 11 + RustFS. All Homer settings are in `homer.environment` below (HOMER_*).
+# See ../../docs/ENVIRONMENT_VARIABLES.md and ../../docs/STORAGE_POLICIES.md.
+services:
+  rustfs-init:
+    image: alpine:3.20
+    volumes:
+      - rustfs_data:/data
+    command: sh -c "chown -R 10001:10001 /data && echo rustfs data volume ok"
+    restart: "no"
+    networks:
+      - homer-compose
+
+  rustfs:
+    image: rustfs/rustfs:latest
+    container_name: rustfs
+    security_opt:
+      - "no-new-privileges:true"
+    environment:
+      RUSTFS_VOLUMES: /data
+      RUSTFS_ADDRESS: 0.0.0.0:9000
+      RUSTFS_CONSOLE_ADDRESS: 0.0.0.0:9001
+      RUSTFS_CONSOLE_ENABLE: "true"
+      RUSTFS_CONSOLE_CORS_ALLOWED_ORIGINS: "*"
+      RUSTFS_ACCESS_KEY: rustfsadmin
+      RUSTFS_SECRET_KEY: rustfsadmin
+      RUSTFS_OBS_LOGGER_LEVEL: info
+      RUSTFS_UNSAFE_BYPASS_DISK_CHECK: "false"
+    volumes:
+      - rustfs_data:/data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "sh",
+          "-c",
+          "curl -fsS http://127.0.0.1:9000/health && curl -fsS http://127.0.0.1:9001/rustfs/console/health",
+        ]
+      interval: 15s
+      timeout: 10s
+      retries: 6
+      start_period: 45s
+    depends_on:
+      rustfs-init:
+        condition: service_completed_successfully
+    networks:
+      - homer-compose
+    restart: unless-stopped
+
+
+  rustfs-init-volume:
+    image: rustfs/rc:latest
+    container_name: rc-rustfs-init
+    depends_on:
+      rustfs:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      until (/usr/bin/rc alias set rustfs http://rustfs:9000 rustfsadmin rustfsadmin) do echo '...waiting...' && sleep 1; done;
+      /usr/bin/rc mb rustfs/homer-data-cold;
+      echo 'RustFS initialization complete';
+      "
+    restart: "no"
+    networks:
+      - homer-compose
+
+  homer:
+    image: ghcr.io/sipcapture/homer:latest
+    depends_on:
+      rustfs:
+        condition: service_healthy
+    volumes:
+      - homer_data:/data/homer
+    ports:
+      - "9060:9060/tcp"
+      - "9060:9060/udp"
+      - "9080:9080/tcp"
+      - "8080:8080/tcp"
+      - "50051:50051/tcp"
+      - "9090:9090/tcp"
+    networks:
+      - homer-compose
+    restart: unless-stopped
+    environment:
+      HOMER_INGEST_ENABLE: "true"
+      HOMER_STORAGE_ENABLE: "true"
+      HOMER_NODE_ENABLE: "true"
+      HOMER_COORDINATOR_ENABLE: "true"
+
+      HOMER_INGEST_WORKER_COUNT: "8"
+      HOMER_INGEST_QUEUE_SIZE: "80000"
+      HOMER_INGEST_UDP_ENABLE: "true"
+      HOMER_INGEST_UDP_HOST: 0.0.0.0
+      HOMER_INGEST_UDP_PORT: "9060"
+      HOMER_INGEST_UDP_MULTICORE: "true"
+      HOMER_INGEST_TCP_ENABLE: "true"
+      HOMER_INGEST_TCP_HOST: 0.0.0.0
+      HOMER_INGEST_TCP_PORT: "9060"
+      HOMER_INGEST_TCP_MULTICORE: "true"
+      HOMER_INGEST_TLS_ENABLE: "false"
+      HOMER_INGEST_HTTP_ENABLE: "true"
+      HOMER_INGEST_HTTP_HOST: 0.0.0.0
+      HOMER_INGEST_HTTP_PORT: "9080"
+      HOMER_INGEST_HTTP_READ_TIMEOUT: "30"
+      HOMER_INGEST_HTTP_WRITE_TIMEOUT: "30"
+      HOMER_INGEST_HTTP_WEBSOCKET_ENABLE: "false"
+      HOMER_INGEST_HTTPS_ENABLE: "false"
+      HOMER_INGEST_HEP_HEPV3_ENABLE: "true"
+      HOMER_INGEST_HEP_PROTOBUF_ENABLE: "true"
+
+      HOMER_STORAGE_DUCKLAKE_CATALOG_TYPE: sqlite
+      HOMER_STORAGE_DUCKLAKE_CATALOG_PATH: /data/homer/homer_catalog.sqlite
+      HOMER_STORAGE_DUCKLAKE_DATA_PATH: s3://homer-data-cold/
+      HOMER_STORAGE_DUCKLAKE_LAKE_NAME: homer_lake
+      HOMER_STORAGE_DUCKLAKE_BATCH_SIZE: "10000"
+      HOMER_STORAGE_DUCKLAKE_FLUSH_INTERVAL_SEC: "30"
+
+      HOMER_STORAGE_DUCKLAKE_S3_ENDPOINT: http://rustfs:9000
+      HOMER_STORAGE_DUCKLAKE_S3_ACCESS_KEY_ID: rustfsadmin
+      HOMER_STORAGE_DUCKLAKE_S3_SECRET_ACCESS_KEY: rustfsadmin
+      HOMER_STORAGE_DUCKLAKE_S3_REGION: us-east-1
+      HOMER_STORAGE_DUCKLAKE_S3_USE_SSL: "false"
+
+      HOMER_STORAGE_DUCKLAKE_COMPACTION_ENABLE: "true"
+      HOMER_STORAGE_DUCKLAKE_COMPACTION_CHECK_INTERVAL_SEC: "1800"
+      HOMER_STORAGE_DUCKLAKE_COMPACTION_RETENTION_DAYS: "30"
+      HOMER_STORAGE_DUCKLAKE_COMPACTION_SNAPSHOT_EXPIRE_INTERVAL_SEC: "3600"
+      HOMER_STORAGE_DUCKLAKE_COMPACTION_MIN_AGE_SEC: "3600"
+      HOMER_STORAGE_DUCKLAKE_COMPACTION_MIN_FILE_SIZE_BYTES: "0"
+      HOMER_STORAGE_DUCKLAKE_COMPACTION_MAX_FILE_SIZE_BYTES: "134217728"
+      HOMER_STORAGE_DUCKLAKE_COMPACTION_MAX_COMPACTED_FILES: "100"
+
+      HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_ENABLE: "true"
+      HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_0_NAME: cold
+      HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_0_TYPE: s3
+      HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_0_PATH: s3://homer-data-cold/
+      HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_0_PRIORITY: "0"
+      HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_0_MAX_DATA_AGE_DAYS: "0"
+      HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_0_S3_REGION: us-east-1
+      HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_0_S3_ACCESS_KEY_ID: rustfsadmin
+      HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_0_S3_SECRET_ACCESS_KEY: rustfsadmin
+      HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_0_S3_ENDPOINT: http://rustfs:9000
+      HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_0_S3_USE_SSL: "false"
+
+      HOMER_NODE_FLIGHT_SERVER_HOST: 0.0.0.0
+      HOMER_NODE_FLIGHT_SERVER_PORT: "50051"
+      HOMER_NODE_FLIGHT_SERVER_AUTH_TOKEN: your-secret-token-here
+      HOMER_NODE_FLIGHT_SERVER_MAX_MESSAGE_SIZE: "16777216"
+      HOMER_NODE_FLIGHTSQL_SERVER_ENABLE: "false"
+
+      HOMER_NODE_DUCKLAKE_LAKE_NAME: homer_lake
+
+      HOMER_NODE_DUCKLAKE_VOLUMES_0_NAME: cold
+      HOMER_NODE_DUCKLAKE_VOLUMES_0_TYPE: s3
+      HOMER_NODE_DUCKLAKE_VOLUMES_0_CATALOG_TYPE: sqlite
+      HOMER_NODE_DUCKLAKE_VOLUMES_0_CATALOG_PATH: /data/homer/homer_catalog.sqlite
+      HOMER_NODE_DUCKLAKE_VOLUMES_0_PATH: s3://homer-data-cold/
+      HOMER_NODE_DUCKLAKE_VOLUMES_0_S3_REGION: us-east-1
+      HOMER_NODE_DUCKLAKE_VOLUMES_0_S3_ACCESS_KEY_ID: rustfsadmin
+      HOMER_NODE_DUCKLAKE_VOLUMES_0_S3_SECRET_ACCESS_KEY: rustfsadmin
+      HOMER_NODE_DUCKLAKE_VOLUMES_0_S3_ENDPOINT: http://rustfs:9000
+      HOMER_NODE_DUCKLAKE_VOLUMES_0_S3_USE_SSL: "false"
+
+      HOMER_COORDINATOR_HTTP_SERVER_ENABLE: "true"
+      HOMER_COORDINATOR_HTTP_SERVER_HOST: 0.0.0.0
+      HOMER_COORDINATOR_HTTP_SERVER_PORT: "8080"
+      HOMER_COORDINATOR_HTTP_SERVER_STATIC_PATH: /usr/local/homer-core/dist
+
+      HOMER_COORDINATOR_NODES_0_NAME: local
+      HOMER_COORDINATOR_NODES_0_HOST: 127.0.0.1
+      HOMER_COORDINATOR_NODES_0_PORT: "50051"
+      HOMER_COORDINATOR_NODES_0_FLIGHTSQL_PORT: "0"
+      HOMER_COORDINATOR_NODES_0_USE_TLS: "false"
+      HOMER_COORDINATOR_NODES_0_TOKEN: your-secret-token-here
+      HOMER_COORDINATOR_NODES_0_PRIORITY: "1"
+
+      HOMER_COORDINATOR_SETTINGS_DB_PATH: /data/homer/homer_settings.duckdb
+      HOMER_COORDINATOR_FLIGHTSQL_SERVER_ENABLE: "false"
+
+      HOMER_COORDINATOR_JWT_SECRET: change-this-to-a-secure-random-string-in-production
+      HOMER_COORDINATOR_JWT_EXPIRE_HOURS: "24"
+      HOMER_COORDINATOR_AUTH_ADMIN_USER: admin
+      HOMER_COORDINATOR_AUTH_ADMIN_PASSWORD_HASH: 883ffc1f37fd0fe542b0fb9740035c4383e7d976c411161d24e62edace280f90
+
+      HOMER_LOG_LEVEL: info
+      HOMER_LOG_JSON: "false"
+      HOMER_LOG_OUTPUT_0: stdout
+
+      HOMER_PROMETHEUS_ENABLE: "true"
+      HOMER_PROMETHEUS_HOST: 0.0.0.0
+      HOMER_PROMETHEUS_PORT: "9090"
+      HOMER_PROMETHEUS_PATH: /metrics
+
+networks:
+  homer-compose:
+    driver: bridge
+
+volumes:
+  rustfs_data:
+  homer_data:


### PR DESCRIPTION
Added:
- docker-compose.yaml (data stored on local parquet files [hot] + s3 bucket [cold])
- docker-compose_s3direct.yaml (direct storage on s3 bucket)
- README updated