### PR TITLE
chore: release 11.0.214

### DIFF
--- a/src/coordinator/handlers/transactions_v4.go
+++ b/src/coordinator/handlers/transactions_v4.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"regexp"
 	"sort"
@@ -549,6 +550,7 @@ func (h *SearchHandler) queryTransactionMessages(ctx context.Context, req *Trans
 	if err != nil {
 		return nil, err
 	}
+	sortTransactionMessageRowsByTimestampAsc(baseRows)
 
 	if h.correlation == nil || !h.correlation.Has(protoType, eventType) {
 		return baseRows, nil
@@ -581,6 +583,7 @@ func (h *SearchHandler) queryTransactionMessages(ctx context.Context, req *Trans
 			"err", err.Error(), "proto", protoType, "event", eventType)
 		return baseRows, nil
 	}
+	sortTransactionMessageRowsByTimestampAsc(expandedRows)
 	return expandedRows, nil
 }
 
@@ -609,7 +612,7 @@ func transactionMessagesSelectSQL(table string, sessionIDs []string, from, to in
 	case isOTLPMetricsDuckLakeTable(table):
 		limit = fmt.Sprintf(" LIMIT %d", maxOTLPMetricsPerQuery)
 	}
-	return fmt.Sprintf("SELECT * FROM %s WHERE %s ORDER BY timestamp ASC%s", table, where, limit)
+	return fmt.Sprintf("SELECT * FROM %s WHERE %s ORDER BY timestamp ASC NULLS LAST%s", table, where, limit)
 }
 
 // executeTransactionMessagesSQL builds and runs the B2B-aware SELECT for a
@@ -655,6 +658,43 @@ func mergeSessionIDs(base, extras []string) []string {
 		out = append(out, s)
 	}
 	return out
+}
+
+// sortTransactionMessageRowsByTimestampAsc orders messages for transaction view / API:
+// oldest capture time first (ASC), null or unparseable timestamps last, stable tie-break on ids.
+func sortTransactionMessageRowsByTimestampAsc(rows []map[string]interface{}) {
+	if len(rows) < 2 {
+		return
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		ni := transactionRowSortNanos(rows[i])
+		nj := transactionRowSortNanos(rows[j])
+		if ni != nj {
+			return ni < nj
+		}
+		return transactionRowSortTie(rows[i]) < transactionRowSortTie(rows[j])
+	})
+}
+
+func transactionRowSortNanos(row map[string]interface{}) int64 {
+	for _, key := range []string{"timestamp", "time"} {
+		if t, ok := pcapwriter.RowTimeOptional(row, key); ok {
+			return t.UnixNano()
+		}
+	}
+	return math.MaxInt64
+}
+
+func transactionRowSortTie(row map[string]interface{}) string {
+	for _, k := range []string{"uuid", "span_id", "trace_id", "name"} {
+		if v, ok := row[k]; ok && v != nil {
+			s := strings.TrimSpace(fmt.Sprint(v))
+			if s != "" {
+				return s
+			}
+		}
+	}
+	return ""
 }
 
 func (h *SearchHandler) V4TransactionMessages(c echo.Context) error {

--- a/src/coordinator/handlers/transactions_v4_messages_sort_test.go
+++ b/src/coordinator/handlers/transactions_v4_messages_sort_test.go
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package handlers
+
+import "testing"
+
+func TestSortTransactionMessageRowsByTimestampAsc_ordersOldestFirst(t *testing.T) {
+	rows := []map[string]interface{}{
+		{"uuid": "b", "timestamp": "2020-01-02T00:00:00Z"},
+		{"uuid": "a", "timestamp": "2020-01-01T00:00:00Z"},
+		{"uuid": "c", "timestamp": "2020-01-01T12:00:00Z"},
+	}
+	sortTransactionMessageRowsByTimestampAsc(rows)
+	if got := rows[0]["uuid"]; got != "a" {
+		t.Fatalf("row0 uuid = %v want a", got)
+	}
+	if got := rows[1]["uuid"]; got != "c" {
+		t.Fatalf("row1 uuid = %v want c", got)
+	}
+	if got := rows[2]["uuid"]; got != "b" {
+		t.Fatalf("row2 uuid = %v want b", got)
+	}
+}
+
+func TestSortTransactionMessageRowsByTimestampAsc_missingTimestampLast(t *testing.T) {
+	rows := []map[string]interface{}{
+		{"uuid": "z", "timestamp": "2020-01-02T00:00:00Z"},
+		{"uuid": "no-ts"},
+		{"uuid": "a", "timestamp": "2020-01-01T00:00:00Z"},
+	}
+	sortTransactionMessageRowsByTimestampAsc(rows)
+	if got := rows[0]["uuid"]; got != "a" {
+		t.Fatalf("row0 uuid = %v want a", got)
+	}
+	if got := rows[1]["uuid"]; got != "z" {
+		t.Fatalf("row1 uuid = %v want z", got)
+	}
+	if got := rows[2]["uuid"]; got != "no-ts" {
+		t.Fatalf("row2 uuid = %v want no-ts", got)
+	}
+}

--- a/src/pcapwriter/rows.go
+++ b/src/pcapwriter/rows.go
@@ -46,13 +46,21 @@ func RowInt(row map[string]interface{}, key string) int {
 // RowTime parses a timestamp field from a map row.
 // Accepts time.Time, string (RFC3339/RFC3339Nano), or numeric (unix seconds/ms/µs/ns).
 func RowTime(row map[string]interface{}, key string) time.Time {
+	if t, ok := RowTimeOptional(row, key); ok {
+		return t
+	}
+	return time.Now().UTC()
+}
+
+// RowTimeOptional parses row[key] into UTC time. Missing or unparseable values return (_, false).
+func RowTimeOptional(row map[string]interface{}, key string) (time.Time, bool) {
 	v, ok := row[key]
 	if !ok || v == nil {
-		return time.Now().UTC()
+		return time.Time{}, false
 	}
 	switch val := v.(type) {
 	case time.Time:
-		return val.UTC()
+		return val.UTC(), true
 	case string:
 		val = strings.TrimSpace(val)
 		for _, layout := range []string{
@@ -62,16 +70,16 @@ func RowTime(row map[string]interface{}, key string) time.Time {
 			"2006-01-02 15:04:05",
 		} {
 			if t, err := time.Parse(layout, val); err == nil {
-				return t.UTC()
+				return t.UTC(), true
 			}
 		}
-		return time.Now().UTC()
+		return time.Time{}, false
 	case float64:
-		return unixToTime(int64(val))
+		return unixToTime(int64(val)), true
 	case int64:
-		return unixToTime(val)
+		return unixToTime(val), true
 	}
-	return time.Now().UTC()
+	return time.Time{}, false
 }
 
 func unixToTime(n int64) time.Time {

--- a/src/pcapwriter/sip_rows_test.go
+++ b/src/pcapwriter/sip_rows_test.go
@@ -92,3 +92,28 @@ func TestNewPCAPWriter_WritePacket_RoundTripHeader(t *testing.T) {
 		t.Fatalf("bad LE magic prefix")
 	}
 }
+
+func TestRowTimeOptional(t *testing.T) {
+	t.Run("RFC3339", func(t *testing.T) {
+		row := map[string]interface{}{"timestamp": "2020-05-01T12:00:00Z"}
+		got, ok := pcapwriter.RowTimeOptional(row, "timestamp")
+		if !ok {
+			t.Fatal("expected ok")
+		}
+		if got.Year() != 2020 || got.Month() != 5 || got.Day() != 1 {
+			t.Fatalf("time = %v", got)
+		}
+	})
+	t.Run("missing", func(t *testing.T) {
+		_, ok := pcapwriter.RowTimeOptional(map[string]interface{}{}, "timestamp")
+		if ok {
+			t.Fatal("expected !ok")
+		}
+	})
+	t.Run("garbage", func(t *testing.T) {
+		_, ok := pcapwriter.RowTimeOptional(map[string]interface{}{"timestamp": "not-a-date"}, "timestamp")
+		if ok {
+			t.Fatal("expected !ok")
+		}
+	})
+}

--- a/src/ui/src/dashboard/TransactionModal.tsx
+++ b/src/ui/src/dashboard/TransactionModal.tsx
@@ -23,6 +23,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { displayDstIp, displaySrcIp } from '@/lib/ipAliasDisplay'
 import { cn } from '@/lib/utils'
+import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react'
 import { getMethodColor } from './flow-utils'
 import { resolveTimeRange } from './utils/resolveTimeRange'
 
@@ -47,6 +48,22 @@ function messageEventLabel(row) {
   return ''
 }
 
+/** Compare displayed event labels: numeric SIP codes as integers, else case-insensitive string. */
+function compareDisplayedEventLabels(a, b) {
+  const sa = String(a ?? '').trim().toLowerCase()
+  const sb = String(b ?? '').trim().toLowerCase()
+  if (sa === sb) return 0
+  const na = /^\d+$/.test(sa) ? parseInt(sa, 10) : NaN
+  const nb = /^\d+$/.test(sb) ? parseInt(sb, 10) : NaN
+  if (Number.isFinite(na) && Number.isFinite(nb)) return na - nb
+  if (sa < sb) return -1
+  if (sa > sb) return 1
+  return 0
+}
+
+/** Synthetic key: original row index from the API (for “#” column sort / restore order). */
+const MESSAGE_SORT_ORIG = '__orig__'
+
 const MESSAGE_TABLE_COLUMNS = [
   { key: 'timestamp', header: 'Timestamp', format: 'datetime' },
   { key: 'call_id', header: 'Call-ID', accessor: messageCallId },
@@ -58,6 +75,74 @@ const MESSAGE_TABLE_COLUMNS = [
   { key: 'caller', header: 'caller' },
   { key: 'callee', header: 'callee' },
 ]
+
+function messageSortScalar(colKey, row, origIndex) {
+  if (colKey === MESSAGE_SORT_ORIG) return origIndex
+  const col = MESSAGE_TABLE_COLUMNS.find((c) => c.key === colKey)
+  if (!col) return ''
+  if (col.accessor) return col.accessor(row)
+  let value = row[col.key]
+  if (col.key === 'src_ip') value = displaySrcIp(row)
+  else if (col.key === 'dst_ip') value = displayDstIp(row)
+  if (col.format === 'datetime') {
+    const d = parseTimestampValue(value)
+    return d && !Number.isNaN(d.getTime()) ? d.getTime() : null
+  }
+  if (col.key === 'src_port' || col.key === 'dst_port') {
+    if (value == null || value === '') return null
+    const n = typeof value === 'number' ? value : parseInt(String(value).trim(), 10)
+    return Number.isFinite(n) ? n : null
+  }
+  if (value === undefined || value === null) return ''
+  return String(value)
+}
+
+/**
+ * Compare two message rows for table sorting. Null / empty numeric or missing time sort last in ASC
+ * (same idea as SQL NULLS LAST).
+ */
+function compareMessageRowsForSort(colKey, dir, rowA, origA, rowB, origB) {
+  const va = messageSortScalar(colKey, rowA, origA)
+  const vb = messageSortScalar(colKey, rowB, origB)
+
+  const nullsLastBody = (cmpNums) => {
+    const aNull = va == null || va === ''
+    const bNull = vb == null || vb === ''
+    if (aNull && bNull) return 0
+    if (aNull) return 1
+    if (bNull) return -1
+    if (cmpNums) {
+      const c = va - vb
+      if (c !== 0) return c
+    }
+    const sa = String(va).toLowerCase()
+    const sb = String(vb).toLowerCase()
+    if (sa < sb) return -1
+    if (sa > sb) return 1
+    return origA - origB
+  }
+
+  let cmp
+  if (colKey === MESSAGE_SORT_ORIG) {
+    cmp = va - vb
+  } else if (colKey === 'timestamp' || colKey === 'src_port' || colKey === 'dst_port') {
+    cmp = nullsLastBody(true)
+  } else if (colKey === 'event') {
+    const aNull = va == null || va === ''
+    const bNull = vb == null || vb === ''
+    if (aNull && bNull) cmp = 0
+    else if (aNull) cmp = 1
+    else if (bNull) cmp = -1
+    else {
+      cmp = compareDisplayedEventLabels(va, vb)
+      if (cmp === 0) cmp = origA - origB
+    }
+  } else {
+    cmp = nullsLastBody(false)
+  }
+  if (cmp !== 0) return dir === 'asc' ? cmp : -cmp
+  return origA - origB
+}
 
 function formatMessageTableCell(col, row, timeZone) {
   let text
@@ -490,6 +575,8 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
   const [otlpLogSearched, setOtlpLogSearched] = React.useState(false)
   const [exportOpen, setExportOpen] = React.useState(false)
   const [messageModals, setMessageModals] = React.useState([])
+  const [msgSortCol, setMsgSortCol] = React.useState(null)
+  const [msgSortDir, setMsgSortDir] = React.useState('asc')
 
   // reset per-tab state whenever a new transaction is opened
   React.useEffect(() => {
@@ -500,6 +587,8 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
     setOtlpLogData(null); setOtlpLogErr(''); setOtlpLogLoading(false); setOtlpLogSearched(false)
     setExportOpen(false)
     setMessageModals([])
+    setMsgSortCol(null)
+    setMsgSortDir('asc')
   }, [modal?.modalKey])
 
   React.useEffect(() => {
@@ -515,6 +604,31 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
   const sessionIdsForApi = (Array.isArray(sessionIds) && sessionIds.length)
     ? sessionIds.map((s) => String(s).trim()).filter(Boolean)
     : (primaryId ? [String(primaryId).trim()] : [])
+
+  const messageRowsIndexed = React.useMemo(
+    () => (items || []).map((row, orig) => ({ row, orig })),
+    [items],
+  )
+
+  const messageRowsSorted = React.useMemo(() => {
+    if (!msgSortCol) return messageRowsIndexed
+    const copy = [...messageRowsIndexed]
+    copy.sort((a, b) =>
+      compareMessageRowsForSort(msgSortCol, msgSortDir, a.row, a.orig, b.row, b.orig),
+    )
+    return copy
+  }, [messageRowsIndexed, msgSortCol, msgSortDir])
+
+  const handleMessageSort = (colKey) => {
+    setMsgSortCol((prev) => {
+      if (prev === colKey) {
+        setMsgSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+        return colKey
+      }
+      setMsgSortDir('asc')
+      return colKey
+    })
+  }
 
   const loadQos = async () => {
     if (qosData || qosLoading) return
@@ -684,20 +798,54 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
                   <Table>
                     <TableHeader className="sticky top-0 z-10 bg-card">
                       <TableRow>
-                        <TableHead className="w-10 text-[10px] uppercase tracking-wider">#</TableHead>
+                        <TableHead className="w-10 text-[10px] uppercase tracking-wider">
+                          <button
+                            type="button"
+                            className="inline-flex cursor-pointer select-none items-center gap-1 border-0 bg-transparent p-0 font-inherit text-inherit hover:text-foreground"
+                            title="Sort by row # (API order)"
+                            onClick={() => handleMessageSort(MESSAGE_SORT_ORIG)}
+                          >
+                            #
+                            {msgSortCol === MESSAGE_SORT_ORIG ? (
+                              msgSortDir === 'asc' ? (
+                                <ArrowUp className="h-3 w-3 shrink-0" />
+                              ) : (
+                                <ArrowDown className="h-3 w-3 shrink-0" />
+                              )
+                            ) : (
+                              <ArrowUpDown className="h-3 w-3 shrink-0 opacity-45 dark:opacity-50" />
+                            )}
+                          </button>
+                        </TableHead>
                         {MESSAGE_TABLE_COLUMNS.map((col) => (
                           <TableHead key={col.key} className="text-[10px] uppercase tracking-wider">
-                            {col.header}
+                            <button
+                              type="button"
+                              className="inline-flex cursor-pointer select-none items-center gap-1 border-0 bg-transparent p-0 font-inherit text-inherit hover:text-foreground"
+                              title={`Sort by ${col.header}`}
+                              onClick={() => handleMessageSort(col.key)}
+                            >
+                              {col.header}
+                              {msgSortCol === col.key ? (
+                                msgSortDir === 'asc' ? (
+                                  <ArrowUp className="h-3 w-3 shrink-0" />
+                                ) : (
+                                  <ArrowDown className="h-3 w-3 shrink-0" />
+                                )
+                              ) : (
+                                <ArrowUpDown className="h-3 w-3 shrink-0 opacity-45 dark:opacity-50" />
+                              )}
+                            </button>
                           </TableHead>
                         ))}
                       </TableRow>
                     </TableHeader>
                     <TableBody>
-                      {(items || []).map((row, idx) => (
+                      {messageRowsSorted.map(({ row, orig }, idx) => (
                         <TableRow
-                          key={row.uuid || idx}
+                          key={row.uuid != null && String(row.uuid) !== '' ? String(row.uuid) : `tx-msg-${orig}`}
                           className={`cursor-pointer hover:brightness-95 ${idx % 2 === 0 ? 'bg-white dark:bg-slate-800' : 'bg-sky-50 dark:bg-sky-900/60'}`}
-                          onClick={() => handleFlowMessageClick({ raw: row, id: row.uuid || idx })}
+                          onClick={() => handleFlowMessageClick({ raw: row, id: row.uuid ?? orig })}
                         >
                           <TableCell className="font-mono text-[11px] text-muted-foreground">
                             {idx + 1}

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.212"
+	VERSION_APPLICATION = "11.0.214"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
Sort transaction messages by timestamp on the API, stable tie-breakers, RowTimeOptional for parsing, and client-side Messages table column sorting.