### PR TITLE
feat(games): Chess + NetChess dashboard widgets, fix DuckLake LP mappings

### DIFF
--- a/docs/VOIPGames.md
+++ b/docs/VOIPGames.md
@@ -2,6 +2,17 @@
 
 The dashboard includes seven mini-games under the **Games** category. Widgets are added from the dashboard palette (`registry.ts`: `packet_defender`, `sip_dialog_master`, `jitter_buffer_hero`, `sipetris`, `netris`, `chess`, `netchess`). Five are educational (SIP/RTP-themed) and two are general-purpose chess games. The chess pair shares one rules engine (`chess.js` on the UI, `notnil/chess` on the server) and one presentational board component (`ChessBoard.tsx`).
 
+### Default dashboards
+
+On first login (or after a `Reset` from `DashboardSettingsDialog`) the coordinator seeds four dashboards (`DashboardService.ResetDashboards`):
+
+1. **Home** — SIP Call Search + Results + Clock.
+2. **Smart Search** — Protocol Search + Results + Time Chart.
+3. **Games** — Packet Defender, SIP Dialog Master, Jitter Buffer Hero, SIPetris, Chess. Single-player only — no coordinator hubs required.
+4. **NetGames** — Netris, NetChess. Multiplayer over WebSocket; both widgets show a connection error until the corresponding hub is reachable, so we keep them on a separate tab.
+
+Users can rename, reorder, or delete any of these dashboards at runtime; the seed only runs when `ListDashboards` returns an empty set.
+
 ---
 
 ## Shared controls

--- a/docs/VOIPGames.md
+++ b/docs/VOIPGames.md
@@ -1,6 +1,6 @@
-# VoIP Games (Homer Next-Gen dashboard)
+# Games (Homer Next-Gen dashboard)
 
-The dashboard includes five educational mini-games under the **Games** category. Widgets are added from the dashboard palette (`registry.ts`: `packet_defender`, `sip_dialog_master`, `jitter_buffer_hero`, `sipetris`, `netris`). They reinforce SIP/RTP terminology and typical traffic-handling patterns in a lightweight, interactive way.
+The dashboard includes seven mini-games under the **Games** category. Widgets are added from the dashboard palette (`registry.ts`: `packet_defender`, `sip_dialog_master`, `jitter_buffer_hero`, `sipetris`, `netris`, `chess`, `netchess`). Five are educational (SIP/RTP-themed) and two are general-purpose chess games. The chess pair shares one rules engine (`chess.js` on the UI, `notnil/chess` on the server) and one presentational board component (`ChessBoard.tsx`).
 
 ---
 
@@ -220,6 +220,87 @@ The relay is intentionally thin: server enforces matchmaking, garbage translatio
 
 ---
 
+## 6. Chess (`chess`)
+
+**Concept:** single-player chess against a built-in bot or — when the operator enables the MCP LLM bridge — against an LLM opponent. The minimax bot runs in a Web Worker so the UI never blocks. The widget is general-purpose entertainment; it does not consume captured traffic.
+
+### Controls
+
+| Control | Behavior |
+|---------|----------|
+| **Time control** | `Untimed` / `Bullet 1+0` / `Blitz 3+2` / `Rapid 10+5` (Fischer increment). Changes only apply on the next `New game`. |
+| **Side** | `White` / `Black` / `Random` — applied on the next new game. |
+| **Level** | 1–4 search depth slider for the bot (also passed as a hint to the LLM). |
+| **Bot / LLM** | Toggle between the local minimax and the MCP LLM. Only shown if `GET /api/v4/games/chess/llm-status` reports `{ enabled: true }`. |
+| **New game** | Resets the position, applies the current side/time-control. |
+| **Takeback** | Pops two plies (your move + bot's reply) so it's your move again. |
+| **Resign** | Ends the game in your loss. |
+| **Export PGN** | Copies the full PGN of the played game to the clipboard. |
+
+### LLM mode
+
+When LLM mode is active, every bot move is requested from the coordinator endpoint `POST /api/v4/games/chess/llm-move`. The coordinator:
+
+1. Calls the configured `mcp.llm` provider via the shared `src/mcp/llm.go` client with a fixed chess system prompt.
+2. Validates the model's reply via `github.com/notnil/chess` (`ValidateUCI`).
+3. If the model returns an illegal or unparseable move, falls back to a server-side greedy picker so the widget always receives a legal UCI for non-terminal positions. The response carries `source: "llm" | "fallback"` and the widget shows an **`fallback`** pill when the fallback path was used.
+
+The LLM client is shared with MCP search, so there's no separate configuration. To enable: set `mcp.llm.enable = true` plus the usual `base_url` / `model` / `api_key` in your homer config.
+
+### Persistence
+
+A game in progress is saved to `localStorage` (`homer_chess_state_v1`) including PGN, side, time control, clocks, mode, and level. It restores across page reloads. Local play state is per-browser; not synced.
+
+---
+
+## 7. NetChess (`netchess`)
+
+**Concept:** two-player chess over the coordinator. Lobby + WebSocket relay, but unlike Netris **the server is the authoritative game state**: it holds the `*notnil/chess.Game`, validates every move, manages clocks, and emits game-over frames. Clients render whatever FEN the server hands them.
+
+### Controls
+
+| Control | Behavior |
+|---------|----------|
+| **Quick / Room / Spectate** | `Quick` auto-pairs you with the next waiting player. `Room` joins/creates a named room (or click `Random` for a 6-letter code). `Spectate` joins an existing room read-only (up to 8 spectators). |
+| **Time control** | `Bullet`, `Blitz`, `Rapid`, `Classical` — first joiner of a room sets the time control, second joiner inherits it. |
+| **Colour** | `White` / `Black` / `Random` — applied at the join handshake. |
+| **Ready** | Sent by both players to start the game (mirrors Netris). |
+| **Offer draw / Takeback / Resign** | Standard chess game-management buttons. Each generates a server-validated transition. |
+
+### Authoritative state
+
+Per room the server tracks: white/black slot, spectator list (cap 8), `*chess.Game`, white/black clocks in ms, a `time.AfterFunc` flag timer, and pending draw / takeback offers. Every client `move` frame is checked against `game.ValidMoves()` and the side-to-move; illegal frames receive an `error` envelope and the game state is unchanged. Clocks tick on the server (`time.AfterFunc` for the flag, recomputed at each move from wall-clock deltas) so a backgrounded / throttled tab cannot gain time.
+
+### Wire protocol
+
+JSON envelope shared with the client; constants live in `src/coordinator/games/netchess/protocol.go`:
+
+| Frame | Direction | Notes |
+|-------|-----------|-------|
+| `hello`, `ready`, `move{uci}`, `resign`, `draw_{offer,accept,decline}`, `takeback_{request,accept,decline}`, `chat{text}` | client → server | one-way commands |
+| `matched{you, opponent, color, room, initial_ms, increment_ms, spectator?}` | server → client | issued on join + on opponent arrival |
+| `start{fen, white_ms, black_ms}` | server → client | both players have sent `ready` |
+| `opponent_move{uci, san, fen, white_ms, black_ms}` | server → both players + spectators | post-validation broadcast |
+| `clock_sync{fen, white_ms, black_ms}` | server → all | after takeback or periodic re-sync |
+| `game_over{result, reason, white_ms, black_ms}` | server → all | `result ∈ {1-0, 0-1, 1/2-1/2}`, `reason ∈ {checkmate, stalemate, resignation, agreement, flag, insufficient_material, fifty_move, threefold_repetition, opponent_disconnect}` |
+| `draw_offered{from}`, `takeback_offered{from}`, `opponent_left`, `waiting_timeout`, `error{message}` | server → recipient | one-shot notifications |
+
+### Source
+
+| Component | File |
+|-----------|------|
+| UI widget | `src/ui/src/dashboard/widgets/NetChessPanel.tsx` |
+| Reusable board | `src/ui/src/dashboard/widgets/ChessBoard.tsx` |
+| Shared chess core | `src/ui/src/dashboard/widgets/chessCore.ts` (wraps `chess.js`) |
+| Client engine (worker) | `src/ui/src/dashboard/widgets/chessEngine.ts`, `chessEngine.worker.ts` (used by `chess` only) |
+| WS client | `src/ui/src/api.ts` (`openNetChessSocket`) |
+| LLM endpoints | `src/ui/src/api.ts` (`fetchChessLLMStatus`, `postChessLLMMove`) |
+| Server-side rules + LLM bridge | `src/coordinator/games/chess/engine.go`, `llm.go` |
+| Server hub | `src/coordinator/games/netchess/hub.go`, `protocol.go` |
+| HTTP / WS handlers | `src/coordinator/handlers/games_v4.go` (`V4NetChess`, `V4ChessLLMMove`, `V4ChessLLMStatus`) |
+
+---
+
 ## Source locations
 
 | Game | File |
@@ -229,6 +310,8 @@ The relay is intentionally thin: server enforces matchmaking, garbage translatio
 | Jitter Buffer Hero | `src/ui/src/dashboard/widgets/JitterBufferHeroPanel.tsx` |
 | SIPetris | `src/ui/src/dashboard/widgets/SIPetrisPanel.tsx` |
 | Netris | `src/ui/src/dashboard/widgets/NetrisPanel.tsx` |
+| Chess | `src/ui/src/dashboard/widgets/ChessPanel.tsx` |
+| NetChess | `src/ui/src/dashboard/widgets/NetChessPanel.tsx` |
 | Widget registration | `src/ui/src/dashboard/widgets/registry.ts` |
 
-The single-player games (Packet Defender, SIP Dialog Master, Jitter Buffer Hero, SIPetris) are **not** wired to live Homer capture; they are **local dashboard UI** only. **Netris** is the one exception — it talks to homer-core's coordinator over a JWT-protected WebSocket (`/api/v4/games/netris`) but only for two-player relay; it does not consume captured traffic.
+The single-player widgets (Packet Defender, SIP Dialog Master, Jitter Buffer Hero, SIPetris, Chess in bot mode) are **not** wired to live Homer capture; they are **local dashboard UI** only. **Netris** and **NetChess** talk to homer-core's coordinator over JWT-protected WebSockets (`/api/v4/games/netris`, `/api/v4/games/netchess`); the **Chess LLM mode** also relies on the coordinator (`/api/v4/games/chess/llm-{status,move}`). None of these endpoints consume captured traffic.

--- a/docs/superpowers/specs/2026-05-16-chess-netchess-widgets-design.md
+++ b/docs/superpowers/specs/2026-05-16-chess-netchess-widgets-design.md
@@ -1,0 +1,238 @@
+# Chess + NetChess dashboard widgets — design
+
+Date: 2026-05-16
+Status: approved
+Owner: Alexandr Dubovikov
+
+## Goal
+
+Add two new dashboard widgets to Homer under the existing **Games** category:
+
+1. **`chess`** — single-player chess. Play against a built-in minimax bot, or — when the operator has enabled the MCP LLM backend — against an LLM opponent served through the existing `src/mcp/llm.go` client.
+2. **`netchess`** — two-player network chess. Architectural mirror of `netris`: lobby + WebSocket relay through the coordinator, but with the **server as the authoritative game state** (move validation, mate/draw detection, clocks).
+
+Both widgets share one chess core (`chess.js` on the UI, `notnil/chess` on the server) and one presentational board component (`ChessBoard.tsx`).
+
+## Non-goals (this iteration)
+
+- Stockfish or other native engine integration. The built-in minimax is good enough for a dashboard widget; LLM-mode covers the "stronger / more interesting opponent" use case.
+- Engine SVG asset sets (Cburnett etc). Unicode glyphs are good enough at widget cell sizes and avoid an asset pipeline.
+- Tournament / Elo / persistent rankings. Local best-score per browser is enough.
+- Variant chess (Chess960, Atomic, Antichess).
+
+## Architecture
+
+```
+src/ui/src/dashboard/widgets/
+  chessCore.ts                # thin chess.js wrapper: typed Move/Square, FEN/PGN helpers, status()
+  chessEngine.ts              # synchronous minimax + alpha-beta, depth 1..4
+  chessEngine.worker.ts       # Web Worker around chessEngine
+  ChessBoard.tsx              # presentational 8x8 board (Tailwind), click/drag-to-move,
+                              # promotion menu, flip, check/last-move highlights
+  ChessPanel.tsx              # single-player widget (Bot | LLM toggle)
+  NetChessPanel.tsx           # PvP widget over WebSocket
+  registry.ts                 # + chess + netchess entries
+
+src/ui/src/api.ts
+  openNetChessSocket(opts)    # WS client mirroring openNetrisSocket
+  postChessLLMMove(body)      # POST /api/v4/games/chess/llm-move
+  fetchChessLLMStatus()       # GET  /api/v4/games/chess/llm-status
+
+src/coordinator/games/netchess/
+  protocol.go                 # Envelope: hello/ready/move/resign/draw_*/takeback/chat +
+                              # matched/start/opponent_move/clock_sync/game_over/draw_offered/...
+  hub.go                      # Hub + Room with notnil/chess game, clocks, spectator list
+  hub_test.go                 # matchmaking, legal/illegal moves, mate/stalemate, resign,
+                              # draw offer/accept, takeback, clock decrement, flag timeout,
+                              # spectator broadcast
+
+src/coordinator/handlers/games_v4.go
+  V4NetChess          (WS)    # /api/v4/games/netchess
+  V4ChessLLMMove      (POST)  # /api/v4/games/chess/llm-move
+  V4ChessLLMStatus    (GET)   # /api/v4/games/chess/llm-status (returns {enabled})
+
+src/coordinator/coordinator.go
+  + games/netchess import
+  + gamesHandler.SetNetChessHub(netchess.NewHub(netchess.Config{}))
+  + gamesHandler.SetMCPClient(mcpClient)        // for chess LLM mode
+  + routes: GET  /games/netchess
+            POST /games/chess/llm-move
+            GET  /games/chess/llm-status
+```
+
+### Key choice: server is authoritative for NetChess
+
+Netris is a thin relay: each client crunches its own board and the server only translates `line_clear` → `garbage_in`. For NetChess we flip the model — the server holds the canonical `*chess.Game` (from `github.com/notnil/chess`) and validates every move. Clients render and submit UCI strings. This:
+
+- Eliminates the entire class of "we drifted out of sync" bugs.
+- Blocks the trivial cheat of clients sending illegal moves.
+- Lets the server own clocks (decrement on its own goroutine, flag with `time.AfterFunc`) so a paused/throttled tab can't gain time.
+
+The trade-off — one extra round-trip of latency per move — is invisible at the resolution chess is played in a browser widget.
+
+### Shared logic, no duplication
+
+`chessCore.ts` is the only place that knows about chess rules on the UI side. Both widgets and the engine worker import from it. The Go side uses `notnil/chess` directly; the wire format between them is FEN + UCI, both of which are standards, so there is no schema duplication.
+
+## Data flow
+
+### Single-player Chess (Bot mode)
+
+```
+ChessPanel  --tryMove(uci)-->  chessCore  --ok-->  setState(fen, history)
+ChessPanel  --postMessage({fen,depth})-->  chessEngine.worker
+                                    <--{uci,evalCp}-- worker
+ChessPanel  --tryMove(uci, by:bot)-->  chessCore  -->  setState
+```
+
+### Single-player Chess (LLM mode)
+
+```
+ChessPanel  --tryMove(uci)-->  setState
+ChessPanel  --POST /games/chess/llm-move {fen, history_pgn, level}-->  coordinator
+coordinator  --mcp/llm.go: chat-completion w/ FEN+PGN+system_prompt-->  LLM
+LLM  --"e2e4"--> coordinator  --validate via notnil/chess--> 
+   ok: respond {uci, source:"llm", latency_ms}
+   bad: run server-side minimax fallback, respond {uci, source:"fallback", latency_ms}
+```
+
+### PvP NetChess
+
+```
+Player A         coordinator hub               Player B           Spectators
+   |  hello, ready  |                              |                  |
+   |--------------->|  matched, start              |                  |
+   |                |----------------------------->|                  |
+   |  move e2e4     |                              |                  |
+   |--------------->|  validate; update game,clocks|                  |
+   |                |  opponent_move{san,fen,clks} |                  |
+   |                |----------------------------->|----------------->|
+   |                |                              |                  |
+   ...
+   |                |  game_over{checkmate, 1-0}   |                  |
+   |<---------------|----------------------------->|----------------->|
+```
+
+## Wire protocol — NetChess Envelope
+
+Single JSON envelope, unknown fields tolerated on both sides (same convention as Netris).
+
+| Field | Type | Sent in | Notes |
+|---|---|---|---|
+| `type` | string | every | see message table |
+| `display_name` | string | hello | optional override |
+| `room` | string | hello, matched | empty → quick-match |
+| `you`, `opponent` | string | matched | usernames |
+| `color` | "white"\|"black" | matched | assigned to you |
+| `time_control` | `{initial_ms, increment_ms}` | matched | from URL query (default 600000+5000) |
+| `uci` | string | move, opponent_move | "e2e4" / "e7e8q" |
+| `san` | string | opponent_move | for history rendering on the receiver |
+| `fen` | string | opponent_move, clock_sync | post-move position |
+| `white_ms`, `black_ms` | int | opponent_move, clock_sync | remaining clock |
+| `result` | "1-0"\|"0-1"\|"1/2-1/2" | game_over | |
+| `reason` | string | game_over | checkmate/stalemate/resignation/flag/agreement/insufficient/50_move/3fold |
+| `from` | string | chat | username |
+| `text` | string | chat | sanitised to printable, ≤ 200 runes |
+| `message` | string | error | human-readable |
+
+Client→server: `hello`, `ready`, `move`, `resign`, `draw_offer`, `draw_accept`, `draw_decline`, `takeback_request`, `takeback_accept`, `takeback_decline`, `chat`.
+
+Server→client: `matched`, `start`, `opponent_move`, `clock_sync`, `game_over`, `draw_offered`, `takeback_offered`, `opponent_left`, `waiting_timeout`, `error`.
+
+## URL & auth
+
+- `GET /api/v4/games/netchess` — same JWT middleware as `/games/netris`.
+- Query params: `?quick=true` OR `?room=CODE`, optional `?color=white|black|random` (default `random`), optional `?time_control=600000+5000` (initial_ms+increment_ms), optional `?spectate=true&room=CODE`.
+
+## Authoritative state on the server
+
+Per `Room`:
+- `game *chess.Game` — notnil/chess. Source of truth.
+- `players [2]*Player` — index 0 = white, index 1 = black.
+- `spectators []*Spectator` — read-only listeners, cap 8.
+- `clocks { whiteMs, blackMs int64; lastMoveAt time.Time; increment time.Duration }`.
+- `flagTimer *time.Timer` — restarted on every move.
+- `mu sync.Mutex` — protects everything above; moves serialise through it.
+
+`timeNow func() time.Time` is injected into the hub so `hub_test.go` can drive clocks deterministically.
+
+## Single-player widget specifics
+
+### Layout (top bar → mirrors Netris/SIPetris):
+- Eval bar (replacing the Score card): mapped from engine cp to [-3..+3] for the visual.
+- `New Game`, `Resign`, `Takeback`, `Export PGN`.
+- Side selector: `White / Black / Random`.
+- Time control: `Untimed / Bullet 1+0 / Blitz 3+2 / Rapid 10+5`.
+- Mode toggle: `Bot` / `LLM (MCP)` — the latter shown only if `fetchChessLLMStatus()` reports `{enabled: true}`.
+- Level slider (1..4) — only meaningful for `Bot` and `fallback` paths.
+
+### Sidebar:
+- PGN move list (click jumps to position, "Back to live" returns).
+- "Last events" log (mate, check, capture, takeback, mode switches).
+
+### Persistence:
+- `localStorage['homer_chess_pgn']` — full PGN, restored on widget mount.
+- `localStorage['homer_chess_best_*']` — per-mode best (longest mate-avoided, fastest mate-delivered) — secondary, optional.
+
+## PvP widget specifics
+
+### Lobby (when `conn === 'idle' | 'closed'`):
+- `Quick` / `Room` mode (mirrors Netris).
+- Time control dropdown (same presets as single-player).
+- Color preference `White / Black / Random`.
+- Spectate-by-room-code shortcut.
+
+### In-game UI:
+- Two clocks (top of own board, top of opponent board).
+- PGN list (click = local review only — does not break the live stream).
+- Action buttons: `Resign`, `Offer draw`, `Request takeback`.
+- Status pill (`Waiting`, `Matched`, `Your move`, `Opponent thinking`, `Won`, `Lost`, `Draw`).
+
+### Spectator mode:
+- No interaction. Board flipped automatically based on `?as=white|black`, defaults to white-at-bottom.
+
+## Error handling
+
+| Error | UI response | Server response |
+|---|---|---|
+| Illegal client move | toast "illegal move", revert board to last server FEN | `error{message:"illegal move"}` and stay in current position |
+| LLM returns invalid UCI | UI never sees raw error; receives `{source:"fallback"}` | logs `mcp_chess_invalid_move` warning, runs minimax |
+| LLM timeout (≥ 8s) | spinner clears, fallback used | same |
+| Opponent disconnects | banner "Opponent disconnected — game saved as draw" if mid-game (server-config), else "Opponent left" in lobby | `game_over{result:"1/2-1/2", reason:"opponent_disconnect"}` after a 30s reconnect window |
+| Clock flag | `game_over{flag}` | server-side `time.AfterFunc` fires |
+| Bad WS frame | client drops, server logs | server closes with `error{message:"protocol violation"}` |
+
+## Testing
+
+### UI (Vitest):
+- `chessCore.test.ts` — legal vs illegal moves, FEN round-trip, PGN export/import, mate/stalemate/3fold detection.
+- `chessEngine.test.ts` — mate-in-1 and mate-in-2 known positions, never loses material to a 1-ply tactic, prefers center early.
+- `ChessBoard.test.tsx` — render, click-to-move, promotion menu, flipped orientation, last-move/check highlights.
+- `ChessPanel.test.tsx` — bot answers, LLM call wired (mocked fetch), takeback rewinds 2 plies in bot mode, end-of-game overlay.
+- `NetChessPanel.test.tsx` — reacts to server frames (mock WS): matched, start, opponent_move, draw_offered, game_over; resign sends correct frame.
+
+### Server (Go):
+- `netchess/hub_test.go` — legal/illegal move via hub, mate→game_over, resign, draw_offer + accept, takeback_request + accept, clock decrement, flag timeout (with injected `timeNow`), spectator broadcast (only receives, can't send).
+- `netchess/protocol_test.go` — Encode/Decode round-trip, SanitiseDisplayName edge cases.
+- `handlers/games_v4_chess_llm_test.go` — `/games/chess/llm-move` happy path (mocked LLM client) + invalid-UCI fallback.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| LLM returns garbage or illegal UCI | Server validates with notnil/chess; on failure, runs minimax fallback and tags response `source:"fallback"`. UI shows tiny indicator. |
+| Web Worker not available | Detect at mount, fall back to synchronous engine at depth ≤ 2. |
+| chess.js bundle size (~50KB gzipped) | Widget lazy-loaded via `lazy()` already; doesn't touch the initial bundle. |
+| Server load from clock timers | `time.AfterFunc` per active room is trivial; limit 1000 simultaneous rooms (config). |
+| Drift between chess.js (UI) and notnil/chess (server) | Server is authoritative. After every move the UI re-syncs to the FEN the server returned. Any divergence is treated as a UI bug. |
+| Spectator firehose abuse | Cap 8 spectators per room. Spectators send no frames; their WS reader just drains. |
+| LLM cost when chess widget is left open | Move requests only fire when it's the bot's turn — one request per actual move. No keep-alive. |
+
+## Out of scope (future)
+
+- Pre-moves, premove queue.
+- Conditional premove ("if knight takes, recapture with bishop").
+- Engine-assisted analysis after the game (built-in Stockfish.js could be added later).
+- Spectator chat.
+- Player profile / rating system.
+- Time-control negotiation between paired players (today it's URL-driven and the first joiner's time control wins).

--- a/src/coordinator/coordinator.go
+++ b/src/coordinator/coordinator.go
@@ -24,10 +24,12 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/sipcapture/homer-core/src/config"
+	"github.com/sipcapture/homer-core/src/coordinator/games/netchess"
 	"github.com/sipcapture/homer-core/src/coordinator/games/netris"
 	"github.com/sipcapture/homer-core/src/coordinator/handlers"
 	"github.com/sipcapture/homer-core/src/coordinator/services"
 	"github.com/sipcapture/homer-core/src/homerconfig"
+	mcppkg "github.com/sipcapture/homer-core/src/mcp"
 	"github.com/sipcapture/homer-core/src/scripting/correlation"
 	"github.com/sipcapture/homer-core/src/stream/hepstream"
 	logger "github.com/sipcapture/homer-core/src/utils/logging"
@@ -249,6 +251,11 @@ func (c *Coordinator) setupRoutes() {
 	// because it costs nothing when nobody is playing.
 	gamesHandler := handlers.NewGamesHandler()
 	gamesHandler.SetNetrisHub(netris.NewHub(netris.Config{}))
+	gamesHandler.SetNetChessHub(netchess.NewHub(netchess.Config{}))
+	// Reuse the same LLM client that powers MCP. NewLLMClient returns
+	// nil when llm.enable=false, in which case the Chess widget will
+	// hide the LLM toggle (V4ChessLLMStatus reports enabled=false).
+	gamesHandler.SetChessLLM(mcppkg.NewLLMClient(&c.config.MCP.LLM))
 	// Wire the live HEP stream service only when the coordinator-side
 	// switch is on; otherwise the handler stays a 503 stub and the UI
 	// hides its "Use live traffic" toggle. The local broker is
@@ -445,6 +452,9 @@ func (c *Coordinator) setupRoutes() {
 		protectedV4.GET("/integrations/grafana/dashboards/:uid", integrationsHandler.V4GrafanaDashboard)
 		protectedV4.GET("/stream/hep", streamHandler.V4HepStream)
 		protectedV4.GET("/games/netris", gamesHandler.V4Netris)
+		protectedV4.GET("/games/netchess", gamesHandler.V4NetChess)
+		protectedV4.GET("/games/chess/llm-status", gamesHandler.V4ChessLLMStatus)
+		protectedV4.POST("/games/chess/llm-move", gamesHandler.V4ChessLLMMove)
 		protectedV4.POST("/query", searchHandler.V4RawQuery)
 		protectedV4.POST("/mcp/query", searchHandler.V4MCPQuery)
 		protectedV4.GET("/mcp/llm/status", searchHandler.V4MCPLLMStatus)

--- a/src/coordinator/games/chess/engine.go
+++ b/src/coordinator/games/chess/engine.go
@@ -1,0 +1,189 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Package chess hosts the server-side helpers for the dashboard chess
+// widgets: a minimal greedy engine (only used as a fallback when the
+// LLM bridge fails) and the LLM call wrapper used by the
+// `/games/chess/llm-move` HTTP endpoint.
+//
+// We intentionally keep the server engine simple. Strong play happens
+// on the client (depth-4 minimax in a Web Worker). The server engine
+// exists *only* so the panel doesn't break when LLM mode is enabled
+// and the model returns garbage; it just needs to produce a legal,
+// non-suicidal move within a few milliseconds.
+package chess
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"strings"
+
+	notnil "github.com/notnil/chess"
+)
+
+// Material values in centipawns. The king's "value" is large so the
+// evaluator never thinks losing it is acceptable — terminal positions
+// short-circuit before this matters in practice, but defensive.
+var pieceValue = map[notnil.PieceType]int{
+	notnil.Pawn:   100,
+	notnil.Knight: 320,
+	notnil.Bishop: 330,
+	notnil.Rook:   500,
+	notnil.Queen:  900,
+	notnil.King:   20000,
+}
+
+// materialBalance returns White-relative centipawns for the supplied
+// position.  Positive = White is ahead.
+func materialBalance(pos *notnil.Position) int {
+	board := pos.Board()
+	balance := 0
+	for sq := notnil.A1; sq <= notnil.H8; sq++ {
+		p := board.Piece(sq)
+		if p == notnil.NoPiece {
+			continue
+		}
+		v := pieceValue[p.Type()]
+		if p.Color() == notnil.White {
+			balance += v
+		} else {
+			balance -= v
+		}
+	}
+	return balance
+}
+
+// evaluate returns a score from the perspective of the side to move
+// in `pos`. Mate-in-this-position is the worst possible outcome for
+// the side to move; we map it to a large negative number so a search
+// avoids walking into it.
+func evaluate(pos *notnil.Position) int {
+	switch pos.Status() {
+	case notnil.Checkmate:
+		return -1_000_000 // side to move is mated
+	case notnil.Stalemate,
+		notnil.InsufficientMaterial,
+		notnil.FiftyMoveRule,
+		notnil.SeventyFiveMoveRule,
+		notnil.ThreefoldRepetition,
+		notnil.FivefoldRepetition,
+		notnil.DrawOffer:
+		return 0
+	}
+	bal := materialBalance(pos)
+	if pos.Turn() == notnil.White {
+		return bal
+	}
+	return -bal
+}
+
+// PickMove returns the best legal move on `game.Position()` using a
+// shallow (depth-1) greedy search: for each candidate, play it and
+// pick the one that minimises the opponent's reply evaluation. Ties
+// are broken deterministically via `rng` (pass a seeded *rand.Rand
+// in tests, or nil for non-deterministic). Returns "" for terminal
+// positions (mate/stalemate/etc).
+func PickMove(game *notnil.Game, rng *rand.Rand) string {
+	pos := game.Position()
+	moves := game.ValidMoves()
+	if len(moves) == 0 {
+		return ""
+	}
+	bestScore := math.MinInt
+	type cand struct {
+		move  *notnil.Move
+		score int
+	}
+	bests := make([]cand, 0, 4)
+	for _, mv := range moves {
+		// Apply the move on a cloned game so we don't disturb the
+		// caller's history.
+		clone := game.Clone()
+		if err := clone.Move(mv); err != nil {
+			continue
+		}
+		// Score = -opponent_eval after our move. evaluate() returns a
+		// side-to-move-relative number, and after our move the side
+		// to move is the opponent, so we negate.
+		score := -evaluate(clone.Position())
+		// Tiny capture bonus to break ties towards taking material
+		// when otherwise equivalent.
+		if isCapture(mv, pos) {
+			score += 5
+		}
+		if score > bestScore {
+			bestScore = score
+			bests = bests[:0]
+			bests = append(bests, cand{move: mv, score: score})
+		} else if score == bestScore {
+			bests = append(bests, cand{move: mv, score: score})
+		}
+	}
+	if len(bests) == 0 {
+		return ""
+	}
+	pick := bests[0]
+	if len(bests) > 1 {
+		if rng != nil {
+			pick = bests[rng.Intn(len(bests))]
+		} else {
+			pick = bests[0]
+		}
+	}
+	return moveUCI(pick.move)
+}
+
+// isCapture reports whether playing `mv` from `pos` removes an
+// opponent piece (regular capture or en passant). notnil/chess
+// exposes this through the move tags; we recompute to stay
+// independent of internal tag bits.
+func isCapture(mv *notnil.Move, pos *notnil.Position) bool {
+	target := pos.Board().Piece(mv.S2())
+	if target != notnil.NoPiece {
+		return true
+	}
+	return mv.HasTag(notnil.EnPassant)
+}
+
+// moveUCI returns the long-algebraic UCI string for the move:
+// `e2e4`, `e7e8q`. Castling is encoded as `e1g1`/`e1c1` (king-only),
+// matching what chess.js produces on the UI side.
+func moveUCI(mv *notnil.Move) string {
+	from := mv.S1().String()
+	to := mv.S2().String()
+	promo := ""
+	switch mv.Promo() {
+	case notnil.Queen:
+		promo = "q"
+	case notnil.Rook:
+		promo = "r"
+	case notnil.Bishop:
+		promo = "b"
+	case notnil.Knight:
+		promo = "n"
+	}
+	return strings.ToLower(from + to + promo)
+}
+
+// ValidateUCI parses `uci` against the position in `game` and returns
+// the matching notnil/chess move pointer. Used by both the LLM-move
+// path (to validate what the model emitted) and the netchess hub.
+// Returns a descriptive error so the caller can log "why" the move
+// was rejected.
+func ValidateUCI(game *notnil.Game, uci string) (*notnil.Move, error) {
+	uci = strings.ToLower(strings.TrimSpace(uci))
+	if len(uci) != 4 && len(uci) != 5 {
+		return nil, fmt.Errorf("invalid uci length: %q", uci)
+	}
+	for _, mv := range game.ValidMoves() {
+		if strings.EqualFold(moveUCI(mv), uci) {
+			return mv, nil
+		}
+	}
+	return nil, fmt.Errorf("illegal move: %s", uci)
+}

--- a/src/coordinator/games/chess/engine_test.go
+++ b/src/coordinator/games/chess/engine_test.go
@@ -1,0 +1,183 @@
+// Copyright (C) 2025 Homer Server Contributors
+
+package chess
+
+import (
+	"context"
+	"encoding/json"
+	"math/rand"
+	"strings"
+	"testing"
+
+	notnil "github.com/notnil/chess"
+)
+
+// startingFEN keeps the tests independent of how notnil/chess names
+// its starting-position constant in any specific version.
+var startingFEN = notnil.NewGame().FEN()
+
+func TestPickMove_StartingPosition(t *testing.T) {
+	game := notnil.NewGame()
+	uci := PickMove(game, rand.New(rand.NewSource(42)))
+	if uci == "" {
+		t.Fatal("expected a legal move at the starting position, got empty string")
+	}
+	if _, err := ValidateUCI(game, uci); err != nil {
+		t.Fatalf("PickMove returned an illegal UCI %q: %v", uci, err)
+	}
+}
+
+func TestPickMove_TakesFreeMaterial(t *testing.T) {
+	// White knight on b3 attacks an undefended black queen on d4.
+	// PickMove (depth-1 greedy) must take it.
+	fen := "rnb1kbnr/pppppppp/8/8/3q4/1N6/PPPPPPPP/R1BQKBNR w KQkq - 0 1"
+	opt, err := notnil.FEN(fen)
+	if err != nil {
+		t.Fatalf("FEN parse: %v", err)
+	}
+	game := notnil.NewGame(opt)
+	uci := PickMove(game, rand.New(rand.NewSource(1)))
+	if uci != "b3d4" {
+		t.Fatalf("expected b3d4 (free queen capture), got %q", uci)
+	}
+}
+
+func TestPickMove_TerminalPosition(t *testing.T) {
+	// Stalemate: black to move, no legal moves.
+	fen := "7k/5K2/6Q1/8/8/8/8/8 b - - 0 1"
+	opt, err := notnil.FEN(fen)
+	if err != nil {
+		t.Fatalf("FEN parse: %v", err)
+	}
+	game := notnil.NewGame(opt)
+	if uci := PickMove(game, nil); uci != "" {
+		t.Fatalf("expected empty UCI on stalemate, got %q", uci)
+	}
+}
+
+func TestValidateUCI(t *testing.T) {
+	game := notnil.NewGame()
+	if _, err := ValidateUCI(game, "e2e4"); err != nil {
+		t.Fatalf("e2e4 should be legal: %v", err)
+	}
+	if _, err := ValidateUCI(game, "e2e5"); err == nil {
+		t.Fatal("e2e5 should be illegal from starting position")
+	}
+	if _, err := ValidateUCI(game, "bogus"); err == nil {
+		t.Fatal("bogus UCI should be rejected on length")
+	}
+}
+
+// stubLLM satisfies LLMChatter and returns a canned response. The
+// `respond` function lets each test customise what the model "says".
+type stubLLM struct {
+	enabled bool
+	model   string
+	respond func(systemPrompt, userPrompt string) (string, error)
+}
+
+func (s *stubLLM) Enabled() bool { return s.enabled }
+func (s *stubLLM) Model() string { return s.model }
+func (s *stubLLM) ChatJSON(_ context.Context, sys, usr string, out any) (string, int64, error) {
+	if s.respond == nil {
+		return s.model, 1, nil
+	}
+	body, err := s.respond(sys, usr)
+	if err != nil {
+		return s.model, 1, err
+	}
+	// Same JSON-shape contract as the real LLMClient.ChatJSON: caller
+	// supplies a pointer to a struct, we unmarshal into it.
+	if out != nil {
+		if err := json.Unmarshal([]byte(body), out); err != nil {
+			return s.model, 1, err
+		}
+	}
+	return s.model, 1, nil
+}
+
+func TestGetLLMMove_HappyPath(t *testing.T) {
+	llm := &stubLLM{
+		enabled: true,
+		model:   "test-1",
+		respond: func(_, _ string) (string, error) {
+			return `{"uci":"e2e4"}`, nil
+		},
+	}
+	resp := GetLLMMove(context.Background(), llm, MoveRequest{
+		FEN: startingFEN,
+	}, nil)
+	if resp.Source != SourceLLM {
+		t.Fatalf("expected LLM source, got %s (%s)", resp.Source, resp.FallbackReason)
+	}
+	if resp.UCI != "e2e4" {
+		t.Fatalf("expected e2e4, got %q", resp.UCI)
+	}
+}
+
+func TestGetLLMMove_FallbackOnInvalidMove(t *testing.T) {
+	llm := &stubLLM{
+		enabled: true,
+		model:   "test-2",
+		respond: func(_, _ string) (string, error) {
+			// Illegal — 3-square pawn move.
+			return `{"uci":"e2e5"}`, nil
+		},
+	}
+	resp := GetLLMMove(context.Background(), llm, MoveRequest{
+		FEN: startingFEN,
+	}, rand.New(rand.NewSource(7)))
+	if resp.Source != SourceFallback {
+		t.Fatalf("expected fallback, got %s", resp.Source)
+	}
+	if resp.UCI == "" {
+		t.Fatal("fallback must still produce a legal move")
+	}
+	if !strings.Contains(resp.FallbackReason, "invalid") {
+		t.Fatalf("expected fallback reason to mention invalid move, got %q", resp.FallbackReason)
+	}
+}
+
+func TestGetLLMMove_FallbackOnLLMError(t *testing.T) {
+	llm := &stubLLM{
+		enabled: true,
+		respond: func(_, _ string) (string, error) {
+			return "", errSimulated{}
+		},
+	}
+	resp := GetLLMMove(context.Background(), llm, MoveRequest{
+		FEN: startingFEN,
+	}, rand.New(rand.NewSource(7)))
+	if resp.Source != SourceFallback {
+		t.Fatalf("expected fallback, got %s", resp.Source)
+	}
+	if resp.UCI == "" {
+		t.Fatal("fallback must produce a legal move on LLM error")
+	}
+}
+
+func TestGetLLMMove_NilClientReturnsFallback(t *testing.T) {
+	resp := GetLLMMove(context.Background(), nil, MoveRequest{
+		FEN: startingFEN,
+	}, rand.New(rand.NewSource(7)))
+	if resp.Source != SourceFallback {
+		t.Fatalf("expected fallback, got %s", resp.Source)
+	}
+	if resp.FallbackReason != "llm disabled" {
+		t.Fatalf("expected reason 'llm disabled', got %q", resp.FallbackReason)
+	}
+}
+
+func TestGetLLMMove_InvalidFen(t *testing.T) {
+	llm := &stubLLM{enabled: true, respond: func(_, _ string) (string, error) {
+		return `{"uci":"e2e4"}`, nil
+	}}
+	resp := GetLLMMove(context.Background(), llm, MoveRequest{FEN: "not a fen"}, nil)
+	if resp.Source != SourceFallback || resp.UCI != "" {
+		t.Fatalf("expected empty fallback on invalid FEN, got %+v", resp)
+	}
+}
+
+type errSimulated struct{}
+
+func (errSimulated) Error() string { return "simulated llm error" }

--- a/src/coordinator/games/chess/llm.go
+++ b/src/coordinator/games/chess/llm.go
@@ -1,0 +1,209 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package chess
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"regexp"
+	"strings"
+
+	notnil "github.com/notnil/chess"
+)
+
+// LLMChatter is the slice of `mcp.LLMClient` we actually need. Pulling
+// it out as an interface lets the handler tests inject a fake client
+// without dragging the OpenAI plumbing along, and matches the
+// `MCPSearcher`-style seams already used in this codebase.
+type LLMChatter interface {
+	Enabled() bool
+	Model() string
+	ChatJSON(ctx context.Context, systemPrompt, userPrompt string, out any) (model string, latencyMS int64, err error)
+}
+
+// MoveSource describes who produced a move returned by GetLLMMove.
+type MoveSource string
+
+const (
+	SourceLLM      MoveSource = "llm"
+	SourceFallback MoveSource = "fallback"
+)
+
+// MoveResponse is the return shape of GetLLMMove. Latency / Model are
+// passed through for the UI to display.
+type MoveResponse struct {
+	UCI       string
+	Source    MoveSource
+	Model     string
+	LatencyMS int64
+	// FallbackReason is populated when Source == SourceFallback. The
+	// HTTP handler surfaces it under `meta` for debugging.
+	FallbackReason string
+}
+
+// MoveRequest is the input to GetLLMMove. FEN is required; History is
+// the move list in PGN-style SAN for context (optional).
+type MoveRequest struct {
+	FEN     string
+	History string
+	// Level hints the LLM at the desired strength (1..4). Mostly
+	// flavour today, but passed through so prompt tuning can
+	// differentiate skill levels later.
+	Level int
+}
+
+const llmChessSystemPrompt = `You are a chess engine. The user will give you a chess position in FEN.
+Reply with ONLY a single JSON object of the form:
+  {"uci": "<move-in-uci>"}
+where <move-in-uci> is the long-algebraic representation of YOUR best legal move
+for the side to move, e.g. "e2e4", "g1f3", "e7e8q" for promotion.
+Rules:
+- The move MUST be legal in the supplied position.
+- Use lowercase letters for squares and promotion piece.
+- Do NOT output any commentary, prose, or markdown. JSON object only.`
+
+// uciRegexp pre-screens raw model output before we even ask
+// `notnil/chess` to validate. It's tolerant: a/h files, 1/8 ranks,
+// optional q/r/b/n promotion.
+var uciRegexp = regexp.MustCompile(`(?i)\b([a-h][1-8][a-h][1-8][qrbn]?)\b`)
+
+// GetLLMMove asks the LLM for a move on the given position, validates
+// the answer against `notnil/chess`, and falls back to the engine's
+// greedy picker on any failure. It always returns a legal move when
+// one exists; the only way `MoveResponse.UCI == ""` is if the position
+// itself is terminal (mate / stalemate / draw).
+//
+// The function never panics on bad input — invalid FENs are mapped to
+// fallback behaviour with a descriptive reason.
+func GetLLMMove(ctx context.Context, llm LLMChatter, req MoveRequest, rng *rand.Rand) MoveResponse {
+	// Parse the FEN once — both the LLM-validation path and the
+	// fallback need a working game object.
+	game, err := gameFromFEN(req.FEN)
+	if err != nil {
+		return MoveResponse{
+			UCI:            "",
+			Source:         SourceFallback,
+			FallbackReason: fmt.Sprintf("invalid fen: %v", err),
+		}
+	}
+
+	// Terminal position → no legal move; just return empty UCI so
+	// the caller can render the game-over overlay.
+	if game.Outcome() != notnil.NoOutcome {
+		return MoveResponse{UCI: "", Source: SourceFallback, FallbackReason: "terminal position"}
+	}
+
+	// LLM disabled — straight to fallback.
+	if llm == nil || !llm.Enabled() {
+		uci := PickMove(game, rng)
+		return MoveResponse{
+			UCI:            uci,
+			Source:         SourceFallback,
+			FallbackReason: "llm disabled",
+		}
+	}
+
+	// Build the user prompt: FEN is the source of truth; history is
+	// just context. We cap the history length so an obscenely long
+	// game doesn't blow up the model's input budget.
+	hist := strings.TrimSpace(req.History)
+	if len(hist) > 8000 {
+		hist = hist[len(hist)-8000:]
+	}
+	userPrompt := fmt.Sprintf(
+		"fen=%s\nhistory_pgn=%s\nlevel=%d\nIt is your move. Reply with a JSON object containing only the UCI of your move.",
+		strings.TrimSpace(req.FEN), hist, clampLevel(req.Level),
+	)
+
+	var parsed struct {
+		UCI string `json:"uci"`
+	}
+	model, latency, err := llm.ChatJSON(ctx, llmChessSystemPrompt, userPrompt, &parsed)
+	if err != nil {
+		uci := PickMove(game, rng)
+		return MoveResponse{
+			UCI:            uci,
+			Source:         SourceFallback,
+			Model:          model,
+			LatencyMS:      latency,
+			FallbackReason: fmt.Sprintf("llm error: %v", err),
+		}
+	}
+
+	// Some models put the UCI elsewhere (raw string, "move" field, etc).
+	candidate := strings.TrimSpace(strings.ToLower(parsed.UCI))
+	if candidate == "" {
+		// Try a last-resort regex on the raw answer — but we didn't
+		// keep the raw answer here. Re-call would be wasteful; just
+		// fall back.
+		uci := PickMove(game, rng)
+		return MoveResponse{
+			UCI:            uci,
+			Source:         SourceFallback,
+			Model:          model,
+			LatencyMS:      latency,
+			FallbackReason: "llm returned no uci field",
+		}
+	}
+
+	// Validate.
+	if _, err := ValidateUCI(game, candidate); err != nil {
+		// Sometimes the model fences a UCI inside other text — try
+		// regex extraction from the candidate string before giving up.
+		if m := uciRegexp.FindString(candidate); m != "" {
+			if _, err2 := ValidateUCI(game, m); err2 == nil {
+				return MoveResponse{
+					UCI:       strings.ToLower(m),
+					Source:    SourceLLM,
+					Model:     model,
+					LatencyMS: latency,
+				}
+			}
+		}
+		uci := PickMove(game, rng)
+		return MoveResponse{
+			UCI:            uci,
+			Source:         SourceFallback,
+			Model:          model,
+			LatencyMS:      latency,
+			FallbackReason: fmt.Sprintf("llm move invalid: %v", err),
+		}
+	}
+
+	return MoveResponse{
+		UCI:       candidate,
+		Source:    SourceLLM,
+		Model:     model,
+		LatencyMS: latency,
+	}
+}
+
+// gameFromFEN wraps notnil's FEN loader with a single-purpose error
+// surface — callers do not need to know which option struct the
+// library wants.
+func gameFromFEN(fen string) (*notnil.Game, error) {
+	if strings.TrimSpace(fen) == "" {
+		return nil, fmt.Errorf("empty fen")
+	}
+	opt, err := notnil.FEN(fen)
+	if err != nil {
+		return nil, err
+	}
+	return notnil.NewGame(opt), nil
+}
+
+func clampLevel(n int) int {
+	if n < 1 {
+		return 1
+	}
+	if n > 4 {
+		return 4
+	}
+	return n
+}

--- a/src/coordinator/games/netchess/hub.go
+++ b/src/coordinator/games/netchess/hub.go
@@ -1,0 +1,980 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package netchess
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	notnil "github.com/notnil/chess"
+)
+
+// Default knobs — coordinator wiring can override via Config{}.
+const (
+	DefaultPlayerOutbox   = 64
+	DefaultWaitingTimeout = 90 * time.Second
+)
+
+// ErrRoomFull signals that a named room already has two players.
+// The handler maps this to a one-shot "error" frame and closes the
+// socket — we never bump an existing pair.
+var ErrRoomFull = errors.New("netchess: room is full")
+
+// Config controls hub behaviour. Zero values fall back to the
+// Default* constants above so coordinator wiring can pass an empty
+// Config and still get a working hub.
+type Config struct {
+	PlayerOutbox   int
+	WaitingTimeout time.Duration
+}
+
+func (c Config) outbox() int {
+	if c.PlayerOutbox <= 0 {
+		return DefaultPlayerOutbox
+	}
+	return c.PlayerOutbox
+}
+
+func (c Config) waiting() time.Duration {
+	if c.WaitingTimeout <= 0 {
+		return DefaultWaitingTimeout
+	}
+	return c.WaitingTimeout
+}
+
+// JoinOptions carry the per-handshake parameters the URL parser
+// extracts from the WS upgrade request.
+type JoinOptions struct {
+	// ColorPref is "white" | "black" | "random" | "" (defaults to random).
+	ColorPref string
+	// InitialMS / IncrementMS configure the clocks for a new room.
+	// Ignored when the room already exists (second joiner inherits
+	// the first joiner's setup).
+	InitialMS   int64
+	IncrementMS int64
+}
+
+// Hub holds all live netchess rooms, the quick-match queue, and the
+// shared RNG used for random colour assignment / quick-room codes.
+type Hub struct {
+	mu       sync.Mutex
+	rooms    map[string]*Room
+	queue    *Player // single waiting quick-match player
+	quickSeq uint64
+	rng      *rand.Rand
+	rngMu    sync.Mutex
+	cfg      Config
+	timeNow  func() time.Time // injected for deterministic clock tests
+}
+
+// NewHub builds an empty hub with the supplied config. The RNG is
+// seeded from the wall clock; tests should call SeedRNG.
+func NewHub(cfg Config) *Hub {
+	return &Hub{
+		rooms:   make(map[string]*Room),
+		rng:     rand.New(rand.NewSource(time.Now().UnixNano())),
+		cfg:     cfg,
+		timeNow: time.Now,
+	}
+}
+
+// SeedRNG fixes the RNG sequence — used in tests for deterministic
+// colour assignment.
+func (h *Hub) SeedRNG(seed int64) {
+	h.rngMu.Lock()
+	defer h.rngMu.Unlock()
+	h.rng = rand.New(rand.NewSource(seed))
+}
+
+// SetTimeNow replaces the hub's clock source. Test-only.
+func (h *Hub) SetTimeNow(fn func() time.Time) { h.timeNow = fn }
+
+// rngIntn grabs a random int under the rng mutex (rand.Rand is not
+// safe for concurrent use).
+func (h *Hub) rngIntn(n int) int {
+	h.rngMu.Lock()
+	defer h.rngMu.Unlock()
+	if n <= 0 {
+		return 0
+	}
+	return h.rng.Intn(n)
+}
+
+// Player is a single live socket. The WS handler owns Out and reads
+// from it in its writer pump; the hub writes to Out and to no other
+// goroutine. Once Out is closed, no further sends are made.
+type Player struct {
+	Username    string
+	DisplayName string
+	Out         chan []byte
+
+	// Set when the player is a read-only spectator. Spectators never
+	// own the `room.white`/`room.black` slot.
+	Spectator bool
+
+	hub      *Hub
+	room     *Room
+	color    string // "white" | "black" | "" for spectators
+	ready    bool
+	doneOnce sync.Once
+	done     chan struct{}
+}
+
+// NewPlayer constructs a Player with an outbox of the requested size.
+// The handler is responsible for filling Username (from the JWT) and
+// optionally DisplayName.
+func NewPlayer(username, displayName string, outboxSize int) *Player {
+	if outboxSize <= 0 {
+		outboxSize = DefaultPlayerOutbox
+	}
+	return &Player{
+		Username:    username,
+		DisplayName: SanitiseDisplayName(displayName),
+		Out:         make(chan []byte, outboxSize),
+		done:        make(chan struct{}),
+	}
+}
+
+// Done is closed when the player has been removed from its room
+// (by Leave or because the room ended). The handler waits on this to
+// tear down its writer pump.
+func (p *Player) Done() <-chan struct{} { return p.done }
+
+func (p *Player) markDone() { p.doneOnce.Do(func() { close(p.done) }) }
+
+// Room is a single chess game between two players (plus zero or more
+// spectators). All transitions happen under hub.mu; per-player sends
+// are non-blocking so a slow client never wedges the hub.
+type Room struct {
+	Code      string
+	Quick     bool
+	createdAt time.Time
+
+	white *Player
+	black *Player
+
+	spectators []*Player
+
+	// Authoritative game state. Nil until both players have sent
+	// "ready" and the game has started.
+	game *notnil.Game
+
+	// Time control.
+	initialMS   int64
+	incrementMS int64
+	whiteMS     int64
+	blackMS     int64
+	// lastMoveAt is the wall-clock moment the side-to-move's clock
+	// started ticking — i.e. just after the previous half-move
+	// (or the start of the game).
+	lastMoveAt time.Time
+	flagTimer  *time.Timer
+
+	// waitTimer fires waiting_timeout if a quick-match queued
+	// player or a lone-room joiner never gets paired.
+	waitTimer *time.Timer
+
+	// pendingDrawFrom / pendingTakebackFrom track outstanding
+	// proposals so the responder's accept/decline is matched to a
+	// real offer (and stale frames after game-end are ignored).
+	pendingDrawFrom     *Player
+	pendingTakebackFrom *Player
+
+	started bool
+	ended   bool
+}
+
+// JoinRoom places a player into a named room (creating it if needed).
+// Returns the room. The handler should call this exactly once per
+// player. The lobby `matched` envelope is enqueued onto the player's
+// outbox before this returns so the writer pump can flush it.
+func (h *Hub) JoinRoom(code string, p *Player, opts JoinOptions) (*Room, error) {
+	if len(code) > MaxRoomCodeLen {
+		code = code[:MaxRoomCodeLen]
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	r, ok := h.rooms[code]
+	if !ok {
+		r = h.createRoom(code, false, opts)
+		h.rooms[code] = r
+		h.seatFirst(r, p, opts)
+		h.armWaitTimer(r)
+		h.send(p, Envelope{Type: MsgMatched, Room: code, You: displayOf(p), Color: p.color,
+			InitialMS: r.initialMS, IncrementMS: r.incrementMS})
+		return r, nil
+	}
+
+	if r.white != nil && r.black != nil {
+		return nil, ErrRoomFull
+	}
+	h.seatSecond(r, p)
+	h.cancelWaitTimer(r)
+	h.notifyMatched(r)
+	return r, nil
+}
+
+// JoinQuick places a player into the quick-match queue. If a player
+// is already waiting, the two are paired into a fresh `quick-N`
+// room; otherwise the caller becomes the new queued player.
+func (h *Hub) JoinQuick(p *Player, opts JoinOptions) (*Room, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.queue == nil {
+		code := fmt.Sprintf("quick-pending-%d", atomic.AddUint64(&h.quickSeq, 1))
+		r := h.createRoom(code, true, opts)
+		h.rooms[code] = r
+		h.seatFirst(r, p, opts)
+		h.queue = p
+		h.armWaitTimer(r)
+		h.send(p, Envelope{Type: MsgMatched, Room: code, You: displayOf(p), Color: p.color,
+			InitialMS: r.initialMS, IncrementMS: r.incrementMS})
+		return r, nil
+	}
+
+	first := h.queue
+	h.queue = nil
+	r := first.room
+	if r == nil {
+		// Defensive: shouldn't happen because we always create the
+		// pending room above.
+		code := fmt.Sprintf("quick-%d", atomic.AddUint64(&h.quickSeq, 1))
+		r = h.createRoom(code, true, opts)
+		h.rooms[code] = r
+	}
+	delete(h.rooms, r.Code)
+	r.Code = fmt.Sprintf("quick-%d", atomic.AddUint64(&h.quickSeq, 1))
+	h.rooms[r.Code] = r
+	h.seatSecond(r, p)
+	h.cancelWaitTimer(r)
+	h.notifyMatched(r)
+	return r, nil
+}
+
+// JoinSpectator attaches a read-only listener to an existing room.
+// Returns ErrRoomFull (overloaded — spec-cap reached) when the
+// spectator quota is saturated.
+func (h *Hub) JoinSpectator(code string, p *Player) (*Room, error) {
+	if len(code) > MaxRoomCodeLen {
+		code = code[:MaxRoomCodeLen]
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	r, ok := h.rooms[code]
+	if !ok {
+		return nil, fmt.Errorf("no such room: %s", code)
+	}
+	if len(r.spectators) >= MaxSpectators {
+		return nil, ErrRoomFull
+	}
+	p.Spectator = true
+	p.hub = h
+	p.room = r
+	r.spectators = append(r.spectators, p)
+	// Brief on arrival: room metadata + current FEN (if game running).
+	fen := ""
+	whiteMS, blackMS := r.initialMS, r.initialMS
+	if r.game != nil {
+		fen = r.game.FEN()
+		whiteMS, blackMS = r.whiteMS, r.blackMS
+	}
+	h.send(p, Envelope{
+		Type: MsgMatched, Room: code, Spectator: true,
+		You:         displayOf(p),
+		Opponent:    fmt.Sprintf("%s vs %s", displayOf(r.white), displayOf(r.black)),
+		InitialMS:   r.initialMS,
+		IncrementMS: r.incrementMS,
+		FEN:         fen,
+		WhiteMS:     whiteMS,
+		BlackMS:     blackMS,
+	})
+	return r, nil
+}
+
+// createRoom builds a Room shell. Caller holds hub.mu.
+func (h *Hub) createRoom(code string, quick bool, opts JoinOptions) *Room {
+	init := opts.InitialMS
+	if init <= 0 {
+		init = DefaultInitialMS
+	}
+	inc := opts.IncrementMS
+	if inc < 0 {
+		inc = 0
+	}
+	if opts.InitialMS == 0 && opts.IncrementMS == 0 {
+		inc = DefaultIncMS
+	}
+	return &Room{
+		Code:        code,
+		Quick:       quick,
+		createdAt:   h.timeNow(),
+		initialMS:   init,
+		incrementMS: inc,
+		whiteMS:     init,
+		blackMS:     init,
+	}
+}
+
+// seatFirst assigns a colour to the lone joiner. Caller holds hub.mu.
+func (h *Hub) seatFirst(r *Room, p *Player, opts JoinOptions) {
+	switch opts.ColorPref {
+	case ColorWhite:
+		r.white = p
+		p.color = ColorWhite
+	case ColorBlack:
+		r.black = p
+		p.color = ColorBlack
+	default:
+		// random — pick now; the other slot is fixed by exclusion.
+		if h.rngIntn(2) == 0 {
+			r.white = p
+			p.color = ColorWhite
+		} else {
+			r.black = p
+			p.color = ColorBlack
+		}
+	}
+	p.hub = h
+	p.room = r
+}
+
+// seatSecond places the second arrival into whichever slot is empty.
+// Caller holds hub.mu.
+func (h *Hub) seatSecond(r *Room, p *Player) {
+	if r.white == nil {
+		r.white = p
+		p.color = ColorWhite
+	} else {
+		r.black = p
+		p.color = ColorBlack
+	}
+	p.hub = h
+	p.room = r
+}
+
+// notifyMatched sends both players the full matched frame. Caller
+// holds hub.mu.
+func (h *Hub) notifyMatched(r *Room) {
+	if r.white == nil || r.black == nil {
+		return
+	}
+	h.send(r.white, Envelope{
+		Type: MsgMatched, Room: r.Code,
+		You: displayOf(r.white), Opponent: displayOf(r.black),
+		Color: ColorWhite, InitialMS: r.initialMS, IncrementMS: r.incrementMS,
+	})
+	h.send(r.black, Envelope{
+		Type: MsgMatched, Room: r.Code,
+		You: displayOf(r.black), Opponent: displayOf(r.white),
+		Color: ColorBlack, InitialMS: r.initialMS, IncrementMS: r.incrementMS,
+	})
+}
+
+func (h *Hub) armWaitTimer(r *Room) {
+	d := h.cfg.waiting()
+	if d <= 0 {
+		return
+	}
+	r.waitTimer = time.AfterFunc(d, func() { h.handleWaitingTimeout(r) })
+}
+
+func (h *Hub) cancelWaitTimer(r *Room) {
+	if r.waitTimer != nil {
+		r.waitTimer.Stop()
+		r.waitTimer = nil
+	}
+}
+
+func (h *Hub) handleWaitingTimeout(r *Room) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if (r.white != nil && r.black != nil) || r.ended {
+		return
+	}
+	r.ended = true
+	if r.white != nil {
+		h.send(r.white, Envelope{Type: MsgWaitingTimeout, Reason: "no_opponent"})
+		h.closePlayer(r.white)
+	}
+	if r.black != nil {
+		h.send(r.black, Envelope{Type: MsgWaitingTimeout, Reason: "no_opponent"})
+		h.closePlayer(r.black)
+	}
+	delete(h.rooms, r.Code)
+}
+
+// armFlagTimer (re)starts the flag timer for the side currently on
+// move. Caller holds hub.mu.
+func (h *Hub) armFlagTimer(r *Room) {
+	if r.flagTimer != nil {
+		r.flagTimer.Stop()
+		r.flagTimer = nil
+	}
+	if r.game == nil || r.ended {
+		return
+	}
+	side := r.game.Position().Turn()
+	var remaining int64
+	if side == notnil.White {
+		remaining = r.whiteMS
+	} else {
+		remaining = r.blackMS
+	}
+	if remaining <= 0 {
+		// Already flagged — handle inline.
+		h.handleFlag(r, side)
+		return
+	}
+	d := time.Duration(remaining) * time.Millisecond
+	r.flagTimer = time.AfterFunc(d, func() {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		if r.ended || r.game == nil {
+			return
+		}
+		// Re-evaluate the elapsed time at fire instead of trusting
+		// the original `remaining`: setTimeNow / pauses in tests can
+		// drift.
+		h.tickClock(r)
+		if r.whiteMS <= 0 {
+			h.handleFlag(r, notnil.White)
+		} else if r.blackMS <= 0 {
+			h.handleFlag(r, notnil.Black)
+		} else {
+			// Spurious — re-arm.
+			h.armFlagTimer(r)
+		}
+	})
+}
+
+// tickClock subtracts elapsed time from the side-to-move's clock and
+// updates lastMoveAt. Caller holds hub.mu.
+func (h *Hub) tickClock(r *Room) {
+	if r.game == nil || !r.started || r.ended {
+		return
+	}
+	now := h.timeNow()
+	elapsed := now.Sub(r.lastMoveAt).Milliseconds()
+	if elapsed <= 0 {
+		return
+	}
+	r.lastMoveAt = now
+	if r.game.Position().Turn() == notnil.White {
+		r.whiteMS -= elapsed
+		if r.whiteMS < 0 {
+			r.whiteMS = 0
+		}
+	} else {
+		r.blackMS -= elapsed
+		if r.blackMS < 0 {
+			r.blackMS = 0
+		}
+	}
+}
+
+func (h *Hub) handleFlag(r *Room, flaggedSide notnil.Color) {
+	r.ended = true
+	if r.flagTimer != nil {
+		r.flagTimer.Stop()
+		r.flagTimer = nil
+	}
+	result := "0-1"
+	if flaggedSide == notnil.Black {
+		result = "1-0"
+	}
+	h.broadcast(r, Envelope{
+		Type: MsgGameOver, Result: result, Reason: ReasonFlag,
+		WhiteMS: r.whiteMS, BlackMS: r.blackMS,
+	})
+}
+
+// HandleFrame routes a decoded client frame through the hub. Errors
+// are surfaced as `error` envelopes back to the sender; the
+// connection is left open so the client can recover.
+func (h *Hub) HandleFrame(p *Player, e Envelope) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	r := p.room
+	if r == nil || r.ended {
+		return
+	}
+	if p.Spectator {
+		// Spectators are mute. Silently drop anything they send.
+		return
+	}
+	switch e.Type {
+	case MsgReady:
+		h.handleReady(r, p)
+	case MsgMove:
+		h.handleMove(r, p, e.UCI)
+	case MsgResign:
+		h.handleResign(r, p)
+	case MsgDrawOffer:
+		h.handleDrawOffer(r, p)
+	case MsgDrawAccept:
+		h.handleDrawAccept(r, p)
+	case MsgDrawDecline:
+		r.pendingDrawFrom = nil
+	case MsgTakebackReq:
+		h.handleTakebackRequest(r, p)
+	case MsgTakebackAccept:
+		h.handleTakebackAccept(r, p)
+	case MsgTakebackDecl:
+		r.pendingTakebackFrom = nil
+	case MsgChat:
+		text := SanitiseChat(e.Text)
+		if text == "" {
+			return
+		}
+		other := opponentOf(r, p)
+		if other != nil {
+			h.send(other, Envelope{Type: MsgChat, From: displayOf(p), Text: text})
+		}
+		for _, sp := range r.spectators {
+			h.send(sp, Envelope{Type: MsgChat, From: displayOf(p), Text: text})
+		}
+	default:
+		h.send(p, Envelope{Type: MsgError, Message: "unknown frame type"})
+	}
+}
+
+func (h *Hub) handleReady(r *Room, p *Player) {
+	if r.white == nil || r.black == nil {
+		// Lone room — readiness latches but doesn't start anything.
+		p.ready = true
+		return
+	}
+	p.ready = true
+	if !r.white.ready || !r.black.ready {
+		return
+	}
+	if r.started {
+		// Idempotent: server already broadcast start; treat extra
+		// readies as no-ops.
+		return
+	}
+	r.game = notnil.NewGame()
+	r.started = true
+	r.lastMoveAt = h.timeNow()
+	r.whiteMS = r.initialMS
+	r.blackMS = r.initialMS
+	startMsg := Envelope{
+		Type: MsgStart, FEN: r.game.FEN(),
+		WhiteMS: r.whiteMS, BlackMS: r.blackMS,
+	}
+	h.broadcast(r, startMsg)
+	if r.initialMS > 0 {
+		h.armFlagTimer(r)
+	}
+}
+
+func (h *Hub) handleMove(r *Room, p *Player, uci string) {
+	if r.game == nil || !r.started {
+		h.send(p, Envelope{Type: MsgError, Message: "game not started"})
+		return
+	}
+	// Wrong side? Reject without disturbing the game state.
+	side := r.game.Position().Turn()
+	if (side == notnil.White && p != r.white) || (side == notnil.Black && p != r.black) {
+		h.send(p, Envelope{Type: MsgError, Message: "not your turn"})
+		return
+	}
+	// Validate via notnil/chess.
+	mv, err := validateUCI(r.game, uci)
+	if err != nil {
+		h.send(p, Envelope{Type: MsgError, Message: err.Error()})
+		return
+	}
+	// Tick the clock before applying — so the time spent on this
+	// move counts against the mover, not the opponent.
+	h.tickClock(r)
+	// Apply.
+	if err := r.game.Move(mv); err != nil {
+		h.send(p, Envelope{Type: MsgError, Message: "engine rejected move"})
+		return
+	}
+	// Increment after the move (Fischer).
+	if r.incrementMS > 0 {
+		if side == notnil.White {
+			r.whiteMS += r.incrementMS
+		} else {
+			r.blackMS += r.incrementMS
+		}
+	}
+	// Reset lastMoveAt so the next side's clock starts now.
+	r.lastMoveAt = h.timeNow()
+
+	// Resolve SAN from the move list (notnil stores SAN on the
+	// completed move via game.Moves()).
+	moves := r.game.Moves()
+	san := ""
+	if len(moves) > 0 {
+		san = notnil.AlgebraicNotation{}.Encode(r.game.Positions()[len(r.game.Positions())-2], moves[len(moves)-1])
+	}
+	// Broadcast.
+	out := Envelope{
+		Type:    MsgOpponentMove,
+		UCI:     uci,
+		SAN:     san,
+		FEN:     r.game.FEN(),
+		WhiteMS: r.whiteMS,
+		BlackMS: r.blackMS,
+	}
+	h.broadcast(r, out)
+
+	// Game-over check.
+	if outcome := r.game.Outcome(); outcome != notnil.NoOutcome {
+		reason := reasonFromMethod(r.game.Method())
+		h.broadcast(r, Envelope{
+			Type:    MsgGameOver,
+			Result:  string(outcome),
+			Reason:  reason,
+			WhiteMS: r.whiteMS,
+			BlackMS: r.blackMS,
+		})
+		r.ended = true
+		if r.flagTimer != nil {
+			r.flagTimer.Stop()
+			r.flagTimer = nil
+		}
+		return
+	}
+
+	// Re-arm flag timer for the new side-to-move.
+	if r.initialMS > 0 {
+		h.armFlagTimer(r)
+	}
+}
+
+func (h *Hub) handleResign(r *Room, p *Player) {
+	if r.game == nil || !r.started || r.ended {
+		return
+	}
+	r.ended = true
+	if r.flagTimer != nil {
+		r.flagTimer.Stop()
+		r.flagTimer = nil
+	}
+	result := "0-1"
+	if p == r.black {
+		result = "1-0"
+	}
+	h.broadcast(r, Envelope{
+		Type: MsgGameOver, Result: result, Reason: ReasonResignation,
+		WhiteMS: r.whiteMS, BlackMS: r.blackMS,
+	})
+}
+
+func (h *Hub) handleDrawOffer(r *Room, p *Player) {
+	if !r.started || r.ended {
+		return
+	}
+	r.pendingDrawFrom = p
+	other := opponentOf(r, p)
+	if other != nil {
+		h.send(other, Envelope{Type: MsgDrawOffered, From: displayOf(p)})
+	}
+}
+
+func (h *Hub) handleDrawAccept(r *Room, p *Player) {
+	if r.pendingDrawFrom == nil || r.pendingDrawFrom == p {
+		return
+	}
+	r.pendingDrawFrom = nil
+	r.ended = true
+	if r.flagTimer != nil {
+		r.flagTimer.Stop()
+		r.flagTimer = nil
+	}
+	h.broadcast(r, Envelope{
+		Type: MsgGameOver, Result: "1/2-1/2", Reason: ReasonAgreement,
+		WhiteMS: r.whiteMS, BlackMS: r.blackMS,
+	})
+}
+
+func (h *Hub) handleTakebackRequest(r *Room, p *Player) {
+	if r.game == nil || !r.started || r.ended {
+		return
+	}
+	if len(r.game.Moves()) == 0 {
+		return
+	}
+	r.pendingTakebackFrom = p
+	other := opponentOf(r, p)
+	if other != nil {
+		h.send(other, Envelope{Type: MsgTakebackOffer, From: displayOf(p)})
+	}
+}
+
+func (h *Hub) handleTakebackAccept(r *Room, p *Player) {
+	if r.pendingTakebackFrom == nil || r.pendingTakebackFrom == p {
+		return
+	}
+	requester := r.pendingTakebackFrom
+	r.pendingTakebackFrom = nil
+	if r.game == nil {
+		return
+	}
+	// Pop half-moves until the requester is on move again. notnil's
+	// Game doesn't expose Undo on the public surface (varies by
+	// version), so reconstruct from the move list.
+	all := r.game.Moves()
+	if len(all) == 0 {
+		return
+	}
+	// Determine how many half-moves to drop so it becomes requester's
+	// turn. requester wants to redo their own move → drop their last
+	// move AND any reply by the opponent. If the requester is the
+	// side-to-move now (didn't get to play yet), one drop is enough.
+	requesterColor := notnil.White
+	if requester == r.black {
+		requesterColor = notnil.Black
+	}
+	target := requesterColor // we want the side-to-move to be requesterColor
+	keep := len(all)
+	for keep > 0 {
+		pos := startingThenReplay(all, keep)
+		if pos.Turn() == target {
+			break
+		}
+		keep--
+	}
+	// Rebuild the game.
+	g := notnil.NewGame()
+	for i := 0; i < keep; i++ {
+		if err := g.Move(all[i]); err != nil {
+			// Defensive — replay should always succeed.
+			break
+		}
+	}
+	r.game = g
+	r.lastMoveAt = h.timeNow()
+	// Broadcast a synthetic clock-sync with the new FEN. UCI is left
+	// empty so clients know this is a takeback rather than a move.
+	h.broadcast(r, Envelope{
+		Type: MsgClockSync, FEN: r.game.FEN(),
+		WhiteMS: r.whiteMS, BlackMS: r.blackMS,
+	})
+	if r.initialMS > 0 {
+		h.armFlagTimer(r)
+	}
+}
+
+// startingThenReplay re-plays `keep` half-moves from the starting
+// position and returns the resulting position. Used by takeback to
+// peek at whose turn it would be after dropping a tail.
+func startingThenReplay(all []*notnil.Move, keep int) *notnil.Position {
+	g := notnil.NewGame()
+	for i := 0; i < keep; i++ {
+		if err := g.Move(all[i]); err != nil {
+			return g.Position()
+		}
+	}
+	return g.Position()
+}
+
+// Leave is invoked by the WS handler when the connection closes. The
+// hub cleans up the player's slot and notifies the opponent.
+func (h *Hub) Leave(p *Player) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	r := p.room
+	if r == nil {
+		// Quick-match queue waiter who never made it to a room.
+		if h.queue == p {
+			h.queue = nil
+		}
+		h.closePlayer(p)
+		return
+	}
+	// Spectator?
+	if p.Spectator {
+		for i, sp := range r.spectators {
+			if sp == p {
+				r.spectators = append(r.spectators[:i], r.spectators[i+1:]...)
+				break
+			}
+		}
+		h.closePlayer(p)
+		return
+	}
+	// One of the players.
+	if r.white == p {
+		r.white = nil
+	}
+	if r.black == p {
+		r.black = nil
+	}
+	if r.started && !r.ended {
+		// Forfeit by abandonment.
+		r.ended = true
+		if r.flagTimer != nil {
+			r.flagTimer.Stop()
+			r.flagTimer = nil
+		}
+		result := "0-1"
+		if p == r.black || p.color == ColorBlack {
+			result = "1-0"
+		}
+		other := r.white
+		if other == nil {
+			other = r.black
+		}
+		if other != nil {
+			h.send(other, Envelope{
+				Type: MsgGameOver, Result: result, Reason: ReasonOpponentLeft,
+				WhiteMS: r.whiteMS, BlackMS: r.blackMS,
+			})
+		}
+		for _, sp := range r.spectators {
+			h.send(sp, Envelope{
+				Type: MsgGameOver, Result: result, Reason: ReasonOpponentLeft,
+				WhiteMS: r.whiteMS, BlackMS: r.blackMS,
+			})
+		}
+	} else if !r.started {
+		// Pre-game: tell the remaining player and reset the room
+		// rather than ending it; they can wait for another joiner.
+		other := r.white
+		if other == nil {
+			other = r.black
+		}
+		if other != nil {
+			h.send(other, Envelope{Type: MsgOpponentLeft})
+		}
+	}
+	h.closePlayer(p)
+	// If both seats are empty (and no spectators), GC the room.
+	if r.white == nil && r.black == nil && len(r.spectators) == 0 {
+		delete(h.rooms, r.Code)
+		if r.flagTimer != nil {
+			r.flagTimer.Stop()
+			r.flagTimer = nil
+		}
+	}
+}
+
+func (h *Hub) closePlayer(p *Player) {
+	defer func() { _ = recover() }() // double-close on Out is benign
+	close(p.Out)
+	p.markDone()
+}
+
+// send tries to enqueue an envelope to a player. Non-blocking — if
+// the outbox is full, we drop the frame. Caller holds hub.mu.
+func (h *Hub) send(p *Player, e Envelope) {
+	if p == nil {
+		return
+	}
+	buf, err := Encode(e)
+	if err != nil {
+		return
+	}
+	select {
+	case p.Out <- buf:
+	default:
+		// outbox full → drop. Clients reconnect when they notice.
+	}
+}
+
+// broadcast sends an envelope to both players and all spectators in
+// the room. Caller holds hub.mu.
+func (h *Hub) broadcast(r *Room, e Envelope) {
+	if r.white != nil {
+		h.send(r.white, e)
+	}
+	if r.black != nil {
+		h.send(r.black, e)
+	}
+	for _, sp := range r.spectators {
+		h.send(sp, e)
+	}
+}
+
+// opponentOf returns the other seated player (nil for spectators or
+// solo rooms).
+func opponentOf(r *Room, p *Player) *Player {
+	if r.white == p {
+		return r.black
+	}
+	if r.black == p {
+		return r.white
+	}
+	return nil
+}
+
+func displayOf(p *Player) string {
+	if p == nil {
+		return ""
+	}
+	if p.DisplayName != "" {
+		return p.DisplayName
+	}
+	return p.Username
+}
+
+// validateUCI mirrors `games/chess.ValidateUCI` but inline here so the
+// netchess package doesn't depend on the LLM helper package.
+func validateUCI(game *notnil.Game, uci string) (*notnil.Move, error) {
+	for _, mv := range game.ValidMoves() {
+		from := mv.S1().String()
+		to := mv.S2().String()
+		promo := ""
+		switch mv.Promo() {
+		case notnil.Queen:
+			promo = "q"
+		case notnil.Rook:
+			promo = "r"
+		case notnil.Bishop:
+			promo = "b"
+		case notnil.Knight:
+			promo = "n"
+		}
+		candidate := from + to + promo
+		if candidate == uci {
+			return mv, nil
+		}
+	}
+	return nil, fmt.Errorf("illegal move: %s", uci)
+}
+
+// reasonFromMethod maps notnil's draw / mate method to one of our
+// stable wire constants.
+func reasonFromMethod(m notnil.Method) string {
+	switch m {
+	case notnil.Checkmate:
+		return ReasonCheckmate
+	case notnil.Stalemate:
+		return ReasonStalemate
+	case notnil.InsufficientMaterial:
+		return ReasonInsufficient
+	case notnil.FiftyMoveRule, notnil.SeventyFiveMoveRule:
+		return ReasonFiftyMove
+	case notnil.ThreefoldRepetition, notnil.FivefoldRepetition:
+		return ReasonThreefold
+	case notnil.DrawOffer:
+		return ReasonAgreement
+	default:
+		return ""
+	}
+}
+
+// RoomCount returns the number of live rooms. Exposed for diagnostics
+// / tests.
+func (h *Hub) RoomCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.rooms)
+}

--- a/src/coordinator/games/netchess/hub_test.go
+++ b/src/coordinator/games/netchess/hub_test.go
@@ -1,0 +1,339 @@
+// Copyright (C) 2025 Homer Server Contributors
+
+package netchess
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// drain pulls every queued envelope off the player's outbox into a
+// slice — destructive read, useful for asserting frames after a
+// hub action. Test-only helper.
+func drain(p *Player) []Envelope {
+	var out []Envelope
+	for {
+		select {
+		case buf, ok := <-p.Out:
+			if !ok {
+				return out
+			}
+			var e Envelope
+			if err := json.Unmarshal(buf, &e); err == nil {
+				out = append(out, e)
+			}
+		default:
+			return out
+		}
+	}
+}
+
+func newTestPlayer(name string) *Player { return NewPlayer(name, "", 32) }
+
+func TestQuickMatchPairsTwoPlayers(t *testing.T) {
+	h := NewHub(Config{WaitingTimeout: 10 * time.Second})
+	h.SeedRNG(1)
+
+	alice := newTestPlayer("alice")
+	bob := newTestPlayer("bob")
+
+	if _, err := h.JoinQuick(alice, JoinOptions{}); err != nil {
+		t.Fatalf("alice join: %v", err)
+	}
+	if _, err := h.JoinQuick(bob, JoinOptions{}); err != nil {
+		t.Fatalf("bob join: %v", err)
+	}
+
+	aliceMsgs := drain(alice)
+	bobMsgs := drain(bob)
+
+	if len(aliceMsgs) < 1 || aliceMsgs[len(aliceMsgs)-1].Type != MsgMatched ||
+		aliceMsgs[len(aliceMsgs)-1].Opponent == "" {
+		t.Fatalf("alice didn't receive matched-with-opponent: %+v", aliceMsgs)
+	}
+	if len(bobMsgs) < 1 || bobMsgs[len(bobMsgs)-1].Type != MsgMatched ||
+		bobMsgs[len(bobMsgs)-1].Opponent == "" {
+		t.Fatalf("bob didn't receive matched-with-opponent: %+v", bobMsgs)
+	}
+	// Colours must differ.
+	if aliceMsgs[len(aliceMsgs)-1].Color == bobMsgs[len(bobMsgs)-1].Color {
+		t.Fatalf("both players got same colour: alice=%s bob=%s",
+			aliceMsgs[len(aliceMsgs)-1].Color, bobMsgs[len(bobMsgs)-1].Color)
+	}
+}
+
+func TestRoomMatchAndStartOnBothReady(t *testing.T) {
+	h := NewHub(Config{WaitingTimeout: 10 * time.Second})
+	a := newTestPlayer("a")
+	b := newTestPlayer("b")
+	if _, err := h.JoinRoom("private", a, JoinOptions{ColorPref: ColorWhite}); err != nil {
+		t.Fatalf("a join: %v", err)
+	}
+	if _, err := h.JoinRoom("private", b, JoinOptions{}); err != nil {
+		t.Fatalf("b join: %v", err)
+	}
+	_ = drain(a)
+	_ = drain(b)
+
+	h.HandleFrame(a, Envelope{Type: MsgReady})
+	h.HandleFrame(b, Envelope{Type: MsgReady})
+
+	aMsgs := drain(a)
+	bMsgs := drain(b)
+	if len(aMsgs) == 0 || aMsgs[0].Type != MsgStart {
+		t.Fatalf("a didn't receive start frame: %+v", aMsgs)
+	}
+	if len(bMsgs) == 0 || bMsgs[0].Type != MsgStart {
+		t.Fatalf("b didn't receive start frame: %+v", bMsgs)
+	}
+	if aMsgs[0].FEN == "" || aMsgs[0].WhiteMS <= 0 {
+		t.Fatalf("start frame missing FEN/clock: %+v", aMsgs[0])
+	}
+}
+
+func TestLegalMoveBroadcastsToOpponent(t *testing.T) {
+	h := NewHub(Config{WaitingTimeout: 10 * time.Second})
+	a := newTestPlayer("a")
+	b := newTestPlayer("b")
+	_, _ = h.JoinRoom("r1", a, JoinOptions{ColorPref: ColorWhite})
+	_, _ = h.JoinRoom("r1", b, JoinOptions{})
+	h.HandleFrame(a, Envelope{Type: MsgReady})
+	h.HandleFrame(b, Envelope{Type: MsgReady})
+	_ = drain(a)
+	_ = drain(b)
+
+	// White plays e2e4.
+	h.HandleFrame(a, Envelope{Type: MsgMove, UCI: "e2e4"})
+
+	for _, p := range []*Player{a, b} {
+		msgs := drain(p)
+		if len(msgs) == 0 {
+			t.Fatalf("expected opponent_move broadcast, %s got nothing", p.Username)
+		}
+		last := msgs[len(msgs)-1]
+		if last.Type != MsgOpponentMove || last.UCI != "e2e4" || last.FEN == "" {
+			t.Fatalf("%s wrong frame: %+v", p.Username, last)
+		}
+	}
+}
+
+func TestIllegalMoveIsRejectedWithError(t *testing.T) {
+	h := NewHub(Config{WaitingTimeout: 10 * time.Second})
+	a := newTestPlayer("a")
+	b := newTestPlayer("b")
+	_, _ = h.JoinRoom("r2", a, JoinOptions{ColorPref: ColorWhite})
+	_, _ = h.JoinRoom("r2", b, JoinOptions{})
+	h.HandleFrame(a, Envelope{Type: MsgReady})
+	h.HandleFrame(b, Envelope{Type: MsgReady})
+	_ = drain(a)
+	_ = drain(b)
+
+	// White tries a 3-square pawn move.
+	h.HandleFrame(a, Envelope{Type: MsgMove, UCI: "e2e5"})
+
+	aMsgs := drain(a)
+	if len(aMsgs) == 0 || aMsgs[len(aMsgs)-1].Type != MsgError {
+		t.Fatalf("expected error frame, got %+v", aMsgs)
+	}
+	// Opponent must not have been told anything.
+	if bMsgs := drain(b); len(bMsgs) != 0 {
+		t.Fatalf("opponent saw something for illegal move: %+v", bMsgs)
+	}
+}
+
+func TestWrongTurnIsRejected(t *testing.T) {
+	h := NewHub(Config{WaitingTimeout: 10 * time.Second})
+	a := newTestPlayer("a")
+	b := newTestPlayer("b")
+	_, _ = h.JoinRoom("r3", a, JoinOptions{ColorPref: ColorWhite})
+	_, _ = h.JoinRoom("r3", b, JoinOptions{})
+	h.HandleFrame(a, Envelope{Type: MsgReady})
+	h.HandleFrame(b, Envelope{Type: MsgReady})
+	_ = drain(a)
+	_ = drain(b)
+
+	// Black tries to move first.
+	h.HandleFrame(b, Envelope{Type: MsgMove, UCI: "e7e5"})
+
+	bMsgs := drain(b)
+	if len(bMsgs) == 0 || bMsgs[len(bMsgs)-1].Type != MsgError {
+		t.Fatalf("expected wrong-turn error, got %+v", bMsgs)
+	}
+}
+
+func TestResignEndsGame(t *testing.T) {
+	h := NewHub(Config{WaitingTimeout: 10 * time.Second})
+	a := newTestPlayer("a")
+	b := newTestPlayer("b")
+	_, _ = h.JoinRoom("r4", a, JoinOptions{ColorPref: ColorWhite})
+	_, _ = h.JoinRoom("r4", b, JoinOptions{})
+	h.HandleFrame(a, Envelope{Type: MsgReady})
+	h.HandleFrame(b, Envelope{Type: MsgReady})
+	_ = drain(a)
+	_ = drain(b)
+
+	h.HandleFrame(a, Envelope{Type: MsgResign})
+	for _, p := range []*Player{a, b} {
+		msgs := drain(p)
+		if len(msgs) == 0 {
+			t.Fatalf("%s no game_over after resign", p.Username)
+		}
+		last := msgs[len(msgs)-1]
+		if last.Type != MsgGameOver || last.Reason != ReasonResignation || last.Result != "0-1" {
+			t.Fatalf("%s wrong game_over after white resign: %+v", p.Username, last)
+		}
+	}
+}
+
+func TestDrawOfferAndAccept(t *testing.T) {
+	h := NewHub(Config{WaitingTimeout: 10 * time.Second})
+	a := newTestPlayer("a")
+	b := newTestPlayer("b")
+	_, _ = h.JoinRoom("r5", a, JoinOptions{ColorPref: ColorWhite})
+	_, _ = h.JoinRoom("r5", b, JoinOptions{})
+	h.HandleFrame(a, Envelope{Type: MsgReady})
+	h.HandleFrame(b, Envelope{Type: MsgReady})
+	_ = drain(a)
+	_ = drain(b)
+
+	h.HandleFrame(a, Envelope{Type: MsgDrawOffer})
+	bMsgs := drain(b)
+	if len(bMsgs) == 0 || bMsgs[len(bMsgs)-1].Type != MsgDrawOffered {
+		t.Fatalf("expected draw_offered to opponent, got %+v", bMsgs)
+	}
+
+	h.HandleFrame(b, Envelope{Type: MsgDrawAccept})
+	for _, p := range []*Player{a, b} {
+		msgs := drain(p)
+		if len(msgs) == 0 || msgs[len(msgs)-1].Type != MsgGameOver || msgs[len(msgs)-1].Result != "1/2-1/2" {
+			t.Fatalf("%s missing 1/2-1/2 after draw accept: %+v", p.Username, msgs)
+		}
+	}
+}
+
+func TestFoolsMateGameOver(t *testing.T) {
+	h := NewHub(Config{WaitingTimeout: 10 * time.Second})
+	a := newTestPlayer("a")
+	b := newTestPlayer("b")
+	_, _ = h.JoinRoom("foolsmate", a, JoinOptions{ColorPref: ColorWhite})
+	_, _ = h.JoinRoom("foolsmate", b, JoinOptions{})
+	h.HandleFrame(a, Envelope{Type: MsgReady})
+	h.HandleFrame(b, Envelope{Type: MsgReady})
+	_ = drain(a)
+	_ = drain(b)
+
+	// 1. f3 e5 2. g4 Qh4#
+	h.HandleFrame(a, Envelope{Type: MsgMove, UCI: "f2f3"})
+	_ = drain(a)
+	_ = drain(b)
+	h.HandleFrame(b, Envelope{Type: MsgMove, UCI: "e7e5"})
+	_ = drain(a)
+	_ = drain(b)
+	h.HandleFrame(a, Envelope{Type: MsgMove, UCI: "g2g4"})
+	_ = drain(a)
+	_ = drain(b)
+	h.HandleFrame(b, Envelope{Type: MsgMove, UCI: "d8h4"})
+
+	for _, p := range []*Player{a, b} {
+		msgs := drain(p)
+		if len(msgs) < 2 {
+			t.Fatalf("%s expected move + game_over, got %+v", p.Username, msgs)
+		}
+		last := msgs[len(msgs)-1]
+		if last.Type != MsgGameOver || last.Reason != ReasonCheckmate || last.Result != "0-1" {
+			t.Fatalf("%s wrong fool's mate outcome: %+v", p.Username, last)
+		}
+	}
+}
+
+func TestRoomFullRejectsThirdPlayer(t *testing.T) {
+	h := NewHub(Config{WaitingTimeout: 10 * time.Second})
+	_, _ = h.JoinRoom("packed", newTestPlayer("a"), JoinOptions{})
+	_, _ = h.JoinRoom("packed", newTestPlayer("b"), JoinOptions{})
+	_, err := h.JoinRoom("packed", newTestPlayer("c"), JoinOptions{})
+	if err == nil {
+		t.Fatal("expected ErrRoomFull for third joiner")
+	}
+}
+
+func TestLeaveBeforeStartLetsRoomerWait(t *testing.T) {
+	h := NewHub(Config{WaitingTimeout: 10 * time.Second})
+	a := newTestPlayer("a")
+	b := newTestPlayer("b")
+	_, _ = h.JoinRoom("waitroom", a, JoinOptions{})
+	_, _ = h.JoinRoom("waitroom", b, JoinOptions{})
+	_ = drain(a)
+	_ = drain(b)
+
+	h.Leave(b)
+
+	aMsgs := drain(a)
+	if len(aMsgs) == 0 || aMsgs[len(aMsgs)-1].Type != MsgOpponentLeft {
+		t.Fatalf("expected opponent_left for a, got %+v", aMsgs)
+	}
+	if h.RoomCount() != 1 {
+		t.Fatalf("room should still exist while a is in it, got %d rooms", h.RoomCount())
+	}
+}
+
+func TestSpectatorJoinAndReceivesBroadcast(t *testing.T) {
+	h := NewHub(Config{WaitingTimeout: 10 * time.Second})
+	a := newTestPlayer("a")
+	b := newTestPlayer("b")
+	_, _ = h.JoinRoom("spec", a, JoinOptions{ColorPref: ColorWhite})
+	_, _ = h.JoinRoom("spec", b, JoinOptions{})
+	h.HandleFrame(a, Envelope{Type: MsgReady})
+	h.HandleFrame(b, Envelope{Type: MsgReady})
+	_ = drain(a)
+	_ = drain(b)
+
+	s := newTestPlayer("spec1")
+	if _, err := h.JoinSpectator("spec", s); err != nil {
+		t.Fatalf("spectator join: %v", err)
+	}
+	specInit := drain(s)
+	if len(specInit) == 0 || !specInit[0].Spectator {
+		t.Fatalf("spectator missing init frame: %+v", specInit)
+	}
+
+	h.HandleFrame(a, Envelope{Type: MsgMove, UCI: "e2e4"})
+	msgs := drain(s)
+	if len(msgs) == 0 || msgs[len(msgs)-1].Type != MsgOpponentMove {
+		t.Fatalf("spectator didn't receive move broadcast: %+v", msgs)
+	}
+
+	// Spectator's own frames must be ignored.
+	h.HandleFrame(s, Envelope{Type: MsgMove, UCI: "e7e5"})
+	if msgs := drain(s); len(msgs) != 0 {
+		t.Fatalf("spectator's send shouldn't echo: %+v", msgs)
+	}
+}
+
+func TestProtocolEncodeDecodeRoundTrip(t *testing.T) {
+	in := Envelope{Type: MsgMove, UCI: "e2e4", WhiteMS: 1234, BlackMS: 5678}
+	buf, err := Encode(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, err := Decode(buf)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Type != in.Type || out.UCI != in.UCI || out.WhiteMS != in.WhiteMS || out.BlackMS != in.BlackMS {
+		t.Fatalf("round-trip mismatch: %+v vs %+v", in, out)
+	}
+}
+
+func TestSanitiseDisplayNameTrimsAndClampsControlChars(t *testing.T) {
+	if got := SanitiseDisplayName("  hello\x07world  "); got != "helloworld" {
+		t.Fatalf("expected 'helloworld', got %q", got)
+	}
+	long := ""
+	for i := 0; i < 50; i++ {
+		long += "x"
+	}
+	if got := SanitiseDisplayName(long); len(got) != MaxDisplayNameLen {
+		t.Fatalf("expected clamp to %d, got %d", MaxDisplayNameLen, len(got))
+	}
+}

--- a/src/coordinator/games/netchess/protocol.go
+++ b/src/coordinator/games/netchess/protocol.go
@@ -1,0 +1,182 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Package netchess implements the lobby + authoritative game state for
+// the two-player Chess ("NetChess") widget on the Homer dashboard.
+//
+// Unlike Netris (a thin relay where each client crunches its own
+// board), NetChess is server-authoritative: the hub holds a
+// `*notnil/chess.Game` per room, validates every move, runs the
+// clocks, and detects mate / draw conditions. Clients render the
+// position the server hands them, submit UCI strings, and never need
+// to second-guess legality.
+package netchess
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// Message types — keep stable across versions; changing them is a
+// breaking protocol change.
+const (
+	// Client → Server
+	MsgHello          = "hello"
+	MsgReady          = "ready"
+	MsgMove           = "move"
+	MsgResign         = "resign"
+	MsgDrawOffer      = "draw_offer"
+	MsgDrawAccept     = "draw_accept"
+	MsgDrawDecline    = "draw_decline"
+	MsgTakebackReq    = "takeback_request"
+	MsgTakebackAccept = "takeback_accept"
+	MsgTakebackDecl   = "takeback_decline"
+	MsgChat           = "chat"
+
+	// Server → Client
+	MsgMatched        = "matched"
+	MsgStart          = "start"
+	MsgOpponentMove   = "opponent_move"
+	MsgClockSync      = "clock_sync"
+	MsgGameOver       = "game_over"
+	MsgDrawOffered    = "draw_offered"
+	MsgTakebackOffer  = "takeback_offered"
+	MsgOpponentLeft   = "opponent_left"
+	MsgWaitingTimeout = "waiting_timeout"
+	MsgError          = "error"
+)
+
+// Game-over reasons. The set is closed: clients render different
+// copy per reason.
+const (
+	ReasonCheckmate    = "checkmate"
+	ReasonStalemate    = "stalemate"
+	ReasonResignation  = "resignation"
+	ReasonAgreement    = "agreement"
+	ReasonFlag         = "flag"
+	ReasonInsufficient = "insufficient_material"
+	ReasonFiftyMove    = "fifty_move"
+	ReasonThreefold    = "threefold_repetition"
+	ReasonOpponentLeft = "opponent_disconnect"
+)
+
+// Time-control defaults — used when the client doesn't override via
+// the URL query. Server enforces clocks; clients display.
+const (
+	DefaultInitialMS  = 600_000 // 10 minutes
+	DefaultIncMS      = 5_000   // 5 second Fischer increment
+	MaxRoomCodeLen    = 64
+	MaxDisplayNameLen = 32
+	MaxChatLen        = 200
+	MaxSpectators     = 8
+)
+
+// Color constants on the wire. We don't reuse chess.Color values
+// because we don't want the wire format coupled to a library type.
+const (
+	ColorWhite = "white"
+	ColorBlack = "black"
+)
+
+// Envelope is the single on-the-wire JSON container. Unknown fields
+// are tolerated on either side, so adding new optional fields does
+// not require a coordinated rollout.
+type Envelope struct {
+	Type string `json:"type"`
+
+	// Hello / Matched / Chat
+	DisplayName string `json:"display_name,omitempty"`
+	Room        string `json:"room,omitempty"`
+	You         string `json:"you,omitempty"`
+	Opponent    string `json:"opponent,omitempty"`
+	Color       string `json:"color,omitempty"`    // your colour: "white"|"black"
+	From        string `json:"from,omitempty"`     // chat sender username
+	Text        string `json:"text,omitempty"`     // chat text
+	Spectator   bool   `json:"spectator,omitempty"` // sent in matched to flag read-only mode
+
+	// Time control (sent in matched once the pair forms)
+	InitialMS   int64 `json:"initial_ms,omitempty"`
+	IncrementMS int64 `json:"increment_ms,omitempty"`
+
+	// Move / OpponentMove
+	UCI string `json:"uci,omitempty"`
+	SAN string `json:"san,omitempty"`
+	FEN string `json:"fen,omitempty"`
+	// Optional client-asserted clock — purely advisory; the server
+	// trusts its own timer.
+	ClockMS int64 `json:"clock_ms,omitempty"`
+
+	// ClockSync / OpponentMove
+	WhiteMS int64 `json:"white_ms,omitempty"`
+	BlackMS int64 `json:"black_ms,omitempty"`
+
+	// GameOver
+	Result string `json:"result,omitempty"` // "1-0" | "0-1" | "1/2-1/2"
+	Reason string `json:"reason,omitempty"` // see Reason* constants
+
+	// Error frames
+	Message string `json:"message,omitempty"`
+}
+
+// Encode marshals the envelope to JSON. The error branch is
+// unreachable for the fields we ship; kept for clarity at call sites.
+func Encode(e Envelope) ([]byte, error) {
+	return json.Marshal(e)
+}
+
+// Decode parses a wire frame and trims the type field so the room
+// loop doesn't have to second-guess. Rejects empty payloads.
+func Decode(buf []byte) (Envelope, error) {
+	var e Envelope
+	if err := json.Unmarshal(buf, &e); err != nil {
+		return e, err
+	}
+	e.Type = strings.TrimSpace(e.Type)
+	return e, nil
+}
+
+// SanitiseDisplayName trims / caps / strips control characters from a
+// user-supplied display label. JWT-derived usernames remain the
+// source of truth for matchmaking; this is a render-only label.
+func SanitiseDisplayName(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	out := make([]rune, 0, MaxDisplayNameLen)
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f {
+			continue
+		}
+		out = append(out, r)
+		if len(out) >= MaxDisplayNameLen {
+			break
+		}
+	}
+	return string(out)
+}
+
+// SanitiseChat clamps a chat message to MaxChatLen runes and drops
+// control characters so the broadcast can't ship raw escape codes to
+// opposing clients.
+func SanitiseChat(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	out := make([]rune, 0, MaxChatLen)
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f {
+			continue
+		}
+		out = append(out, r)
+		if len(out) >= MaxChatLen {
+			break
+		}
+	}
+	return string(out)
+}

--- a/src/coordinator/handlers/games_v4.go
+++ b/src/coordinator/handlers/games_v4.go
@@ -8,6 +8,7 @@
 package handlers
 
 import (
+	"math/rand"
 	"net/http"
 	"strings"
 	"time"
@@ -15,6 +16,8 @@ import (
 	"github.com/fasthttp/websocket"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/labstack/echo/v4"
+	chessgame "github.com/sipcapture/homer-core/src/coordinator/games/chess"
+	"github.com/sipcapture/homer-core/src/coordinator/games/netchess"
 	"github.com/sipcapture/homer-core/src/coordinator/games/netris"
 )
 
@@ -28,10 +31,23 @@ import (
 // how StreamHandler treats a nil StreamService.
 type GamesHandler struct {
 	netrisHub *netris.Hub
+	// chessLLM is the LLM client used by the single-player Chess
+	// widget's "LLM mode". Nil = LLM mode unavailable (the widget
+	// will hide the toggle).
+	chessLLM chessgame.LLMChatter
+	// chessRNG is used by the chess LLM fallback to break ties
+	// between equally-scored greedy moves. Separate RNG so tests can
+	// inject a deterministic seed; nil falls back to non-deterministic.
+	chessRNG *rand.Rand
+	// netchessHub powers the PvP NetChess widget. Nil keeps the
+	// endpoint stubbed (503) — same pattern as netris.
+	netchessHub *netchess.Hub
 }
 
 func NewGamesHandler() *GamesHandler {
-	return &GamesHandler{}
+	return &GamesHandler{
+		chessRNG: rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
 }
 
 // SetNetrisHub injects the running hub. Pass nil to keep the endpoint
@@ -39,6 +55,19 @@ func NewGamesHandler() *GamesHandler {
 // operator explicitly disables games).
 func (h *GamesHandler) SetNetrisHub(hub *netris.Hub) {
 	h.netrisHub = hub
+}
+
+// SetChessLLM wires in the shared LLM client. Pass nil (or a client
+// where Enabled() is false) to leave the Chess widget in bot-only
+// mode; the dashboard reads this state via V4ChessLLMStatus.
+func (h *GamesHandler) SetChessLLM(llm chessgame.LLMChatter) {
+	h.chessLLM = llm
+}
+
+// SetNetChessHub injects the PvP NetChess hub. Pass nil to keep the
+// endpoint stubbed out.
+func (h *GamesHandler) SetNetChessHub(hub *netchess.Hub) {
+	h.netchessHub = hub
 }
 
 const (
@@ -188,6 +217,243 @@ func (h *GamesHandler) V4Netris(c echo.Context) error {
 	// while it's still calling WriteMessage.
 	<-writeDone
 	return nil
+}
+
+const (
+	netchessReadLimit     = 8 * 1024
+	netchessPongWait      = 60 * time.Second
+	netchessPingInterval  = 25 * time.Second
+	netchessOutboxBuffer  = 64
+)
+
+// V4NetChess upgrades the request to a WebSocket and routes the
+// resulting client through the netchess.Hub. Same auth and write/read
+// pump shape as V4Netris; the only structural differences are the
+// extra query parameters (color, time control, spectate) and the
+// authoritative server-side game state inside the hub.
+//
+// Query parameters:
+//
+//	room=<code>          Join (or create) a named room. Capacity 2 (+8 spectators).
+//	mode=quick           Auto-pair with the next unmatched player.
+//	color=white|black|random
+//	initial_ms=<int>     Initial clock per side in ms (default 600000).
+//	increment_ms=<int>   Fischer increment in ms (default 5000).
+//	spectate=true        Join an existing room read-only (requires room=<code>).
+//	display=<name>       Optional display label (≤ MaxDisplayNameLen sane chars).
+func (h *GamesHandler) V4NetChess(c echo.Context) error {
+	if h.netchessHub == nil {
+		return writeError(c, http.StatusServiceUnavailable,
+			"Service Unavailable", "NetChess is not configured")
+	}
+
+	username := usernameFromContext(c)
+	if username == "" {
+		return writeError(c, http.StatusUnauthorized,
+			"Unauthorized", "JWT username claim is missing")
+	}
+
+	q := c.Request().URL.Query()
+	room := strings.TrimSpace(q.Get("room"))
+	if len(room) > netchess.MaxRoomCodeLen {
+		room = room[:netchess.MaxRoomCodeLen]
+	}
+	mode := strings.ToLower(strings.TrimSpace(q.Get("mode")))
+	display := q.Get("display")
+	spectate := strings.EqualFold(strings.TrimSpace(q.Get("spectate")), "true")
+	color := strings.ToLower(strings.TrimSpace(q.Get("color")))
+	switch color {
+	case netchess.ColorWhite, netchess.ColorBlack, "random", "":
+		// ok
+	default:
+		return writeError(c, http.StatusBadRequest, "Bad Request",
+			"color must be white, black, or random")
+	}
+
+	if spectate && room == "" {
+		return writeError(c, http.StatusBadRequest, "Bad Request",
+			"spectate=true requires ?room=<code>")
+	}
+	if !spectate && room == "" && mode != "quick" {
+		return writeError(c, http.StatusBadRequest, "Bad Request",
+			"must specify either ?room=<code>, ?mode=quick, or ?spectate=true&room=<code>")
+	}
+
+	initialMS := parseInt64Param(q.Get("initial_ms"))
+	incrementMS := parseInt64Param(q.Get("increment_ms"))
+
+	conn, err := clientStreamUpgrader.Upgrade(c.Response(), c.Request(), nil)
+	if err != nil {
+		return nil
+	}
+	defer conn.Close()
+
+	conn.SetReadLimit(netchessReadLimit)
+	_ = conn.SetReadDeadline(time.Now().Add(netchessPongWait))
+	conn.SetPongHandler(func(string) error {
+		return conn.SetReadDeadline(time.Now().Add(netchessPongWait))
+	})
+
+	player := netchess.NewPlayer(username, display, netchessOutboxBuffer)
+	opts := netchess.JoinOptions{
+		ColorPref:   color,
+		InitialMS:   initialMS,
+		IncrementMS: incrementMS,
+	}
+
+	switch {
+	case spectate:
+		if _, err := h.netchessHub.JoinSpectator(room, player); err != nil {
+			buf, _ := netchess.Encode(netchess.Envelope{Type: netchess.MsgError, Message: err.Error()})
+			_ = conn.SetWriteDeadline(time.Now().Add(clientWriteTimeout))
+			_ = conn.WriteMessage(websocket.TextMessage, buf)
+			return nil
+		}
+	case room != "":
+		if _, err := h.netchessHub.JoinRoom(room, player, opts); err != nil {
+			buf, _ := netchess.Encode(netchess.Envelope{Type: netchess.MsgError, Message: err.Error()})
+			_ = conn.SetWriteDeadline(time.Now().Add(clientWriteTimeout))
+			_ = conn.WriteMessage(websocket.TextMessage, buf)
+			return nil
+		}
+	default:
+		if _, err := h.netchessHub.JoinQuick(player, opts); err != nil {
+			buf, _ := netchess.Encode(netchess.Envelope{Type: netchess.MsgError, Message: err.Error()})
+			_ = conn.SetWriteDeadline(time.Now().Add(clientWriteTimeout))
+			_ = conn.WriteMessage(websocket.TextMessage, buf)
+			return nil
+		}
+	}
+	defer h.netchessHub.Leave(player)
+
+	writeDone := make(chan struct{})
+	go func() {
+		defer close(writeDone)
+		ticker := time.NewTicker(netchessPingInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case buf, ok := <-player.Out:
+				if !ok {
+					_ = conn.SetWriteDeadline(time.Now().Add(clientWriteTimeout))
+					_ = conn.WriteMessage(websocket.CloseMessage,
+						websocket.FormatCloseMessage(websocket.CloseGoingAway, "session closed"))
+					return
+				}
+				if err := conn.SetWriteDeadline(time.Now().Add(clientWriteTimeout)); err != nil {
+					return
+				}
+				if err := conn.WriteMessage(websocket.TextMessage, buf); err != nil {
+					return
+				}
+			case <-ticker.C:
+				if err := conn.WriteControl(websocket.PingMessage, nil,
+					time.Now().Add(clientWriteTimeout)); err != nil {
+					return
+				}
+			}
+		}
+	}()
+
+	for {
+		_, payload, err := conn.ReadMessage()
+		if err != nil {
+			break
+		}
+		env, err := netchess.Decode(payload)
+		if err != nil || env.Type == "" {
+			continue
+		}
+		h.netchessHub.HandleFrame(player, env)
+	}
+
+	<-writeDone
+	return nil
+}
+
+// parseInt64Param is a small forgiving int64 parser for query params:
+// empty / unparseable → 0 so the hub falls back to its defaults.
+func parseInt64Param(s string) int64 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	var v int64
+	for _, ch := range s {
+		if ch < '0' || ch > '9' {
+			return 0
+		}
+		v = v*10 + int64(ch-'0')
+		if v > 1<<40 {
+			return 0
+		}
+	}
+	return v
+}
+
+// chessLLMStatusResponse mirrors the JSON shape the Chess widget
+// reads via fetchChessLLMStatus(). Stable: changing field names is a
+// breaking client/server contract.
+type chessLLMStatusResponse struct {
+	Enabled bool   `json:"enabled"`
+	Model   string `json:"model,omitempty"`
+}
+
+// V4ChessLLMStatus reports whether the dashboard Chess widget can
+// offer LLM-opponent mode. Cheap, no body — the widget polls this on
+// mount.
+func (h *GamesHandler) V4ChessLLMStatus(c echo.Context) error {
+	if h.chessLLM == nil || !h.chessLLM.Enabled() {
+		return c.JSON(http.StatusOK, chessLLMStatusResponse{Enabled: false})
+	}
+	return c.JSON(http.StatusOK, chessLLMStatusResponse{
+		Enabled: true,
+		Model:   h.chessLLM.Model(),
+	})
+}
+
+// chessLLMMoveRequest is the body the Chess widget sends when it's the
+// LLM's turn. We keep the field names short and match the UI camelCase
+// style for the response.
+type chessLLMMoveRequest struct {
+	FEN     string `json:"fen"`
+	History string `json:"history_pgn,omitempty"`
+	Level   int    `json:"level,omitempty"`
+}
+
+type chessLLMMoveResponse struct {
+	UCI       string `json:"uci"`
+	Source    string `json:"source"` // "llm" | "fallback"
+	Model     string `json:"model,omitempty"`
+	LatencyMS int64  `json:"latency_ms"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+// V4ChessLLMMove asks the configured LLM for a move on the supplied
+// FEN. Validates the model output via notnil/chess; on any failure,
+// falls back to a server-side greedy picker so the widget always
+// gets *some* legal move back. The widget displays the `source`
+// indicator so the user can see which path was taken.
+func (h *GamesHandler) V4ChessLLMMove(c echo.Context) error {
+	var req chessLLMMoveRequest
+	if err := c.Bind(&req); err != nil {
+		return writeError(c, http.StatusBadRequest, "Bad Request", "invalid JSON body")
+	}
+	if strings.TrimSpace(req.FEN) == "" {
+		return writeError(c, http.StatusBadRequest, "Bad Request", "fen is required")
+	}
+	resp := chessgame.GetLLMMove(c.Request().Context(), h.chessLLM, chessgame.MoveRequest{
+		FEN:     req.FEN,
+		History: req.History,
+		Level:   req.Level,
+	}, h.chessRNG)
+	return c.JSON(http.StatusOK, chessLLMMoveResponse{
+		UCI:       resp.UCI,
+		Source:    string(resp.Source),
+		Model:     resp.Model,
+		LatencyMS: resp.LatencyMS,
+		Reason:    resp.FallbackReason,
+	})
 }
 
 // usernameFromContext extracts the JWT username claim placed by the

--- a/src/coordinator/services/dashboard_service.go
+++ b/src/coordinator/services/dashboard_service.go
@@ -218,6 +218,39 @@ func (s *DashboardService) ResetDashboards(ctx context.Context, username string)
 	if _, err := s.CreateDashboard(ctx, username, "smartsearch", searchData); err != nil {
 		return err
 	}
+
+	// Default "Games" dashboard with all single-player game widgets pre-laid out
+	// on the 12-col grid. Players land here and try every game without having
+	// to use the Add Widget dialog.
+	gamesData, _ := json.Marshal(map[string]interface{}{
+		"name": "Games", "param": "games", "shared": false, "type": 2, "weight": 30,
+		"config": map[string]interface{}{"columns": 12, "grid_type": "fit", "locked": false},
+		"widgets": []map[string]interface{}{
+			{"id": "packet-defender-1", "type": "packet_defender", "x": 0, "y": 0, "w": 6, "h": 10, "title": "Packet Defender"},
+			{"id": "sip-dialog-master-1", "type": "sip_dialog_master", "x": 6, "y": 0, "w": 6, "h": 10, "title": "SIP Dialog Master"},
+			{"id": "jitter-buffer-hero-1", "type": "jitter_buffer_hero", "x": 0, "y": 10, "w": 6, "h": 10, "title": "Jitter Buffer Hero"},
+			{"id": "sipetris-1", "type": "sipetris", "x": 6, "y": 10, "w": 6, "h": 12, "title": "SIPetris"},
+			{"id": "chess-1", "type": "chess", "x": 0, "y": 22, "w": 8, "h": 12, "title": "Chess"},
+		},
+	})
+	if _, err := s.CreateDashboard(ctx, username, "games", gamesData); err != nil {
+		return err
+	}
+
+	// Default "NetGames" dashboard with the multiplayer game widgets. They
+	// require coordinator hubs (netris, netchess), so we surface them in a
+	// dedicated tab to avoid surprising single-user installs.
+	netGamesData, _ := json.Marshal(map[string]interface{}{
+		"name": "NetGames", "param": "netgames", "shared": false, "type": 3, "weight": 40,
+		"config": map[string]interface{}{"columns": 12, "grid_type": "fit", "locked": false},
+		"widgets": []map[string]interface{}{
+			{"id": "netris-1", "type": "netris", "x": 0, "y": 0, "w": 12, "h": 14, "title": "Netris"},
+			{"id": "netchess-1", "type": "netchess", "x": 0, "y": 14, "w": 12, "h": 14, "title": "NetChess"},
+		},
+	})
+	if _, err := s.CreateDashboard(ctx, username, "netgames", netGamesData); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/src/coordinator/services/dashboard_service.go
+++ b/src/coordinator/services/dashboard_service.go
@@ -239,13 +239,15 @@ func (s *DashboardService) ResetDashboards(ctx context.Context, username string)
 
 	// Default "NetGames" dashboard with the multiplayer game widgets. They
 	// require coordinator hubs (netris, netchess), so we surface them in a
-	// dedicated tab to avoid surprising single-user installs.
+	// dedicated tab to avoid surprising single-user installs. NetChess
+	// matches the single-player Chess widget footprint (8x12) rather than
+	// the full 12-wide arena Netris needs.
 	netGamesData, _ := json.Marshal(map[string]interface{}{
 		"name": "NetGames", "param": "netgames", "shared": false, "type": 3, "weight": 40,
 		"config": map[string]interface{}{"columns": 12, "grid_type": "fit", "locked": false},
 		"widgets": []map[string]interface{}{
 			{"id": "netris-1", "type": "netris", "x": 0, "y": 0, "w": 12, "h": 14, "title": "Netris"},
-			{"id": "netchess-1", "type": "netchess", "x": 0, "y": 14, "w": 12, "h": 14, "title": "NetChess"},
+			{"id": "netchess-1", "type": "netchess", "x": 0, "y": 14, "w": 8, "h": 12, "title": "NetChess"},
 		},
 	})
 	if _, err := s.CreateDashboard(ctx, username, "netgames", netGamesData); err != nil {

--- a/src/coordinator/services/dashboard_service_test.go
+++ b/src/coordinator/services/dashboard_service_test.go
@@ -1,0 +1,153 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+// TestResetDashboards_SeedsDefaultsIncludingGames pins the set of dashboards
+// a brand-new user gets on first login: Home, Smart Search, Games, NetGames.
+// The Games tab must contain every single-player game widget; NetGames must
+// contain the multiplayer ones. The layout numbers themselves are tweakable —
+// the test only asserts the wiring, not pixel-perfect grid coords.
+func TestResetDashboards_SeedsDefaultsIncludingGames(t *testing.T) {
+	dir := t.TempDir()
+	db, err := OpenSettingsDB(filepath.Join(dir, "settings.duckdb"))
+	if err != nil {
+		t.Fatalf("OpenSettingsDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := EnsureSettingsSchema(db); err != nil {
+		t.Fatalf("EnsureSettingsSchema: %v", err)
+	}
+
+	svc := NewDashboardService(db)
+	ctx := context.Background()
+	const user = "alice"
+
+	if err := svc.ResetDashboards(ctx, user); err != nil {
+		t.Fatalf("ResetDashboards: %v", err)
+	}
+
+	settings, err := svc.ListDashboards(ctx, user)
+	if err != nil {
+		t.Fatalf("ListDashboards: %v", err)
+	}
+
+	byParam := make(map[string]json.RawMessage, len(settings))
+	for _, s := range settings {
+		byParam[s.Param] = s.Data
+	}
+
+	expectedDashboards := []string{"home", "smartsearch", "games", "netgames"}
+	for _, p := range expectedDashboards {
+		if _, ok := byParam[p]; !ok {
+			t.Fatalf("default dashboard %q missing; got %v", p, keys(byParam))
+		}
+	}
+
+	games := decodeWidgets(t, byParam["games"])
+	wantGames := map[string]bool{
+		"packet_defender":    false,
+		"sip_dialog_master":  false,
+		"jitter_buffer_hero": false,
+		"sipetris":           false,
+		"chess":              false,
+	}
+	for _, w := range games {
+		if _, ok := wantGames[w]; ok {
+			wantGames[w] = true
+		}
+	}
+	for w, present := range wantGames {
+		if !present {
+			t.Errorf("Games dashboard missing widget type %q (got %v)", w, games)
+		}
+	}
+
+	netGames := decodeWidgets(t, byParam["netgames"])
+	wantNet := map[string]bool{"netris": false, "netchess": false}
+	for _, w := range netGames {
+		if _, ok := wantNet[w]; ok {
+			wantNet[w] = true
+		}
+	}
+	for w, present := range wantNet {
+		if !present {
+			t.Errorf("NetGames dashboard missing widget type %q (got %v)", w, netGames)
+		}
+	}
+}
+
+// TestResetDashboards_IsIdempotent confirms a second call replaces the
+// dashboards in place rather than duplicating them — the API handler calls
+// Reset whenever ListDashboards returns nothing, so a partially-deleted user
+// must converge on the seed set.
+func TestResetDashboards_IsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	db, err := OpenSettingsDB(filepath.Join(dir, "settings.duckdb"))
+	if err != nil {
+		t.Fatalf("OpenSettingsDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := EnsureSettingsSchema(db); err != nil {
+		t.Fatalf("EnsureSettingsSchema: %v", err)
+	}
+
+	svc := NewDashboardService(db)
+	ctx := context.Background()
+
+	if err := svc.ResetDashboards(ctx, "bob"); err != nil {
+		t.Fatalf("first ResetDashboards: %v", err)
+	}
+	first, err := svc.ListDashboards(ctx, "bob")
+	if err != nil {
+		t.Fatalf("first ListDashboards: %v", err)
+	}
+
+	if err := svc.ResetDashboards(ctx, "bob"); err != nil {
+		t.Fatalf("second ResetDashboards: %v", err)
+	}
+	second, err := svc.ListDashboards(ctx, "bob")
+	if err != nil {
+		t.Fatalf("second ListDashboards: %v", err)
+	}
+
+	if len(first) != len(second) {
+		t.Fatalf("dashboard count drifted: first=%d second=%d", len(first), len(second))
+	}
+}
+
+func decodeWidgets(t *testing.T, raw json.RawMessage) []string {
+	t.Helper()
+	var doc struct {
+		Widgets []struct {
+			Type string `json:"type"`
+		} `json:"widgets"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("decode dashboard data: %v", err)
+	}
+	out := make([]string, 0, len(doc.Widgets))
+	for _, w := range doc.Widgets {
+		out = append(out, w.Type)
+	}
+	return out
+}
+
+func keys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/src/coordinator/services/lp_mapping_sync.go
+++ b/src/coordinator/services/lp_mapping_sync.go
@@ -136,6 +136,15 @@ func (s *LPMappingSyncService) loop(ctx context.Context) {
 // SyncOnce performs a single discovery + upsert pass. Exposed so tests
 // can drive the loop deterministically without waiting for a tick.
 func (s *LPMappingSyncService) SyncOnce(ctx context.Context) error {
+	// Idempotent self-heal: scrub any mapping_schema rows older
+	// versions of this service published for internal catalog tables
+	// (DuckLake metadata, system schemas). New rows are no longer
+	// emitted for those — see discoverTables exclusions — but a
+	// freshly-upgraded coordinator must clean its history without an
+	// operator migration step.
+	if err := s.purgeInternalLPMappings(ctx); err != nil {
+		logger.Warn("LPMappingSync: purge internal mappings failed", "err", err.Error())
+	}
 	tables, err := s.discoverTables(ctx)
 	if err != nil {
 		return fmt.Errorf("discover lp tables: %w", err)
@@ -180,15 +189,36 @@ type discoveredLPTable struct {
 	Columns []LPColumn
 }
 
+// discoveryExclusions are predicates that drop catalog-internal tables
+// (DuckLake metadata, system schemas) from the LP discovery set. They
+// must apply on every branch — with or without an operator-configured
+// `prefix` — because nothing in `prefix` defends against the catalog
+// tables also matching `ducklake_*` literally.
+//
+// In particular DuckLake stores its metadata in regular base tables
+// like `ducklake_table`, `ducklake_column`, `ducklake_column_tag`,
+// `ducklake_snapshot`, `ducklake_data_file`, `ducklake_file_column_stats`,
+// `ducklake_partition_column`, and `ducklake_partition_info`. Treating
+// any of those as a line-protocol measurement produces a bogus
+// `main__ducklake_*` mapping_schema row that operators see (and ask
+// about) in Settings → Mappings.
+const discoveryExclusions = "table_type = 'BASE TABLE'" +
+	" AND table_schema NOT IN ('information_schema', 'pg_catalog')" +
+	" AND table_name NOT LIKE 'ducklake_%'"
+
 func (s *LPMappingSyncService) discoverTables(ctx context.Context) ([]discoveredLPTable, error) {
 	var sql string
 	if s.prefix != "" {
-		sql = "SELECT table_catalog, table_schema, table_name FROM information_schema.tables WHERE table_name LIKE '" +
-			escapeSQL(s.prefix) + "%' ORDER BY table_catalog, table_schema, table_name"
+		sql = "SELECT table_catalog, table_schema, table_name FROM information_schema.tables WHERE " +
+			discoveryExclusions + " AND table_name LIKE '" + escapeSQL(s.prefix) + "%'" +
+			" ORDER BY table_catalog, table_schema, table_name"
 	} else {
 		sql = "SELECT table_catalog, table_schema, table_name FROM information_schema.tables WHERE " +
-			"table_name NOT LIKE 'hep_proto_%' AND table_name NOT LIKE 'otlp_%' AND table_name NOT LIKE 'mem_hep_%' " +
-			"ORDER BY table_catalog, table_schema, table_name"
+			discoveryExclusions +
+			" AND table_name NOT LIKE 'hep_proto_%'" +
+			" AND table_name NOT LIKE 'otlp_%'" +
+			" AND table_name NOT LIKE 'mem_hep_%'" +
+			" ORDER BY table_catalog, table_schema, table_name"
 	}
 	rows, err := s.flight.Query(ctx, sql)
 	if err != nil {
@@ -343,6 +373,43 @@ func (s *LPMappingSyncService) upsertMapping(ctx context.Context, t discoveredLP
 		return false, fmt.Errorf("insert lp mapping schema=%s table=%s: %w", t.Schema, t.Name, err)
 	}
 	return true, nil
+}
+
+// purgeInternalLPMappings removes mapping_schema rows that were
+// published by earlier versions of this service for catalog-internal
+// tables that should never have been treated as Line Protocol
+// measurements. Today that means:
+//
+//   - DuckLake catalog tables (ducklake_table, ducklake_column,
+//     ducklake_column_tag, ducklake_snapshot, ducklake_data_file,
+//     ducklake_file_column_stats, ducklake_partition_column,
+//     ducklake_partition_info).
+//   - System schemas (information_schema.*, pg_catalog.*).
+//
+// The DELETE is scoped to `hepid = LPVirtualHepID` so we never touch
+// hand-curated rows operators may have added under a real HEP type.
+// Idempotent — safe to run on every tick. RowsAffected is logged only
+// when something actually went away to keep happy-path tick logs
+// quiet.
+func (s *LPMappingSyncService) purgeInternalLPMappings(ctx context.Context) error {
+	if s.db == nil {
+		return nil
+	}
+	q := fmt.Sprintf(
+		`DELETE FROM mapping_schema WHERE hepid = %d AND (`+
+			` profile LIKE '%%__ducklake\_%%' ESCAPE '\'`+
+			` OR profile LIKE 'ducklake\_%%' ESCAPE '\'`+
+			` OR profile LIKE 'information\_schema\_\_%%' ESCAPE '\'`+
+			` OR profile LIKE 'pg\_catalog\_\_%%' ESCAPE '\'`+
+			`)`, LPVirtualHepID)
+	res, err := s.db.ExecContext(ctx, q)
+	if err != nil {
+		return err
+	}
+	if n, err := res.RowsAffected(); err == nil && n > 0 {
+		logger.Info("LPMappingSync: purged catalog-internal mappings", "deleted", n)
+	}
+	return nil
 }
 
 // LPMappingGUID returns a deterministic UUIDv5-like identifier for a

--- a/src/coordinator/services/lp_mapping_sync_test.go
+++ b/src/coordinator/services/lp_mapping_sync_test.go
@@ -176,6 +176,104 @@ func TestLPMappingSync_UpsertLifecycle(t *testing.T) {
 	}
 }
 
+// TestLPMappingSync_PurgeInternalMappings drives purgeInternalLPMappings
+// against a real DuckDB-backed settings DB. It pre-seeds the
+// mapping_schema with a mix of legitimate LP rows (lp_cpu) and
+// catalog-internal rows that earlier versions of this service would
+// have published (DuckLake metadata tables, information_schema), then
+// verifies the purge:
+//
+//   - deletes every catalog-internal row,
+//   - leaves the genuine lp_* row intact,
+//   - is idempotent (a second call leaves the table unchanged).
+func TestLPMappingSync_PurgeInternalMappings(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.duckdb")
+	db, err := OpenSettingsDB(path)
+	if err != nil {
+		t.Fatalf("OpenSettingsDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := EnsureSettingsSchema(db); err != nil {
+		t.Fatalf("EnsureSettingsSchema: %v", err)
+	}
+	ctx := context.Background()
+
+	svc := NewLPMappingSyncService(db, &FlightService{}, "", 0)
+
+	// Seed: one legitimate measurement plus a sampling of the
+	// internal-catalog rows we want gone.
+	seedRows := []struct {
+		schema, table string
+	}{
+		{"main", "lp_cpu"}, // keep
+		{"main", "ducklake_table"},
+		{"main", "ducklake_column"},
+		{"main", "ducklake_column_tag"},
+		{"main", "ducklake_snapshot"},
+		{"main", "ducklake_data_file"},
+		{"main", "ducklake_file_column_stats"},
+		{"main", "ducklake_partition_column"},
+		{"main", "ducklake_partition_info"},
+		{"information_schema", "tables"},
+		{"pg_catalog", "pg_class"},
+	}
+	cols := []LPColumn{
+		{Name: "time", DataType: "TIMESTAMP", Position: 1},
+		{Name: "value", DataType: "DOUBLE", Position: 2},
+	}
+	for _, sr := range seedRows {
+		row := discoveredLPTable{Schema: sr.schema, Name: sr.table, Columns: cols}
+		if _, err := svc.upsertMapping(ctx, row); err != nil {
+			t.Fatalf("seed %s.%s: %v", sr.schema, sr.table, err)
+		}
+	}
+
+	var before int64
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM mapping_schema WHERE hepid = `+itoa(LPVirtualHepID)).Scan(&before); err != nil {
+		t.Fatalf("count before: %v", err)
+	}
+	if before != int64(len(seedRows)) {
+		t.Fatalf("seeded %d rows, COUNT(*) = %d", len(seedRows), before)
+	}
+
+	if err := svc.purgeInternalLPMappings(ctx); err != nil {
+		t.Fatalf("purgeInternalLPMappings: %v", err)
+	}
+
+	var after int64
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM mapping_schema WHERE hepid = `+itoa(LPVirtualHepID)).Scan(&after); err != nil {
+		t.Fatalf("count after: %v", err)
+	}
+	if after != 1 {
+		t.Fatalf("expected 1 row left after purge (lp_cpu), got %d", after)
+	}
+
+	// And what's left must be the legitimate measurement.
+	var profile string
+	if err := db.QueryRowContext(ctx,
+		`SELECT profile FROM mapping_schema WHERE hepid = `+itoa(LPVirtualHepID)).Scan(&profile); err != nil {
+		t.Fatalf("inspect remaining: %v", err)
+	}
+	if profile != "main__lp_cpu" {
+		t.Fatalf("unexpected surviving profile %q", profile)
+	}
+
+	// Idempotency: second purge is a no-op.
+	if err := svc.purgeInternalLPMappings(ctx); err != nil {
+		t.Fatalf("idempotent purge: %v", err)
+	}
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM mapping_schema WHERE hepid = `+itoa(LPVirtualHepID)).Scan(&after); err != nil {
+		t.Fatalf("count after idempotent: %v", err)
+	}
+	if after != 1 {
+		t.Fatalf("idempotent purge changed row count: %d", after)
+	}
+}
+
 // itoa keeps the test SQL legible without pulling strconv into the
 // scope of every assertion.
 func itoa(i int) string {

--- a/src/go.mod
+++ b/src/go.mod
@@ -94,6 +94,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/notnil/chess v1.10.0 // indirect
 	github.com/panjf2000/ants/v2 v2.11.3 // indirect
 	github.com/paulmach/orb v0.12.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -6,6 +6,7 @@ github.com/VictoriaMetrics/fastcache v1.13.2 h1:2XTB49aLSuCex7e9P5rqrfQcMkzGjh5V
 github.com/VictoriaMetrics/fastcache v1.13.2/go.mod h1:hHXhl4DA2fTL2HTZDJFXWgW0LNjo6B+4aj2Wmng3TjU=
 github.com/adubovikov/duckdb-go-bindings v0.10502.0-homer.gcopt.2 h1:biYQHm42AjJGVPvUtQmO0mBnR9sBT35ZPuqoeUZ2hwc=
 github.com/adubovikov/duckdb-go-bindings v0.10502.0-homer.gcopt.2/go.mod h1:8KF3oEKrmYdSbZnQ1BPTdxAZDHRaM1LEv+oBvL2nSLk=
+github.com/ajstarks/svgo v0.0.0-20200320125537-f189e35d30ca/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa h1:LHTHcTQiSGT7VVbI0o4wBRNQIgn917usHWOd6VAffYI=
 github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
@@ -223,6 +224,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/notnil/chess v1.10.0 h1:RR3MgS9G6zZmJ+VPTJolyxdaIgxoUPyUUY+2iaw35G0=
+github.com/notnil/chess v1.10.0/go.mod h1:cRuJUIBFq9Xki05TWHJxHYkC+fFpq45IWwk94DdlCrA=
 github.com/panjf2000/ants/v2 v2.11.3 h1:AfI0ngBoXJmYOpDh9m516vjqoUu2sLrIVgppI9TZVpg=
 github.com/panjf2000/ants/v2 v2.11.3/go.mod h1:8u92CYMUc6gyvTIw8Ru7Mt7+/ESnJahz5EVtqfrilek=
 github.com/panjf2000/gnet/v2 v2.9.5 h1:h/APp9rAFRVAspPl/prruU+FcjqilGyjHDJZ4eTB8Cw=

--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -17,6 +17,7 @@
         "@phosphor-icons/react": "^2.1.10",
         "@tailwindcss/vite": "^4.2.2",
         "@uiw/react-codemirror": "^4.25.9",
+        "chess.js": "^1.4.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.8.0",
@@ -5496,6 +5497,12 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/chess.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/chess.js/-/chess.js-1.4.0.tgz",
+      "integrity": "sha512-BBJgrrtKQOzFLonR0l+k64A98NLemPwNsCskwb+29bRwobUa4iTm51E1kwGPbWXAcfdDa18nad6vpPPKPWarqw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/chromium-bidi": {
       "version": "14.0.0",

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -25,6 +25,7 @@
     "@phosphor-icons/react": "^2.1.10",
     "@tailwindcss/vite": "^4.2.2",
     "@uiw/react-codemirror": "^4.25.9",
+    "chess.js": "^1.4.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",

--- a/src/ui/src/api.ts
+++ b/src/ui/src/api.ts
@@ -466,4 +466,218 @@ export function openNetrisSocket(
   }
 }
 
+// ---------------------------------------------------------------------------
+// NetChess (PvP) — WebSocket envelope + thin client
+// ---------------------------------------------------------------------------
+
+/**
+ * Single envelope for the NetChess (PvP Chess) WebSocket. The server
+ * mirror lives in `src/coordinator/games/netchess/protocol.go` — keep
+ * field names in sync. Unknown fields are tolerated on both sides.
+ */
+export interface NetChessMessage {
+  type: string
+  display_name?: string
+  room?: string
+  you?: string
+  opponent?: string
+  /** Your colour (only set on `matched`). */
+  color?: 'white' | 'black'
+  spectator?: boolean
+
+  /** Time control (set on `matched`). */
+  initial_ms?: number
+  increment_ms?: number
+
+  /** Move / opponent_move / clock_sync */
+  uci?: string
+  san?: string
+  fen?: string
+  clock_ms?: number
+  white_ms?: number
+  black_ms?: number
+
+  /** game_over */
+  result?: '1-0' | '0-1' | '1/2-1/2'
+  reason?: string
+
+  /** chat */
+  from?: string
+  text?: string
+
+  /** error */
+  message?: string
+}
+
+export type NetChessSocketState = 'connecting' | 'open' | 'closed'
+
+export interface NetChessSocketOptions {
+  /** Named room code. Mutually exclusive with `quick`. */
+  room?: string
+  /** Auto-pair with the next unmatched player. */
+  quick?: boolean
+  /** Join `room` read-only as a spectator. */
+  spectate?: boolean
+  /** Colour preference for new rooms. Default random. */
+  color?: 'white' | 'black' | 'random'
+  /** Time control overrides (milliseconds). */
+  initialMs?: number
+  incrementMs?: number
+  /** Optional display label override. */
+  display?: string
+}
+
+export interface NetChessSocket {
+  send: (msg: NetChessMessage) => void
+  close: () => void
+  readonly state: () => NetChessSocketState
+}
+
+/**
+ * Thin WebSocket client for `/api/v4/games/netchess`. Same reconnect
+ * / backoff strategy as `openNetrisSocket`; after reconnects the
+ * caller should re-emit `hello` / `ready` since the server keeps no
+ * cross-socket session state beyond an in-flight room.
+ */
+export function openNetChessSocket(
+  opts: NetChessSocketOptions,
+  handlers: {
+    onMessage: (msg: NetChessMessage) => void
+    onOpen?: () => void
+    onClose?: (ev: CloseEvent) => void
+    onError?: (err: unknown) => void
+  },
+): NetChessSocket {
+  let ws: WebSocket | null = null
+  let closedByUser = false
+  let attempt = 0
+  let reconnectTimer: number | null = null
+  let currentState: NetChessSocketState = 'closed'
+
+  const params: QueryParams = {}
+  if (opts.room) params.room = opts.room
+  if (opts.quick) params.mode = 'quick'
+  if (opts.spectate) params.spectate = 'true'
+  if (opts.color) params.color = opts.color
+  if (opts.initialMs !== undefined) params.initial_ms = String(opts.initialMs)
+  if (opts.incrementMs !== undefined) params.increment_ms = String(opts.incrementMs)
+  if (opts.display) params.display = opts.display
+
+  const connect = () => {
+    if (closedByUser) return
+    currentState = 'connecting'
+    const url = buildWsURL('/games/netchess', params)
+    let sock: WebSocket
+    try {
+      sock = new WebSocket(url)
+    } catch (err) {
+      handlers.onError?.(err)
+      scheduleReconnect()
+      return
+    }
+    ws = sock
+    sock.onopen = () => {
+      attempt = 0
+      currentState = 'open'
+      handlers.onOpen?.()
+    }
+    sock.onmessage = (ev) => {
+      try {
+        const parsed = JSON.parse(String(ev.data)) as NetChessMessage
+        handlers.onMessage(parsed)
+      } catch (err) {
+        handlers.onError?.(err)
+      }
+    }
+    sock.onerror = (err) => {
+      handlers.onError?.(err)
+    }
+    sock.onclose = (ev) => {
+      currentState = 'closed'
+      handlers.onClose?.(ev)
+      if (!closedByUser) scheduleReconnect()
+    }
+  }
+
+  const scheduleReconnect = () => {
+    if (closedByUser) return
+    attempt = Math.min(attempt + 1, 8)
+    const backoffMs = Math.min(30000, 500 * 2 ** (attempt - 1))
+    const jitter = Math.random() * 250
+    reconnectTimer = window.setTimeout(connect, backoffMs + jitter)
+  }
+
+  connect()
+
+  return {
+    send: (msg) => {
+      if (!ws || ws.readyState !== WebSocket.OPEN) return
+      try {
+        ws.send(JSON.stringify(msg))
+      } catch (err) {
+        handlers.onError?.(err)
+      }
+    },
+    close: () => {
+      closedByUser = true
+      if (reconnectTimer !== null) {
+        window.clearTimeout(reconnectTimer)
+        reconnectTimer = null
+      }
+      if (ws) {
+        try { ws.close(1000, 'client closed') } catch { /* ignore */ }
+        ws = null
+      }
+      currentState = 'closed'
+    },
+    state: () => currentState,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Chess widget — LLM opponent endpoints
+// ---------------------------------------------------------------------------
+
+/** Status of the optional LLM-opponent mode for the single-player Chess
+ *  widget. Mirrors the server-side `chessLLMStatusResponse`. The Chess
+ *  widget polls this on mount to decide whether to render the LLM
+ *  toggle. `enabled=false` keeps the widget in bot-only mode. */
+export interface ChessLLMStatus {
+  enabled: boolean
+  model?: string
+}
+
+export async function fetchChessLLMStatus(): Promise<ChessLLMStatus> {
+  try {
+    return await apiGet<ChessLLMStatus>('/api/v4/games/chess/llm-status')
+  } catch {
+    // Endpoint absent or unauthorized — treat as disabled so the
+    // widget gracefully falls back to bot-only mode.
+    return { enabled: false }
+  }
+}
+
+/** Request body for `/api/v4/games/chess/llm-move`. */
+export interface ChessLLMMoveRequest {
+  fen: string
+  history_pgn?: string
+  level?: number
+}
+
+/** Response shape for `/api/v4/games/chess/llm-move`. `uci` is empty
+ *  for terminal positions; otherwise it is always a legal move. */
+export interface ChessLLMMoveResponse {
+  uci: string
+  source: 'llm' | 'fallback'
+  model?: string
+  latency_ms: number
+  reason?: string
+}
+
+export async function postChessLLMMove(req: ChessLLMMoveRequest): Promise<ChessLLMMoveResponse> {
+  const res = await apiPost<ChessLLMMoveResponse>('/api/v4/games/chess/llm-move', req)
+  if (!res) throw new Error('chess llm-move returned no body')
+  return res
+}
+
 export { apiBase, tokenKey, getToken, authHeaders, parseError }

--- a/src/ui/src/dashboard/widgets/ChessBoard.test.tsx
+++ b/src/ui/src/dashboard/widgets/ChessBoard.test.tsx
@@ -9,11 +9,14 @@ describe('ChessBoard', () => {
     expect(screen.getAllByRole('button')).toHaveLength(64)
   })
 
-  it('renders pieces using Unicode glyphs in the starting position', () => {
+  it('renders pieces using filled Unicode glyphs in the starting position', () => {
     const { container } = render(<ChessBoard fen={STARTING_FEN} cellPx={32} />)
-    expect(container.textContent).toContain('♔') // white king
-    expect(container.textContent).toContain('♚') // black king
-    expect(container.textContent).toContain('♟') // a black pawn
+    // Both colours share the filled silhouettes — colour is carried by
+    // the text-white / text-black class, not by a different glyph.
+    expect(container.textContent).toContain('♚')
+    expect(container.textContent).toContain('♟')
+    expect(container.querySelectorAll('span.text-white').length).toBeGreaterThan(0)
+    expect(container.querySelectorAll('span.text-black').length).toBeGreaterThan(0)
   })
 
   it('click-select-then-click-move emits onMove with from/to', () => {

--- a/src/ui/src/dashboard/widgets/ChessBoard.test.tsx
+++ b/src/ui/src/dashboard/widgets/ChessBoard.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { ChessBoard } from './ChessBoard'
+import { STARTING_FEN } from './chessCore'
+
+describe('ChessBoard', () => {
+  it('renders 64 square buttons', () => {
+    render(<ChessBoard fen={STARTING_FEN} cellPx={32} />)
+    expect(screen.getAllByRole('button')).toHaveLength(64)
+  })
+
+  it('renders pieces using Unicode glyphs in the starting position', () => {
+    const { container } = render(<ChessBoard fen={STARTING_FEN} cellPx={32} />)
+    expect(container.textContent).toContain('♔') // white king
+    expect(container.textContent).toContain('♚') // black king
+    expect(container.textContent).toContain('♟') // a black pawn
+  })
+
+  it('click-select-then-click-move emits onMove with from/to', () => {
+    const onMove = vi.fn()
+    render(<ChessBoard fen={STARTING_FEN} cellPx={32} onMove={onMove} />)
+    fireEvent.click(screen.getByLabelText('e2'))
+    fireEvent.click(screen.getByLabelText('e4'))
+    expect(onMove).toHaveBeenCalledWith({ from: 'e2', to: 'e4' })
+  })
+
+  it('ignores illegal destinations', () => {
+    const onMove = vi.fn()
+    render(<ChessBoard fen={STARTING_FEN} cellPx={32} onMove={onMove} />)
+    fireEvent.click(screen.getByLabelText('e2'))
+    fireEvent.click(screen.getByLabelText('e5')) // 3-square pawn move
+    expect(onMove).not.toHaveBeenCalled()
+  })
+
+  it('does not emit when interactive is false', () => {
+    const onMove = vi.fn()
+    render(<ChessBoard fen={STARTING_FEN} cellPx={32} interactive={false} onMove={onMove} />)
+    fireEvent.click(screen.getByLabelText('e2'))
+    fireEvent.click(screen.getByLabelText('e4'))
+    expect(onMove).not.toHaveBeenCalled()
+  })
+
+  it('shows promotion picker on pawn promotion and emits chosen piece', () => {
+    const onMove = vi.fn()
+    // Position: white pawn on e7, white king g1, black king e1; white to move.
+    const fen = '8/4P3/8/8/8/8/8/4k1K1 w - - 0 1'
+    render(<ChessBoard fen={fen} cellPx={32} onMove={onMove} />)
+    fireEvent.click(screen.getByLabelText('e7'))
+    fireEvent.click(screen.getByLabelText('e8'))
+    // No move emitted yet — picker is up.
+    expect(onMove).not.toHaveBeenCalled()
+    // Pick a rook.
+    fireEvent.click(screen.getByLabelText('Promote to R'))
+    expect(onMove).toHaveBeenCalledWith({ from: 'e7', to: 'e8', promotion: 'r' })
+  })
+
+  it('flips the board so that black is on the bottom when flipped=true', () => {
+    const { container } = render(
+      <ChessBoard fen={STARTING_FEN} cellPx={32} flipped />,
+    )
+    // First grid child should now be the a1 (white rook on the back rank)
+    // because flipped puts rank 1 at the top.
+    const grid = container.querySelector('.grid')
+    const firstSquare = grid?.firstElementChild as HTMLElement
+    expect(firstSquare.getAttribute('aria-label')).toBe('h1')
+  })
+})

--- a/src/ui/src/dashboard/widgets/ChessBoard.tsx
+++ b/src/ui/src/dashboard/widgets/ChessBoard.tsx
@@ -1,0 +1,317 @@
+/**
+ * ChessBoard — presentational 8x8 board.
+ *
+ * No game state of its own. The owner (`ChessPanel`, `NetChessPanel`)
+ * passes a FEN; the board renders it, accepts clicks, and reports
+ * a candidate move back via `onMove`. Pieces are Unicode glyphs so
+ * we don't need a separate asset pipeline; that's good enough at
+ * widget cell sizes (24–80 px).
+ *
+ * Interaction model — click-to-select then click-to-move:
+ *   1. Click your own piece → it gets a "selected" outline + legal
+ *      destination dots appear on every reachable square.
+ *   2. Click a destination dot → emit onMove({from, to}). If the move
+ *      is a pawn promotion, a small popover asks Q/R/B/N first.
+ *   3. Click the selected piece again, or anywhere illegal, deselects.
+ *
+ * The component never validates moves authoritatively — the parent
+ * decides what to do with `onMove`. We compute `legalMoves` only so
+ * the destination dots are accurate (and to know whether a promotion
+ * picker is needed). If `interactive=false`, the click handlers are
+ * no-ops and the destination dots are not shown.
+ */
+
+import { useMemo, useState } from 'react'
+import { cn } from '@/lib/utils'
+import {
+  type BoardSnapshot,
+  type ChessColor,
+  type ChessPieceType,
+  type ChessSquare,
+  type Promotion,
+  type UciMove,
+  legalMoves,
+  newGame,
+  snapshot,
+  turn,
+} from './chessCore'
+
+const FILES = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] as const
+const RANKS = ['8', '7', '6', '5', '4', '3', '2', '1'] as const
+
+const PIECE_GLYPH: Record<ChessColor, Record<ChessPieceType, string>> = {
+  w: { k: '♔', q: '♕', r: '♖', b: '♗', n: '♘', p: '♙' },
+  b: { k: '♚', q: '♛', r: '♜', b: '♝', n: '♞', p: '♟' },
+}
+
+/** Square is "light" if (file + rank) is even, "dark" otherwise. */
+function squareShade(square: ChessSquare): 'light' | 'dark' {
+  const fileIdx = FILES.indexOf(square.charAt(0) as (typeof FILES)[number])
+  const rankIdx = parseInt(square.charAt(1), 10) - 1
+  return (fileIdx + rankIdx) % 2 === 0 ? 'dark' : 'light'
+}
+
+export interface ChessBoardProps {
+  fen: string
+  cellPx: number
+  /** Flip the board so black is at the bottom. */
+  flipped?: boolean
+  /** Disable user input (used for review mode, spectator, opponent's turn). */
+  interactive?: boolean
+  /** Restrict pickable pieces to this colour (e.g. you only move white). */
+  movableColor?: ChessColor
+  /** Highlight from/to of the last move. */
+  lastMove?: { from: ChessSquare; to: ChessSquare }
+  /** Outline this square in red (king in check). */
+  checkSquare?: ChessSquare | null
+  /** Emitted when the user completes a move (including promotion choice). */
+  onMove?: (move: UciMove) => void
+}
+
+interface PendingPromotion {
+  from: ChessSquare
+  to: ChessSquare
+}
+
+export function ChessBoard(props: ChessBoardProps) {
+  const {
+    fen,
+    cellPx,
+    flipped = false,
+    interactive = true,
+    movableColor,
+    lastMove,
+    checkSquare,
+    onMove,
+  } = props
+
+  const board = useMemo<BoardSnapshot>(() => {
+    try {
+      return snapshot(newGame(fen))
+    } catch {
+      return snapshot(newGame())
+    }
+  }, [fen])
+
+  const sideToMove = useMemo<ChessColor>(() => {
+    try {
+      return turn(newGame(fen))
+    } catch {
+      return 'w'
+    }
+  }, [fen])
+
+  const [selected, setSelected] = useState<ChessSquare | null>(null)
+  const [pendingPromo, setPendingPromo] = useState<PendingPromotion | null>(null)
+  // React's "reset state on prop change" pattern: track the last FEN
+  // in state and clear the selection synchronously when the position
+  // changes (the new FEN may not even contain the previously-selected
+  // piece). Calling setState during render is fine when guarded by an
+  // equality check — React converges on the next render and no extra
+  // effect is needed.
+  const [lastFen, setLastFen] = useState(fen)
+  if (lastFen !== fen) {
+    setLastFen(fen)
+    setSelected(null)
+    setPendingPromo(null)
+  }
+
+  const legalForSelected = useMemo(() => {
+    if (!selected) return [] as ReturnType<typeof legalMoves>
+    try {
+      return legalMoves(newGame(fen), selected)
+    } catch {
+      return []
+    }
+  }, [fen, selected])
+
+  const legalDestSet = useMemo(() => new Set(legalForSelected.map((m) => m.to)), [legalForSelected])
+  const promotionRequired = (from: ChessSquare, to: ChessSquare): boolean => {
+    return legalForSelected.some(
+      (m) => m.from === from && m.to === to && m.promotion !== undefined,
+    )
+  }
+
+  const handleSquareClick = (sq: ChessSquare) => {
+    if (!interactive) return
+    const cellPiece = pieceAt(board, sq)
+    // Click a candidate destination?
+    if (selected && legalDestSet.has(sq)) {
+      if (promotionRequired(selected, sq)) {
+        setPendingPromo({ from: selected, to: sq })
+        return
+      }
+      onMove?.({ from: selected, to: sq })
+      setSelected(null)
+      return
+    }
+    // Click your own piece → (re-)select.
+    if (cellPiece && cellPiece.color === sideToMove && (!movableColor || cellPiece.color === movableColor)) {
+      setSelected(sq === selected ? null : sq)
+      return
+    }
+    // Anything else clears.
+    setSelected(null)
+  }
+
+  const handlePromotionChoice = (choice: Promotion) => {
+    if (!pendingPromo) return
+    onMove?.({ from: pendingPromo.from, to: pendingPromo.to, promotion: choice })
+    setPendingPromo(null)
+    setSelected(null)
+  }
+
+  const orderedRanks = flipped ? [...RANKS].reverse() : RANKS
+  const orderedFiles = flipped ? [...FILES].reverse() : FILES
+
+  return (
+    <div
+      className="relative inline-block select-none rounded-md border border-border bg-card/40 p-1 shadow-sm"
+      style={{ width: cellPx * 8 + 8, height: cellPx * 8 + 8 }}
+      aria-label="Chess board"
+    >
+      <div
+        className="grid"
+        style={{
+          gridTemplateColumns: `repeat(8, ${cellPx}px)`,
+          gridTemplateRows: `repeat(8, ${cellPx}px)`,
+        }}
+      >
+        {orderedRanks.map((rank) =>
+          orderedFiles.map((file) => {
+            const sq = `${file}${rank}` as ChessSquare
+            const shade = squareShade(sq)
+            const piece = pieceAtFenIndex(board, file, rank)
+            const isSelected = selected === sq
+            const isLegalDest = !!selected && legalDestSet.has(sq)
+            const isLastFrom = lastMove?.from === sq
+            const isLastTo = lastMove?.to === sq
+            const isCheck = checkSquare === sq
+            return (
+              <button
+                key={sq}
+                type="button"
+                aria-label={sq}
+                onClick={() => handleSquareClick(sq)}
+                disabled={!interactive}
+                className={cn(
+                  'relative flex items-center justify-center font-semibold leading-none transition-colors',
+                  shade === 'light'
+                    ? 'bg-[#eed7b4] dark:bg-[#b58863]'
+                    : 'bg-[#b58863] dark:bg-[#6b4f3a]',
+                  (isLastFrom || isLastTo) && 'ring-2 ring-yellow-400/70 ring-inset',
+                  isSelected && 'ring-2 ring-primary ring-inset',
+                  isCheck && 'ring-2 ring-rose-500 ring-inset',
+                  !interactive && 'cursor-default',
+                )}
+                style={{ width: cellPx, height: cellPx, fontSize: Math.floor(cellPx * 0.78) }}
+              >
+                {piece && (
+                  <span
+                    aria-hidden
+                    className={cn(
+                      'pointer-events-none drop-shadow-sm',
+                      piece.color === 'w' ? 'text-white' : 'text-black',
+                    )}
+                    style={{ textShadow: piece.color === 'w' ? '0 0 2px rgba(0,0,0,0.7)' : '0 0 2px rgba(255,255,255,0.5)' }}
+                  >
+                    {PIECE_GLYPH[piece.color][piece.type]}
+                  </span>
+                )}
+                {isLegalDest && !piece && (
+                  <span
+                    aria-hidden
+                    className="pointer-events-none absolute h-1/3 w-1/3 rounded-full bg-black/30 dark:bg-white/35"
+                  />
+                )}
+                {isLegalDest && piece && (
+                  <span
+                    aria-hidden
+                    className="pointer-events-none absolute inset-1 rounded-md ring-2 ring-rose-500/70"
+                  />
+                )}
+                {/* Rank coordinate (a-file column for the side at the bottom) */}
+                {file === orderedFiles[0] && (
+                  <span
+                    aria-hidden
+                    className="pointer-events-none absolute left-0.5 top-0.5 text-[9px] font-bold opacity-60"
+                  >
+                    {rank}
+                  </span>
+                )}
+                {/* File coordinate (bottom row) */}
+                {rank === orderedRanks[orderedRanks.length - 1] && (
+                  <span
+                    aria-hidden
+                    className="pointer-events-none absolute bottom-0.5 right-1 text-[9px] font-bold opacity-60"
+                  >
+                    {file}
+                  </span>
+                )}
+              </button>
+            )
+          }),
+        )}
+      </div>
+
+      {pendingPromo && (
+        <PromotionPicker
+          color={sideToMove}
+          onChoose={handlePromotionChoice}
+          onCancel={() => setPendingPromo(null)}
+        />
+      )}
+    </div>
+  )
+}
+
+function PromotionPicker({
+  color,
+  onChoose,
+  onCancel,
+}: {
+  color: ChessColor
+  onChoose: (p: Promotion) => void
+  onCancel: () => void
+}) {
+  const choices: Promotion[] = ['q', 'r', 'b', 'n']
+  return (
+    <div
+      className="absolute inset-0 z-30 flex items-center justify-center bg-background/70"
+      onClick={onCancel}
+    >
+      <div
+        className="flex gap-1 rounded-md border border-border bg-card p-2 shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {choices.map((c) => (
+          <button
+            key={c}
+            type="button"
+            onClick={() => onChoose(c)}
+            className="flex h-12 w-12 items-center justify-center rounded border border-border bg-background text-3xl hover:bg-muted"
+            aria-label={`Promote to ${c.toUpperCase()}`}
+          >
+            <span className={color === 'w' ? 'text-white drop-shadow-sm' : 'text-black drop-shadow-sm'}>
+              {PIECE_GLYPH[color][c]}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function pieceAt(board: BoardSnapshot, sq: ChessSquare) {
+  const file = sq.charCodeAt(0) - 97
+  const rank = 8 - parseInt(sq.charAt(1), 10)
+  return board[rank]?.[file] ?? null
+}
+
+function pieceAtFenIndex(
+  board: BoardSnapshot,
+  file: (typeof FILES)[number],
+  rank: (typeof RANKS)[number],
+) {
+  return pieceAt(board, `${file}${rank}` as ChessSquare)
+}

--- a/src/ui/src/dashboard/widgets/ChessBoard.tsx
+++ b/src/ui/src/dashboard/widgets/ChessBoard.tsx
@@ -39,9 +39,24 @@ import {
 const FILES = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] as const
 const RANKS = ['8', '7', '6', '5', '4', '3', '2', '1'] as const
 
+// Both colours render the same filled Unicode silhouettes
+// (U+265A–U+265F). The outlined "white" glyphs (♔♕♖♗♘♙) render as
+// hollow shapes that read as thin/spindly at widget cell sizes, so
+// we use the solid versions for both and let `text-white` /
+// `text-black` + a contrast halo carry the colour. End result: white
+// and black pieces have the same shape, only the fill differs — what
+// chess.com / Lichess do.
+const FILLED_GLYPH: Record<ChessPieceType, string> = {
+  k: '♚',
+  q: '♛',
+  r: '♜',
+  b: '♝',
+  n: '♞',
+  p: '♟',
+}
 const PIECE_GLYPH: Record<ChessColor, Record<ChessPieceType, string>> = {
-  w: { k: '♔', q: '♕', r: '♖', b: '♗', n: '♘', p: '♙' },
-  b: { k: '♚', q: '♛', r: '♜', b: '♝', n: '♞', p: '♟' },
+  w: FILLED_GLYPH,
+  b: FILLED_GLYPH,
 }
 
 /** Square is "light" if (file + rank) is even, "dark" otherwise. */
@@ -213,7 +228,12 @@ export function ChessBoard(props: ChessBoardProps) {
                       'pointer-events-none drop-shadow-sm',
                       piece.color === 'w' ? 'text-white' : 'text-black',
                     )}
-                    style={{ textShadow: piece.color === 'w' ? '0 0 2px rgba(0,0,0,0.7)' : '0 0 2px rgba(255,255,255,0.5)' }}
+                    style={{
+                      textShadow:
+                        piece.color === 'w'
+                          ? '0 0 1px #000, 0 0 1px #000, 0 0 2px rgba(0,0,0,0.9)'
+                          : '0 0 1px rgba(255,255,255,0.6), 0 0 2px rgba(255,255,255,0.4)',
+                    }}
                   >
                     {PIECE_GLYPH[piece.color][piece.type]}
                   </span>

--- a/src/ui/src/dashboard/widgets/ChessPanel.tsx
+++ b/src/ui/src/dashboard/widgets/ChessPanel.tsx
@@ -1,0 +1,768 @@
+/**
+ * ChessPanel — single-player chess widget.
+ *
+ * You vs. one of two opponents:
+ *   - "bot": built-in minimax (depth from the level slider, 1..4),
+ *     runs in a Web Worker so the UI stays responsive.
+ *   - "llm": delegates each bot move to `POST /api/v4/games/chess/llm-move`,
+ *     which routes through `src/mcp/llm.go` and falls back to a
+ *     server-side minimax if the LLM returns garbage. The toggle is
+ *     shown only when `fetchChessLLMStatus()` reports `{enabled: true}`.
+ *
+ * Features (MVP):
+ *   - Time controls: Untimed / Bullet 1+0 / Blitz 3+2 / Rapid 10+5.
+ *     Server-grade Fischer increment, ticked from the client (single
+ *     player only — no anti-cheat needed here).
+ *   - Side choice (white / black / random), board auto-flips for black.
+ *   - Level slider (1..4) — used by bot mode and as the fallback depth
+ *     hint in LLM mode.
+ *   - Takeback: in bot mode pops two plies (your move + bot's reply);
+ *     in LLM mode same logic.
+ *   - PGN export to clipboard; localStorage persistence of an
+ *     in-progress game across reloads.
+ *   - End-of-game overlay (mate / stalemate / 3fold / 50-move /
+ *     insufficient material / resigned / flag).
+ *
+ * Out of scope for this widget — see `NetChessPanel` for 2-player.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import {
+  fetchChessLLMStatus,
+  postChessLLMMove,
+  type ChessLLMMoveResponse,
+} from '@/api'
+import { ChessBoard } from './ChessBoard'
+import { ZoomControls } from './ZoomControls'
+import { readZoom, writeZoom } from './gameZoomStorage'
+import { useArenaCellSize } from './useArenaCellSize'
+import {
+  type ChessColor,
+  type ChessSquare,
+  type GameStatus,
+  type SanMove,
+  type UciMove,
+  STARTING_FEN,
+  fromPGN,
+  newGame,
+  parseUci,
+  snapshot,
+  status,
+  toPGN,
+  tryMove,
+  turn,
+  undoMove,
+} from './chessCore'
+
+const CHESS_GAME_ID = 'chess'
+const PERSIST_KEY = 'homer_chess_state_v1'
+
+const BOARD_CHROME_PX = 10
+const CELL_MIN_PX = 22
+const CELL_MAX_PX = 64
+const SIDEBAR_PX = 220
+
+type TimeControlId = 'untimed' | 'bullet' | 'blitz' | 'rapid'
+
+interface TimeControl {
+  id: TimeControlId
+  label: string
+  initialMs: number
+  incrementMs: number
+}
+
+const TIME_CONTROLS: Record<TimeControlId, TimeControl> = {
+  untimed: { id: 'untimed', label: 'Untimed', initialMs: 0, incrementMs: 0 },
+  bullet:  { id: 'bullet',  label: 'Bullet 1+0', initialMs: 60_000,   incrementMs: 0 },
+  blitz:   { id: 'blitz',   label: 'Blitz 3+2',  initialMs: 180_000,  incrementMs: 2_000 },
+  rapid:   { id: 'rapid',   label: 'Rapid 10+5', initialMs: 600_000,  incrementMs: 5_000 },
+}
+
+type Mode = 'bot' | 'llm'
+type SidePref = 'white' | 'black' | 'random'
+
+interface PersistedState {
+  pgn: string
+  playerColor: ChessColor
+  timeControlId: TimeControlId
+  whiteMs: number
+  blackMs: number
+  level: number
+  mode: Mode
+}
+
+function readPersisted(): PersistedState | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = localStorage.getItem(PERSIST_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<PersistedState>
+    if (typeof parsed.pgn !== 'string') return null
+    return {
+      pgn: parsed.pgn,
+      playerColor: parsed.playerColor === 'b' ? 'b' : 'w',
+      timeControlId:
+        parsed.timeControlId && (TIME_CONTROLS as Record<string, TimeControl>)[parsed.timeControlId]
+          ? (parsed.timeControlId as TimeControlId)
+          : 'untimed',
+      whiteMs: typeof parsed.whiteMs === 'number' ? parsed.whiteMs : 0,
+      blackMs: typeof parsed.blackMs === 'number' ? parsed.blackMs : 0,
+      level: typeof parsed.level === 'number' ? clampLevel(parsed.level) : 3,
+      mode: parsed.mode === 'llm' ? 'llm' : 'bot',
+    }
+  } catch {
+    return null
+  }
+}
+
+function writePersisted(s: PersistedState) {
+  if (typeof window === 'undefined') return
+  try { localStorage.setItem(PERSIST_KEY, JSON.stringify(s)) } catch { /* ignore */ }
+}
+
+function clearPersisted() {
+  if (typeof window === 'undefined') return
+  try { localStorage.removeItem(PERSIST_KEY) } catch { /* ignore */ }
+}
+
+function clampLevel(n: number): number {
+  return Math.min(4, Math.max(1, Math.floor(n)))
+}
+
+function formatClock(ms: number): string {
+  if (ms <= 0) return '0:00'
+  const totalSec = Math.ceil(ms / 1000)
+  const m = Math.floor(totalSec / 60)
+  const s = totalSec % 60
+  return `${m}:${s.toString().padStart(2, '0')}`
+}
+
+interface EngineMessageIn {
+  id: number
+  fen: string
+  depth: number
+}
+interface EngineMessageOut {
+  id: number
+  uci: string | null
+  evalCp?: number
+  pv?: string[]
+  error?: string
+}
+
+export default function ChessPanel() {
+  // --- Persisted setup --------------------------------------------------
+  const initialPersisted = useMemo(readPersisted, [])
+
+  const [timeControlId, setTimeControlId] = useState<TimeControlId>(
+    initialPersisted?.timeControlId ?? 'untimed',
+  )
+  const timeControl = TIME_CONTROLS[timeControlId]
+
+  const [playerColor, setPlayerColor] = useState<ChessColor>(
+    initialPersisted?.playerColor ?? 'w',
+  )
+  const [sidePref, setSidePref] = useState<SidePref>('white')
+  const [level, setLevel] = useState<number>(initialPersisted?.level ?? 3)
+  const [mode, setMode] = useState<Mode>(initialPersisted?.mode ?? 'bot')
+
+  // --- LLM availability (polled once on mount) --------------------------
+  const [llmAvailable, setLlmAvailable] = useState(false)
+  const [llmModel, setLlmModel] = useState<string>('')
+  const [lastMoveSource, setLastMoveSource] = useState<'player' | 'bot' | 'llm' | 'fallback' | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    fetchChessLLMStatus()
+      .then((s) => {
+        if (cancelled) return
+        setLlmAvailable(!!s.enabled)
+        setLlmModel(s.model ?? '')
+        // If we restored persisted mode=llm but the server says LLM
+        // is now disabled, drop back to bot so the widget keeps
+        // making moves.
+        if (!s.enabled) setMode('bot')
+      })
+      .catch(() => { /* treated as disabled */ })
+    return () => { cancelled = true }
+  }, [])
+
+  // --- Game state -------------------------------------------------------
+  const gameRef = useRef(newGame())
+  const [fen, setFen] = useState(STARTING_FEN)
+  const [history, setHistory] = useState<SanMove[]>([])
+  const [gameStatus, setGameStatus] = useState<GameStatus>('ongoing')
+  const [lastMove, setLastMove] = useState<{ from: ChessSquare; to: ChessSquare } | null>(null)
+  const [resigned, setResigned] = useState<'white' | 'black' | null>(null)
+  const [flagged, setFlagged] = useState<'white' | 'black' | null>(null)
+  const [thinking, setThinking] = useState(false)
+  const [banner, setBanner] = useState('')
+  const bannerTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // --- Clocks -----------------------------------------------------------
+  const [whiteMs, setWhiteMs] = useState<number>(initialPersisted?.whiteMs ?? timeControl.initialMs)
+  const [blackMs, setBlackMs] = useState<number>(initialPersisted?.blackMs ?? timeControl.initialMs)
+  const whiteRef = useRef(whiteMs)
+  const blackRef = useRef(blackMs)
+  useEffect(() => { whiteRef.current = whiteMs }, [whiteMs])
+  useEffect(() => { blackRef.current = blackMs }, [blackMs])
+
+  // Game-active flag derives from status — clocks tick only while ongoing
+  // and history is non-empty (so the first move starts the clock).
+  const gameOver = gameStatus !== 'ongoing' || resigned !== null || flagged !== null
+
+  // --- Hydrate from persisted PGN once on mount -------------------------
+  useEffect(() => {
+    if (!initialPersisted) return
+    try {
+      const { game, history: h } = fromPGN(initialPersisted.pgn)
+      gameRef.current = game
+      setFen(game.fen())
+      setHistory(h)
+      const last = h[h.length - 1]
+      if (last) setLastMove({ from: last.from, to: last.to })
+      setGameStatus(status(game))
+    } catch {
+      // Corrupt persisted state — wipe.
+      clearPersisted()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // --- Worker management ------------------------------------------------
+  const workerRef = useRef<Worker | null>(null)
+  const pendingReqId = useRef(0)
+  const ensureWorker = useCallback(() => {
+    if (workerRef.current) return workerRef.current
+    try {
+      const w: Worker = new Worker(new URL('./chessEngine.worker.ts', import.meta.url), { type: 'module' })
+      workerRef.current = w
+      return w
+    } catch {
+      workerRef.current = null
+      return null
+    }
+  }, [])
+  const terminateWorker = useCallback(() => {
+    if (workerRef.current) {
+      workerRef.current.terminate()
+      workerRef.current = null
+    }
+  }, [])
+  useEffect(() => () => terminateWorker(), [terminateWorker])
+
+  // --- Sizing -----------------------------------------------------------
+  const wrapRef = useRef<HTMLDivElement | null>(null)
+  const [zoom, setZoom] = useState<number>(() => readZoom(CHESS_GAME_ID))
+  const { cellPx } = useArenaCellSize(8, 8, {
+    containerRef: wrapRef,
+    reserveWidth: BOARD_CHROME_PX,
+    reserveHeight: BOARD_CHROME_PX,
+    min: CELL_MIN_PX,
+    max: CELL_MAX_PX,
+    zoom,
+  })
+
+  // --- Banner -----------------------------------------------------------
+  const showBanner = useCallback((msg: string) => {
+    setBanner(msg)
+    if (bannerTimer.current) clearTimeout(bannerTimer.current)
+    bannerTimer.current = setTimeout(() => setBanner(''), 1600)
+  }, [])
+
+  // --- Persist on every history / clock change --------------------------
+  useEffect(() => {
+    if (history.length === 0 && !resigned && !flagged) {
+      clearPersisted()
+      return
+    }
+    writePersisted({
+      pgn: toPGN(gameRef.current),
+      playerColor,
+      timeControlId,
+      whiteMs: whiteRef.current,
+      blackMs: blackRef.current,
+      level,
+      mode,
+    })
+  }, [history, playerColor, timeControlId, level, mode, resigned, flagged])
+
+  // --- Apply a move (player or engine) ----------------------------------
+  const applyMove = useCallback(
+    (move: UciMove, source: 'player' | 'engine'): SanMove | null => {
+      const result = tryMove(gameRef.current, move)
+      if (!result) return null
+      setFen(gameRef.current.fen())
+      setHistory((prev) => [...prev, result])
+      setLastMove({ from: result.from, to: result.to })
+      const newStatus = status(gameRef.current)
+      setGameStatus(newStatus)
+      // Fischer increment after each completed half-move.
+      if (timeControl.incrementMs > 0) {
+        if (result.color === 'w') setWhiteMs((v) => v + timeControl.incrementMs)
+        else setBlackMs((v) => v + timeControl.incrementMs)
+      }
+      if (source === 'player') setLastMoveSource('player')
+      else if (mode === 'bot') setLastMoveSource('bot')
+      // 'llm' / 'fallback' are set in requestEngineMove based on the
+      // server's source bit — leave whatever was set there.
+      if (newStatus === 'checkmate') {
+        showBanner(source === 'player' ? 'Checkmate — you win' : 'Checkmate — bot wins')
+      } else if (newStatus !== 'ongoing') {
+        showBanner(`Game over — ${humanStatus(newStatus)}`)
+      } else if (result.isCheck) {
+        showBanner('Check')
+      }
+      return result
+    },
+    [timeControl.incrementMs, showBanner, mode],
+  )
+
+  // --- Engine turn ------------------------------------------------------
+  const requestEngineMove = useCallback(() => {
+    if (gameOver) return
+    if (turn(gameRef.current) === playerColor) return // not the engine's turn
+    setThinking(true)
+    const id = ++pendingReqId.current
+    if (mode === 'bot') {
+      const worker = ensureWorker()
+      if (!worker) {
+        // No worker available — fall back to synchronous engine.
+        import('./chessEngine').then(({ search }) => {
+          const r = search(gameRef.current.fen(), { depth: clampLevel(level) })
+          if (id !== pendingReqId.current) return
+          if (r.uci) {
+            const parsed = parseUci(r.uci)
+            if (parsed) applyMove(parsed, 'engine')
+          }
+          setThinking(false)
+        })
+        return
+      }
+      const msg: EngineMessageIn = { id, fen: gameRef.current.fen(), depth: clampLevel(level) }
+      worker.onmessage = (e: MessageEvent<EngineMessageOut>) => {
+        if (e.data.id !== id) return
+        setThinking(false)
+        if (!e.data.uci) return
+        const parsed = parseUci(e.data.uci)
+        if (parsed) applyMove(parsed, 'engine')
+      }
+      worker.postMessage(msg)
+    } else {
+      // LLM mode: ask the server. The server validates the model's
+      // answer and falls back to its own greedy picker on failure,
+      // so the response always carries a legal UCI for non-terminal
+      // positions. We surface the `source` indicator in the status
+      // pill so the user knows whether the LLM or the fallback
+      // moved this turn.
+      postChessLLMMove({
+        fen: gameRef.current.fen(),
+        history_pgn: toPGN(gameRef.current),
+        level: clampLevel(level),
+      })
+        .then((resp: ChessLLMMoveResponse) => {
+          if (id !== pendingReqId.current) return
+          setThinking(false)
+          if (!resp.uci) return
+          const parsed = parseUci(resp.uci)
+          if (!parsed) return
+          setLastMoveSource(resp.source === 'llm' ? 'llm' : 'fallback')
+          applyMove(parsed, 'engine')
+        })
+        .catch(() => {
+          if (id !== pendingReqId.current) return
+          // Network / 5xx — fall back to the local worker so the
+          // game can keep going.
+          setThinking(false)
+          setLastMoveSource('fallback')
+          const worker = ensureWorker()
+          if (!worker) return
+          const msg: EngineMessageIn = { id, fen: gameRef.current.fen(), depth: clampLevel(level) }
+          worker.onmessage = (e: MessageEvent<EngineMessageOut>) => {
+            if (e.data.id !== id) return
+            if (!e.data.uci) return
+            const parsed = parseUci(e.data.uci)
+            if (parsed) applyMove(parsed, 'engine')
+          }
+          worker.postMessage(msg)
+        })
+    }
+  }, [applyMove, ensureWorker, gameOver, level, mode, playerColor])
+
+  // After every history change, ask the engine if it's now its turn.
+  useEffect(() => {
+    if (gameOver) return
+    if (turn(gameRef.current) !== playerColor) {
+      // small delay so the user perceives that the engine "thinks"
+      const t = setTimeout(() => requestEngineMove(), 120)
+      return () => clearTimeout(t)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [history, playerColor, gameOver])
+
+  // --- Clock tick -------------------------------------------------------
+  useEffect(() => {
+    if (timeControl.initialMs === 0) return // untimed
+    if (gameOver) return
+    if (history.length === 0) return // clock starts on the first move
+    const interval = setInterval(() => {
+      const side = turn(gameRef.current)
+      if (side === 'w') {
+        const next = Math.max(0, whiteRef.current - 100)
+        whiteRef.current = next
+        setWhiteMs(next)
+        if (next <= 0) setFlagged('white')
+      } else {
+        const next = Math.max(0, blackRef.current - 100)
+        blackRef.current = next
+        setBlackMs(next)
+        if (next <= 0) setFlagged('black')
+      }
+    }, 100)
+    return () => clearInterval(interval)
+  }, [timeControl.initialMs, gameOver, history.length])
+
+  // --- Player move ------------------------------------------------------
+  const onBoardMove = useCallback(
+    (move: UciMove) => {
+      if (gameOver) return
+      if (turn(gameRef.current) !== playerColor) return
+      applyMove(move, 'player')
+    },
+    [applyMove, gameOver, playerColor],
+  )
+
+  // --- New game --------------------------------------------------------
+  const newSession = useCallback(() => {
+    pendingReqId.current++ // invalidate any in-flight engine result
+    terminateWorker()
+    gameRef.current = newGame()
+    setFen(STARTING_FEN)
+    setHistory([])
+    setGameStatus('ongoing')
+    setLastMove(null)
+    setResigned(null)
+    setFlagged(null)
+    setThinking(false)
+    let color: ChessColor
+    if (sidePref === 'white') color = 'w'
+    else if (sidePref === 'black') color = 'b'
+    else color = Math.random() < 0.5 ? 'w' : 'b'
+    setPlayerColor(color)
+    const fresh = TIME_CONTROLS[timeControlId]
+    setWhiteMs(fresh.initialMs)
+    setBlackMs(fresh.initialMs)
+    whiteRef.current = fresh.initialMs
+    blackRef.current = fresh.initialMs
+    clearPersisted()
+  }, [sidePref, terminateWorker, timeControlId])
+
+  // --- Resign -----------------------------------------------------------
+  const resign = useCallback(() => {
+    if (gameOver) return
+    pendingReqId.current++
+    setResigned(playerColor === 'w' ? 'white' : 'black')
+    showBanner('You resigned')
+  }, [gameOver, playerColor, showBanner])
+
+  // --- Takeback ---------------------------------------------------------
+  const takeback = useCallback(() => {
+    if (history.length === 0) return
+    pendingReqId.current++ // cancel any in-flight engine reply
+    // Pop one ply, and if it's now the engine's turn, pop another so
+    // the player is on move again.
+    let popped = 0
+    if (undoMove(gameRef.current)) popped++
+    if (popped === 1 && !gameOver && turn(gameRef.current) !== playerColor) {
+      if (undoMove(gameRef.current)) popped++
+    }
+    if (popped === 0) return
+    setFen(gameRef.current.fen())
+    setHistory((prev) => prev.slice(0, Math.max(0, prev.length - popped)))
+    const last = gameRef.current.history({ verbose: true }).slice(-1)[0]
+    setLastMove(last ? { from: last.from as ChessSquare, to: last.to as ChessSquare } : null)
+    setGameStatus(status(gameRef.current))
+    setResigned(null)
+    setFlagged(null)
+    showBanner(`Takeback (${popped} ${popped === 1 ? 'ply' : 'plies'})`)
+  }, [gameOver, history.length, playerColor, showBanner])
+
+  // --- PGN export -------------------------------------------------------
+  const exportPgn = useCallback(async () => {
+    const pgn = toPGN(gameRef.current, {
+      Event: 'Homer dashboard chess',
+      White: playerColor === 'w' ? 'Player' : (mode === 'llm' ? 'LLM' : 'Bot'),
+      Black: playerColor === 'b' ? 'Player' : (mode === 'llm' ? 'LLM' : 'Bot'),
+      Result:
+        gameStatus === 'checkmate'
+          ? turn(gameRef.current) === 'w' ? '0-1' : '1-0'
+          : resigned
+          ? resigned === 'white' ? '0-1' : '1-0'
+          : flagged
+          ? flagged === 'white' ? '0-1' : '1-0'
+          : gameStatus === 'ongoing' ? '*' : '1/2-1/2',
+    })
+    try {
+      await navigator.clipboard?.writeText(pgn)
+      showBanner('PGN copied to clipboard')
+    } catch {
+      // Fallback — open a textarea-style banner. For now just keep it short.
+      showBanner('PGN ready (clipboard blocked)')
+    }
+  }, [flagged, gameStatus, mode, playerColor, resigned, showBanner])
+
+  const handleZoomChange = useCallback((next: number) => {
+    setZoom(writeZoom(CHESS_GAME_ID, next))
+  }, [])
+
+  // --- Derived display --------------------------------------------------
+  const flipped = playerColor === 'b'
+  // checkSquare is derived from `fen` so React invalidates the memo on
+  // every position change; we parse `fen` again here (rather than
+  // touching `gameRef.current`) so the dependency list and the code
+  // line up — keeps the react-hooks/exhaustive-deps rule happy and
+  // makes the function safe even if `gameRef` drifts.
+  const checkSquare = useMemo<ChessSquare | null>(() => {
+    try {
+      const g = newGame(fen)
+      if (!g.isCheck()) return null
+      const side = turn(g)
+      const board = snapshot(g)
+      for (const row of board) {
+        for (const cell of row) {
+          if (cell && cell.type === 'k' && cell.color === side) return cell.square
+        }
+      }
+    } catch { /* ignore unparseable fens */ }
+    return null
+  }, [fen])
+
+  const sideToMove = turn(gameRef.current)
+  const movableColor = playerColor
+
+  const endLabel = useMemo(() => {
+    if (resigned) return `${resigned === 'white' ? 'White' : 'Black'} resigned`
+    if (flagged) return `${flagged === 'white' ? 'White' : 'Black'} flagged on time`
+    if (gameStatus === 'ongoing') return ''
+    return humanStatus(gameStatus)
+  }, [flagged, gameStatus, resigned])
+
+  return (
+    <div className="flex h-full min-h-0 select-none flex-col font-mono text-xs text-foreground">
+      {/* Top bar */}
+      <div className="mb-1 flex flex-wrap items-center gap-2 gap-y-1 border-b border-border/60 pb-1">
+        <Pill
+          label="Status"
+          value={
+            gameOver
+              ? endLabel || 'Game over'
+              : sideToMove === playerColor
+              ? 'Your move'
+              : thinking
+              ? (mode === 'llm' ? `${llmModel || 'LLM'} thinking…` : 'Bot thinking…')
+              : (mode === 'llm' ? 'LLM to move' : 'Bot to move')
+          }
+        />
+        <Pill label="You" value={playerColor === 'w' ? 'White' : 'Black'} />
+        <Pill label="Moves" value={String(Math.ceil(history.length / 2))} />
+        {lastMoveSource === 'fallback' && mode === 'llm' && (
+          <span
+            className="rounded-md border border-amber-500/60 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold text-amber-700 dark:text-amber-400"
+            title="LLM returned an invalid move — server fallback engine played this turn"
+          >
+            fallback
+          </span>
+        )}
+
+        <div className="min-w-[4px] flex-1" />
+
+        <select
+          aria-label="Time control"
+          className="h-8 rounded border border-border bg-card/60 px-1 text-xs"
+          value={timeControlId}
+          onChange={(e) => setTimeControlId(e.target.value as TimeControlId)}
+          disabled={history.length > 0 && !gameOver}
+          title="Time control — new game required to apply"
+        >
+          {Object.values(TIME_CONTROLS).map((tc) => (
+            <option key={tc.id} value={tc.id}>{tc.label}</option>
+          ))}
+        </select>
+
+        <select
+          aria-label="Side"
+          className="h-8 rounded border border-border bg-card/60 px-1 text-xs"
+          value={sidePref}
+          onChange={(e) => setSidePref(e.target.value as SidePref)}
+          title="Side for the next new game"
+        >
+          <option value="white">White</option>
+          <option value="black">Black</option>
+          <option value="random">Random</option>
+        </select>
+
+        <label className="flex items-center gap-1 text-[10px] text-muted-foreground" title="Engine search depth">
+          Level
+          <input
+            type="range"
+            min={1}
+            max={4}
+            value={level}
+            onChange={(e) => setLevel(clampLevel(Number(e.target.value)))}
+            className="h-1 w-16"
+          />
+          <span className="tabular-nums text-foreground">{level}</span>
+        </label>
+
+        {llmAvailable && (
+          <div className="flex items-center gap-1" title="Opponent source">
+            <Button
+              size="sm"
+              variant={mode === 'bot' ? 'default' : 'outline'}
+              className="h-8 px-2 text-xs"
+              onClick={() => setMode('bot')}
+            >
+              Bot
+            </Button>
+            <Button
+              size="sm"
+              variant={mode === 'llm' ? 'default' : 'outline'}
+              className="h-8 px-2 text-xs"
+              onClick={() => setMode('llm')}
+            >
+              LLM
+            </Button>
+          </div>
+        )}
+
+        <ZoomControls zoom={zoom} onZoomChange={handleZoomChange} title="Board zoom" />
+
+        <Button size="sm" variant="secondary" className="h-8 px-2 text-xs" onClick={newSession}>
+          New game
+        </Button>
+        <Button size="sm" variant="outline" className="h-8 px-2 text-xs" onClick={takeback} disabled={history.length === 0}>
+          Takeback
+        </Button>
+        <Button size="sm" variant="outline" className="h-8 px-2 text-xs" onClick={resign} disabled={gameOver || history.length === 0}>
+          Resign
+        </Button>
+        <Button size="sm" variant="outline" className="h-8 px-2 text-xs" onClick={exportPgn} disabled={history.length === 0}>
+          Export PGN
+        </Button>
+      </div>
+
+      {/* Main: board + sidebar */}
+      <div className="flex min-h-0 flex-1 items-stretch gap-3 overflow-hidden">
+        <div
+          ref={wrapRef}
+          className="flex min-h-0 min-w-0 flex-1 items-center justify-center overflow-auto"
+        >
+          <div className="relative">
+            <ChessBoard
+              fen={fen}
+              cellPx={cellPx}
+              flipped={flipped}
+              interactive={!gameOver && sideToMove === playerColor}
+              movableColor={movableColor}
+              lastMove={lastMove ?? undefined}
+              checkSquare={checkSquare ?? undefined}
+              onMove={onBoardMove}
+            />
+            {banner && (
+              <div className="pointer-events-none absolute left-1/2 top-2 z-30 -translate-x-1/2 whitespace-nowrap rounded-md border border-border bg-card px-3 py-1 text-[11px] font-medium shadow-sm">
+                {banner}
+              </div>
+            )}
+            {gameOver && (
+              <div className="absolute inset-0 z-40 flex items-center justify-center rounded-md bg-background/60">
+                <div className="max-w-xs rounded-lg border border-border bg-card p-4 text-center shadow-lg">
+                  <div className="text-base font-semibold">Game over</div>
+                  <div className="mt-1 text-muted-foreground">{endLabel}</div>
+                  <Button size="sm" className="mt-3" onClick={newSession}>New game</Button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div
+          className="flex min-h-0 shrink-0 flex-col gap-2 overflow-hidden"
+          style={{ width: SIDEBAR_PX }}
+        >
+          <div className="flex gap-2">
+            <ClockCard label="White" ms={whiteMs} active={!gameOver && sideToMove === 'w' && history.length > 0} timed={timeControl.initialMs > 0} />
+            <ClockCard label="Black" ms={blackMs} active={!gameOver && sideToMove === 'b' && history.length > 0} timed={timeControl.initialMs > 0} />
+          </div>
+
+          <div className="flex min-h-0 flex-1 flex-col rounded-lg border border-border bg-card/60 p-1.5">
+            <div className="mb-0.5 text-[9px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Move list
+            </div>
+            <div className="min-h-0 flex-1 overflow-auto pr-0.5">
+              {history.length === 0 ? (
+                <div className="text-[10px] italic text-muted-foreground">No moves yet.</div>
+              ) : (
+                <ol className="space-y-0.5 text-[11px]">
+                  {pairMoves(history).map((pair, i) => (
+                    <li key={i} className="flex gap-1 tabular-nums">
+                      <span className="w-6 shrink-0 text-muted-foreground">{i + 1}.</span>
+                      <span className="w-14 shrink-0">{pair[0]?.san ?? ''}</span>
+                      <span className="w-14 shrink-0">{pair[1]?.san ?? ''}</span>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Pill({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border bg-card/60 px-2 py-0.5">
+      <div className="text-[9px] uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className="text-xs font-semibold leading-tight">{value}</div>
+    </div>
+  )
+}
+
+function ClockCard({ label, ms, active, timed }: { label: string; ms: number; active: boolean; timed: boolean }) {
+  return (
+    <div
+      className={cn(
+        'flex-1 rounded-md border px-2 py-1 text-center',
+        active ? 'border-primary/70 bg-primary/10' : 'border-border bg-card/60',
+      )}
+    >
+      <div className="text-[9px] uppercase tracking-wider text-muted-foreground">{label}</div>
+      <div className="text-lg font-bold tabular-nums leading-tight">
+        {timed ? formatClock(ms) : '∞'}
+      </div>
+    </div>
+  )
+}
+
+function pairMoves(h: SanMove[]): [SanMove | undefined, SanMove | undefined][] {
+  const out: [SanMove | undefined, SanMove | undefined][] = []
+  for (let i = 0; i < h.length; i += 2) {
+    out.push([h[i], h[i + 1]])
+  }
+  return out
+}
+
+function humanStatus(s: GameStatus): string {
+  switch (s) {
+    case 'ongoing': return 'in progress'
+    case 'checkmate': return 'checkmate'
+    case 'stalemate': return 'stalemate'
+    case 'draw_50': return 'draw by 50-move rule'
+    case 'draw_3fold': return 'draw by threefold repetition'
+    case 'draw_insufficient': return 'draw by insufficient material'
+    case 'draw': return 'draw'
+    default: return s
+  }
+}

--- a/src/ui/src/dashboard/widgets/ChessPanel.tsx
+++ b/src/ui/src/dashboard/widgets/ChessPanel.tsx
@@ -60,8 +60,14 @@ const CHESS_GAME_ID = 'chess'
 const PERSIST_KEY = 'homer_chess_state_v1'
 
 const BOARD_CHROME_PX = 10
-const CELL_MIN_PX = 22
-const CELL_MAX_PX = 64
+// 8x8 boards reach the auto-fit ceiling far earlier than the 10x20
+// Tetris-style arenas this hook was designed for. Keep the floor low
+// enough to honour ZOOM_MIN=0.5 even on tiny widgets, and the ceiling
+// high enough that ZOOM_MAX=2.0 on a typical widget produces a
+// visibly larger board (the wrapper scrolls when the result exceeds
+// the container).
+const CELL_MIN_PX = 16
+const CELL_MAX_PX = 160
 const SIDEBAR_PX = 220
 
 type TimeControlId = 'untimed' | 'bullet' | 'blitz' | 'rapid'

--- a/src/ui/src/dashboard/widgets/NetChessPanel.tsx
+++ b/src/ui/src/dashboard/widgets/NetChessPanel.tsx
@@ -1,0 +1,767 @@
+/**
+ * NetChessPanel — two-player chess over a coordinator-hosted WebSocket.
+ *
+ * Architectural contrast with `NetrisPanel`:
+ *   - Server is **authoritative** (`src/coordinator/games/netchess`):
+ *     it holds the `*notnil/chess.Game`, validates every move,
+ *     manages the clocks, and emits game-over frames.
+ *   - The widget renders whatever FEN the server hands it. It does
+ *     not run its own chess engine; the only client-side validation
+ *     is via `chess.js` and is purely cosmetic (highlight legal
+ *     destinations on click).
+ *
+ * Lifecycle states:
+ *   idle    → lobby controls (Quick / Room / time control / colour)
+ *   connecting → socket open in flight
+ *   waiting → matched message received with no opponent
+ *   matched → opponent present, both need to send `ready`
+ *   playing → server broadcast `start`
+ *   won/lost/draw → `game_over` received
+ *   closed  → disconnect without finishing
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+import {
+  openNetChessSocket,
+  type NetChessMessage,
+  type NetChessSocket,
+  type NetChessSocketState,
+} from '@/api'
+import { ChessBoard } from './ChessBoard'
+import { ZoomControls } from './ZoomControls'
+import { readZoom, writeZoom } from './gameZoomStorage'
+import { useArenaCellSize } from './useArenaCellSize'
+import {
+  type ChessColor,
+  type ChessSquare,
+  type UciMove,
+  STARTING_FEN,
+  isValidFen,
+  newGame,
+  snapshot,
+} from './chessCore'
+
+const NETCHESS_GAME_ID = 'netchess'
+
+const BOARD_CHROME_PX = 10
+const CELL_MIN_PX = 22
+const CELL_MAX_PX = 64
+const SIDEBAR_PX = 220
+
+type ConnState =
+  | 'idle'
+  | 'connecting'
+  | 'waiting'
+  | 'matched'
+  | 'playing'
+  | 'won'
+  | 'lost'
+  | 'draw'
+  | 'closed'
+
+interface TimeControlOpt {
+  id: string
+  label: string
+  initialMs: number
+  incrementMs: number
+}
+
+const TIME_CONTROLS: TimeControlOpt[] = [
+  { id: 'bullet', label: 'Bullet 1+0', initialMs: 60_000, incrementMs: 0 },
+  { id: 'blitz', label: 'Blitz 3+2', initialMs: 180_000, incrementMs: 2_000 },
+  { id: 'rapid', label: 'Rapid 10+5', initialMs: 600_000, incrementMs: 5_000 },
+  { id: 'classical', label: 'Classical 30+0', initialMs: 1_800_000, incrementMs: 0 },
+]
+
+function generateRoomCode(): string {
+  const alphabet = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789'
+  let out = ''
+  for (let i = 0; i < 6; i++) out += alphabet.charAt(Math.floor(Math.random() * alphabet.length))
+  return out
+}
+
+function formatClock(ms: number): string {
+  if (ms <= 0) return '0:00'
+  const totalSec = Math.ceil(ms / 1000)
+  const m = Math.floor(totalSec / 60)
+  const s = totalSec % 60
+  return `${m}:${s.toString().padStart(2, '0')}`
+}
+
+interface PgnEntry {
+  ply: number
+  san: string
+}
+
+export default function NetChessPanel() {
+  // --- Lobby setup ------------------------------------------------------
+  const [mode, setMode] = useState<'quick' | 'room' | 'spectate'>('quick')
+  const [roomCode, setRoomCode] = useState('')
+  const [colorPref, setColorPref] = useState<'white' | 'black' | 'random'>('random')
+  const [tcId, setTcId] = useState<string>('blitz')
+  const timeControl = useMemo(
+    () => TIME_CONTROLS.find((t) => t.id === tcId) ?? TIME_CONTROLS[1]!,
+    [tcId],
+  )
+
+  // --- Session state ----------------------------------------------------
+  const [conn, setConnRaw] = useState<ConnState>('idle')
+  const [activeRoom, setActiveRoom] = useState('')
+  const [sockState, setSockState] = useState<NetChessSocketState>('closed')
+  const [youName, setYouName] = useState('')
+  const [oppName, setOppName] = useState('')
+  const [myColor, setMyColor] = useState<ChessColor | null>(null)
+  const [spectator, setSpectator] = useState(false)
+  const [serverInitialMs, setServerInitialMs] = useState(0)
+  // serverIncrementMs is sent in `matched` but we currently only use
+  // the server's own clock numbers — keep a state slot for the future
+  // (showing "+5s/move" in the lobby pill) but mark unused for now.
+  const [, setServerIncrementMs] = useState(0)
+
+  // --- Game state (server-authoritative) -------------------------------
+  const [fen, setFen] = useState(STARTING_FEN)
+  const [lastMove, setLastMove] = useState<{ from: ChessSquare; to: ChessSquare } | null>(null)
+  const [moveList, setMoveList] = useState<PgnEntry[]>([])
+  const [whiteMs, setWhiteMs] = useState(0)
+  const [blackMs, setBlackMs] = useState(0)
+  // Local ticking: the server is the source of truth and pushes
+  // clock_sync on every move; between moves the client interpolates
+  // from `lastSyncAt` so the clocks don't appear frozen.
+  const lastSyncAt = useRef<number>(0)
+  const [endReason, setEndReason] = useState('')
+  const [endResult, setEndResult] = useState<'1-0' | '0-1' | '1/2-1/2' | ''>('')
+  const [drawOffered, setDrawOffered] = useState<'them' | 'mine' | null>(null)
+  const [takebackOffered, setTakebackOffered] = useState<'them' | 'mine' | null>(null)
+  const [banner, setBanner] = useState('')
+  const bannerTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // refs for non-React handlers
+  const sockRef = useRef<NetChessSocket | null>(null)
+  const connRef = useRef<ConnState>('idle')
+  const fenRef = useRef(fen)
+  useEffect(() => { fenRef.current = fen }, [fen])
+  useEffect(() => { connRef.current = conn }, [conn])
+  const setConn = useCallback((s: ConnState) => {
+    connRef.current = s
+    setConnRaw(s)
+  }, [])
+
+  // --- Sizing -----------------------------------------------------------
+  const wrapRef = useRef<HTMLDivElement | null>(null)
+  const [zoom, setZoom] = useState<number>(() => readZoom(NETCHESS_GAME_ID))
+  const { cellPx } = useArenaCellSize(8, 8, {
+    containerRef: wrapRef,
+    reserveWidth: BOARD_CHROME_PX,
+    reserveHeight: BOARD_CHROME_PX,
+    min: CELL_MIN_PX,
+    max: CELL_MAX_PX,
+    zoom,
+  })
+  const handleZoomChange = useCallback((next: number) => {
+    setZoom(writeZoom(NETCHESS_GAME_ID, next))
+  }, [])
+
+  const showBanner = useCallback((msg: string) => {
+    setBanner(msg)
+    if (bannerTimer.current) clearTimeout(bannerTimer.current)
+    bannerTimer.current = setTimeout(() => setBanner(''), 1800)
+  }, [])
+
+  // --- Side-to-move derived from FEN -----------------------------------
+  const sideToMove = useMemo<ChessColor>(() => {
+    if (!isValidFen(fen)) return 'w'
+    try {
+      const g = newGame(fen)
+      return g.turn()
+    } catch {
+      return 'w'
+    }
+  }, [fen])
+
+  const checkSquare = useMemo<ChessSquare | null>(() => {
+    if (!isValidFen(fen)) return null
+    try {
+      const g = newGame(fen)
+      if (!g.isCheck()) return null
+      const side = g.turn()
+      const board = snapshot(g)
+      for (const row of board) {
+        for (const cell of row) {
+          if (cell && cell.type === 'k' && cell.color === side) return cell.square
+        }
+      }
+    } catch { /* ignore */ }
+    return null
+  }, [fen])
+
+  // --- Clock interpolation (between server syncs) ----------------------
+  useEffect(() => {
+    if (conn !== 'playing' || serverInitialMs <= 0) return
+    const id = window.setInterval(() => {
+      const now = Date.now()
+      const elapsed = lastSyncAt.current === 0 ? 0 : now - lastSyncAt.current
+      if (sideToMove === 'w') {
+        setWhiteMs((ms) => Math.max(0, ms - elapsed))
+      } else {
+        setBlackMs((ms) => Math.max(0, ms - elapsed))
+      }
+      lastSyncAt.current = now
+    }, 200)
+    return () => window.clearInterval(id)
+  }, [conn, serverInitialMs, sideToMove])
+
+  // --- Server message handler ------------------------------------------
+  const onServerMessage = useCallback(
+    (msg: NetChessMessage) => {
+      switch (msg.type) {
+        case 'matched': {
+          setYouName(msg.you ?? '')
+          setOppName(msg.opponent ?? '')
+          setActiveRoom(msg.room ?? '')
+          setSpectator(!!msg.spectator)
+          if (msg.color === 'white') setMyColor('w')
+          else if (msg.color === 'black') setMyColor('b')
+          else setMyColor(null)
+          if (msg.initial_ms !== undefined) {
+            setServerInitialMs(msg.initial_ms)
+            setWhiteMs(msg.initial_ms)
+            setBlackMs(msg.initial_ms)
+          }
+          if (msg.increment_ms !== undefined) setServerIncrementMs(msg.increment_ms)
+          if (msg.fen && isValidFen(msg.fen)) setFen(msg.fen)
+          if (msg.spectator) {
+            // Spectators jump straight to "playing" (read-only view).
+            setConn(msg.fen ? 'playing' : 'matched')
+          } else if (!msg.opponent) {
+            setConn('waiting')
+          } else {
+            setConn('matched')
+          }
+          break
+        }
+        case 'start': {
+          if (msg.fen && isValidFen(msg.fen)) setFen(msg.fen)
+          if (typeof msg.white_ms === 'number') setWhiteMs(msg.white_ms)
+          if (typeof msg.black_ms === 'number') setBlackMs(msg.black_ms)
+          lastSyncAt.current = Date.now()
+          setConn('playing')
+          setLastMove(null)
+          setMoveList([])
+          setEndReason('')
+          setEndResult('')
+          setDrawOffered(null)
+          setTakebackOffered(null)
+          break
+        }
+        case 'opponent_move': {
+          if (msg.fen && isValidFen(msg.fen)) setFen(msg.fen)
+          if (msg.uci && msg.uci.length >= 4) {
+            setLastMove({
+              from: msg.uci.slice(0, 2) as ChessSquare,
+              to: msg.uci.slice(2, 4) as ChessSquare,
+            })
+          }
+          if (msg.san) {
+            setMoveList((prev) => [...prev, { ply: prev.length, san: msg.san! }])
+          }
+          if (typeof msg.white_ms === 'number') setWhiteMs(msg.white_ms)
+          if (typeof msg.black_ms === 'number') setBlackMs(msg.black_ms)
+          lastSyncAt.current = Date.now()
+          break
+        }
+        case 'clock_sync': {
+          if (msg.fen && isValidFen(msg.fen)) setFen(msg.fen)
+          if (typeof msg.white_ms === 'number') setWhiteMs(msg.white_ms)
+          if (typeof msg.black_ms === 'number') setBlackMs(msg.black_ms)
+          lastSyncAt.current = Date.now()
+          break
+        }
+        case 'game_over': {
+          setEndResult((msg.result as '1-0' | '0-1' | '1/2-1/2') ?? '')
+          setEndReason(msg.reason ?? '')
+          if (typeof msg.white_ms === 'number') setWhiteMs(msg.white_ms)
+          if (typeof msg.black_ms === 'number') setBlackMs(msg.black_ms)
+          // Map result → won / lost / draw.
+          if (spectator || myColor === null) {
+            setConn('draw') // for spectator just leave the overlay on
+          } else if (msg.result === '1/2-1/2') {
+            setConn('draw')
+          } else if (
+            (msg.result === '1-0' && myColor === 'w') ||
+            (msg.result === '0-1' && myColor === 'b')
+          ) {
+            setConn('won')
+          } else {
+            setConn('lost')
+          }
+          break
+        }
+        case 'draw_offered': {
+          setDrawOffered('them')
+          showBanner(`${msg.from || 'Opponent'} offered a draw`)
+          break
+        }
+        case 'takeback_offered': {
+          setTakebackOffered('them')
+          showBanner(`${msg.from || 'Opponent'} requests a takeback`)
+          break
+        }
+        case 'opponent_left': {
+          if (connRef.current === 'matched') {
+            setConn('waiting')
+            setOppName('')
+            showBanner('Opponent left — waiting for another')
+          }
+          break
+        }
+        case 'waiting_timeout': {
+          setConn('closed')
+          setEndReason('no_opponent')
+          break
+        }
+        case 'error': {
+          showBanner(msg.message || 'error')
+          break
+        }
+        default:
+          break
+      }
+    },
+    [myColor, setConn, showBanner, spectator],
+  )
+
+  // --- Connect / disconnect --------------------------------------------
+  const closeSocket = useCallback(() => {
+    sockRef.current?.close()
+    sockRef.current = null
+    setSockState('closed')
+  }, [])
+
+  const startSession = useCallback(() => {
+    closeSocket()
+    setConn('connecting')
+    setOppName('')
+    setYouName('')
+    setActiveRoom(mode === 'room' || mode === 'spectate' ? roomCode.trim() : '')
+    setEndReason('')
+    setEndResult('')
+    setSpectator(false)
+    setMoveList([])
+    setLastMove(null)
+
+    const opts = {
+      quick: mode === 'quick',
+      room: mode === 'room' || mode === 'spectate' ? roomCode.trim() : undefined,
+      spectate: mode === 'spectate',
+      color: colorPref,
+      initialMs: timeControl.initialMs,
+      incrementMs: timeControl.incrementMs,
+    }
+    const sock = openNetChessSocket(opts, {
+      onOpen: () => setSockState('open'),
+      onClose: () => {
+        setSockState('closed')
+        if (connRef.current === 'connecting' || connRef.current === 'waiting' || connRef.current === 'matched') {
+          setConn('closed')
+        }
+      },
+      onError: () => { /* surfaced via state */ },
+      onMessage: onServerMessage,
+    })
+    sockRef.current = sock
+    setSockState('connecting')
+  }, [closeSocket, colorPref, mode, onServerMessage, roomCode, setConn, timeControl.incrementMs, timeControl.initialMs])
+
+  const leaveSession = useCallback(() => {
+    closeSocket()
+    setConn('idle')
+    setOppName('')
+    setYouName('')
+    setActiveRoom('')
+    setMyColor(null)
+    setSpectator(false)
+    setFen(STARTING_FEN)
+    setLastMove(null)
+    setMoveList([])
+    setWhiteMs(0)
+    setBlackMs(0)
+    setEndReason('')
+    setEndResult('')
+    setDrawOffered(null)
+    setTakebackOffered(null)
+  }, [closeSocket, setConn])
+
+  // Cleanup on unmount.
+  useEffect(() => () => {
+    sockRef.current?.close()
+    sockRef.current = null
+    if (bannerTimer.current) clearTimeout(bannerTimer.current)
+  }, [])
+
+  // --- Send helpers ----------------------------------------------------
+  const sendReady = useCallback(() => {
+    sockRef.current?.send({ type: 'ready' })
+    showBanner('Ready — waiting for opponent…')
+  }, [showBanner])
+
+  const onBoardMove = useCallback(
+    (move: UciMove) => {
+      if (conn !== 'playing' || spectator) return
+      if (myColor !== sideToMove) return // not your turn
+      const uci = `${move.from}${move.to}${move.promotion ?? ''}`
+      sockRef.current?.send({ type: 'move', uci })
+    },
+    [conn, myColor, sideToMove, spectator],
+  )
+
+  const resign = useCallback(() => {
+    sockRef.current?.send({ type: 'resign' })
+  }, [])
+  const offerDraw = useCallback(() => {
+    sockRef.current?.send({ type: 'draw_offer' })
+    setDrawOffered('mine')
+    showBanner('Draw offered')
+  }, [showBanner])
+  const acceptDraw = useCallback(() => {
+    sockRef.current?.send({ type: 'draw_accept' })
+    setDrawOffered(null)
+  }, [])
+  const declineDraw = useCallback(() => {
+    sockRef.current?.send({ type: 'draw_decline' })
+    setDrawOffered(null)
+  }, [])
+  const requestTakeback = useCallback(() => {
+    sockRef.current?.send({ type: 'takeback_request' })
+    setTakebackOffered('mine')
+    showBanner('Takeback requested')
+  }, [showBanner])
+  const acceptTakeback = useCallback(() => {
+    sockRef.current?.send({ type: 'takeback_accept' })
+    setTakebackOffered(null)
+  }, [])
+  const declineTakeback = useCallback(() => {
+    sockRef.current?.send({ type: 'takeback_decline' })
+    setTakebackOffered(null)
+  }, [])
+
+  // --- Derived display --------------------------------------------------
+  const flipped = myColor === 'b'
+  const youCanMove = conn === 'playing' && !spectator && myColor === sideToMove
+  const statusLabel = useMemo(() => {
+    switch (conn) {
+      case 'idle': return 'Idle'
+      case 'connecting': return 'Connecting…'
+      case 'waiting': return activeRoom ? `Waiting · room ${activeRoom}` : 'Waiting for opponent…'
+      case 'matched': return `Matched · vs ${oppName || '???'}`
+      case 'playing': return spectator ? 'Spectating' : youCanMove ? 'Your move' : "Opponent's move"
+      case 'won': return `Won · ${endReason}`
+      case 'lost': return `Lost · ${endReason}`
+      case 'draw': return `Draw · ${endReason}`
+      case 'closed': return endReason ? `Disconnected · ${endReason}` : 'Disconnected'
+      default: return conn
+    }
+  }, [activeRoom, conn, endReason, oppName, spectator, youCanMove])
+
+  // Reformat last opponent's SAN history grouped 2-per-row.
+  const pgnRows = useMemo(() => {
+    const rows: { num: number; white?: string; black?: string }[] = []
+    for (let i = 0; i < moveList.length; i += 2) {
+      rows.push({
+        num: i / 2 + 1,
+        white: moveList[i]?.san,
+        black: moveList[i + 1]?.san,
+      })
+    }
+    return rows
+  }, [moveList])
+
+  return (
+    <div className="flex h-full min-h-0 select-none flex-col font-mono text-xs text-foreground">
+      {/* Top bar */}
+      <div className="mb-1 flex flex-wrap items-center gap-2 gap-y-1 border-b border-border/60 pb-1">
+        <span
+          className={cn(
+            'rounded-md border px-2 py-0.5 text-[10px] font-semibold',
+            (conn === 'playing' || conn === 'matched') && 'border-primary/60 bg-primary/10 text-primary',
+            conn === 'won' && 'border-emerald-500/60 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+            conn === 'lost' && 'border-rose-500/60 bg-rose-500/10 text-rose-600 dark:text-rose-400',
+            (conn === 'idle' || conn === 'closed' || conn === 'connecting' || conn === 'waiting' || conn === 'draw') && 'border-border bg-card/60 text-muted-foreground',
+          )}
+        >
+          {statusLabel}
+        </span>
+
+        {myColor && conn !== 'idle' && (
+          <span className="rounded-md border border-border bg-card/60 px-2 py-0.5 text-[10px]">
+            You: <b>{myColor === 'w' ? 'White' : 'Black'}</b>
+          </span>
+        )}
+
+        {activeRoom && (conn === 'waiting' || conn === 'matched' || conn === 'playing') && (
+          <button
+            type="button"
+            title="Click to copy room code"
+            onClick={() => {
+              try {
+                navigator.clipboard?.writeText(activeRoom)
+                showBanner(`Room code copied: ${activeRoom}`)
+              } catch { showBanner(`Room code: ${activeRoom}`) }
+            }}
+            className="rounded-md border border-border bg-card/60 px-2 py-0.5 text-[10px] font-mono uppercase tracking-wider hover:bg-card"
+          >
+            Room: <b>{activeRoom}</b>
+          </button>
+        )}
+
+        <div className="min-w-[4px] flex-1" />
+        <ZoomControls zoom={zoom} onZoomChange={handleZoomChange} title="Board zoom" />
+
+        {conn === 'idle' || conn === 'closed' ? (
+          <LobbyControls
+            mode={mode}
+            setMode={setMode}
+            roomCode={roomCode}
+            setRoomCode={setRoomCode}
+            colorPref={colorPref}
+            setColorPref={setColorPref}
+            tcId={tcId}
+            setTcId={setTcId}
+            onStart={startSession}
+          />
+        ) : (
+          <div className="flex items-center gap-1">
+            {conn === 'matched' && (
+              <Button type="button" size="sm" className="h-8 px-3 text-xs" onClick={sendReady}>
+                Ready
+              </Button>
+            )}
+            {conn === 'playing' && !spectator && (
+              <>
+                <Button size="sm" variant="outline" className="h-8 px-2 text-xs" onClick={offerDraw} disabled={drawOffered === 'mine'}>
+                  {drawOffered === 'mine' ? 'Draw offered' : 'Offer draw'}
+                </Button>
+                <Button size="sm" variant="outline" className="h-8 px-2 text-xs" onClick={requestTakeback} disabled={takebackOffered === 'mine'}>
+                  Takeback
+                </Button>
+                <Button size="sm" variant="outline" className="h-8 px-2 text-xs" onClick={resign}>
+                  Resign
+                </Button>
+              </>
+            )}
+            <Button size="sm" variant="outline" className="h-8 px-3 text-xs" onClick={leaveSession}>
+              {conn === 'won' || conn === 'lost' || conn === 'draw' ? 'Leave' : 'Cancel'}
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {/* Main */}
+      <div className="flex min-h-0 flex-1 items-stretch gap-3 overflow-hidden">
+        <div
+          ref={wrapRef}
+          className="flex min-h-0 min-w-0 flex-1 items-center justify-center overflow-auto"
+        >
+          <div className="relative">
+            <ChessBoard
+              fen={fen}
+              cellPx={cellPx}
+              flipped={flipped}
+              interactive={youCanMove}
+              movableColor={myColor ?? undefined}
+              lastMove={lastMove ?? undefined}
+              checkSquare={checkSquare ?? undefined}
+              onMove={onBoardMove}
+            />
+            {banner && (
+              <div className="pointer-events-none absolute left-1/2 top-2 z-30 -translate-x-1/2 whitespace-nowrap rounded-md border border-border bg-card px-3 py-1 text-[11px] font-medium shadow-sm">
+                {banner}
+              </div>
+            )}
+            {(conn === 'idle' || conn === 'connecting' || conn === 'waiting' || conn === 'matched') && (
+              <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center rounded-md bg-background/55 px-3 text-center text-[11px] text-muted-foreground">
+                <div>
+                  <div className="text-sm font-semibold text-foreground">NetChess</div>
+                  {conn === 'idle' && <div className="mt-1">Pick a mode in the toolbar to start.</div>}
+                  {conn === 'connecting' && <div className="mt-1">Connecting…</div>}
+                  {conn === 'waiting' && (
+                    <div className="mt-1">
+                      Waiting for opponent…{activeRoom ? <> Share code <b>{activeRoom}</b>.</> : null}
+                    </div>
+                  )}
+                  {conn === 'matched' && (
+                    <div className="mt-1">Matched with <b>{oppName || '???'}</b>. Press <b>Ready</b>.</div>
+                  )}
+                </div>
+              </div>
+            )}
+            {(conn === 'won' || conn === 'lost' || conn === 'draw') && (
+              <div className="absolute inset-0 z-30 flex items-center justify-center rounded-md bg-background/60">
+                <div className="max-w-xs rounded-lg border border-border bg-card p-4 text-center shadow-lg">
+                  <div className="text-base font-semibold">
+                    {conn === 'won' ? 'You win' : conn === 'lost' ? 'You lose' : 'Draw'}
+                  </div>
+                  <div className="mt-1 text-muted-foreground">{endResult}{endReason ? ` · ${endReason}` : ''}</div>
+                  <Button size="sm" className="mt-3" onClick={leaveSession}>Back to lobby</Button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Sidebar */}
+        <div
+          className="flex min-h-0 shrink-0 flex-col gap-2 overflow-hidden"
+          style={{ width: SIDEBAR_PX }}
+        >
+          <div className="flex gap-2">
+            <ClockCard label="White" ms={whiteMs} active={conn === 'playing' && sideToMove === 'w'} timed={serverInitialMs > 0} />
+            <ClockCard label="Black" ms={blackMs} active={conn === 'playing' && sideToMove === 'b'} timed={serverInitialMs > 0} />
+          </div>
+
+          {(drawOffered === 'them' || takebackOffered === 'them') && (
+            <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-2 text-[11px]">
+              <div className="mb-1 font-semibold">
+                {drawOffered === 'them' ? 'Draw offered' : 'Takeback requested'}
+              </div>
+              <div className="flex gap-1">
+                <Button size="sm" className="h-7 px-2 text-xs" onClick={drawOffered === 'them' ? acceptDraw : acceptTakeback}>
+                  Accept
+                </Button>
+                <Button size="sm" variant="outline" className="h-7 px-2 text-xs" onClick={drawOffered === 'them' ? declineDraw : declineTakeback}>
+                  Decline
+                </Button>
+              </div>
+            </div>
+          )}
+
+          <div className="flex min-h-0 flex-1 flex-col rounded-lg border border-border bg-card/60 p-1.5">
+            <div className="mb-0.5 text-[9px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Moves
+            </div>
+            <div className="min-h-0 flex-1 overflow-auto pr-0.5">
+              {pgnRows.length === 0 ? (
+                <div className="text-[10px] italic text-muted-foreground">No moves yet.</div>
+              ) : (
+                <ol className="space-y-0.5 text-[11px]">
+                  {pgnRows.map((r) => (
+                    <li key={r.num} className="flex gap-1 tabular-nums">
+                      <span className="w-6 shrink-0 text-muted-foreground">{r.num}.</span>
+                      <span className="w-14 shrink-0">{r.white ?? ''}</span>
+                      <span className="w-14 shrink-0">{r.black ?? ''}</span>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-1 flex items-center justify-between text-[10px] text-muted-foreground">
+        <span>
+          {youName ? <>You: <b className="text-foreground">{youName}</b> · </> : null}
+          {spectator ? 'Spectator view' : 'Click your piece, then a destination · drag-and-drop coming soon'}
+        </span>
+        <span>{sockState === 'open' ? 'WS ●' : sockState === 'connecting' ? 'WS …' : 'WS ○'}</span>
+      </div>
+    </div>
+  )
+}
+
+function LobbyControls(props: {
+  mode: 'quick' | 'room' | 'spectate'
+  setMode: (m: 'quick' | 'room' | 'spectate') => void
+  roomCode: string
+  setRoomCode: (s: string) => void
+  colorPref: 'white' | 'black' | 'random'
+  setColorPref: (c: 'white' | 'black' | 'random') => void
+  tcId: string
+  setTcId: (s: string) => void
+  onStart: () => void
+}) {
+  const { mode, setMode, roomCode, setRoomCode, colorPref, setColorPref, tcId, setTcId, onStart } = props
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      <Button type="button" size="sm" variant={mode === 'quick' ? 'default' : 'outline'} className="h-8 px-2 text-xs" onClick={() => setMode('quick')}>
+        Quick
+      </Button>
+      <Button type="button" size="sm" variant={mode === 'room' ? 'default' : 'outline'} className="h-8 px-2 text-xs" onClick={() => setMode('room')}>
+        Room
+      </Button>
+      <Button type="button" size="sm" variant={mode === 'spectate' ? 'default' : 'outline'} className="h-8 px-2 text-xs" onClick={() => setMode('spectate')}>
+        Spectate
+      </Button>
+      {(mode === 'room' || mode === 'spectate') && (
+        <>
+          <Input
+            value={roomCode}
+            onChange={(e) => setRoomCode(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter' && roomCode.trim() !== '') onStart() }}
+            placeholder="room code"
+            className="h-8 w-32 font-mono"
+            spellCheck={false}
+            autoComplete="off"
+          />
+          {mode === 'room' && (
+            <Button type="button" size="sm" variant="outline" className="h-8 px-2 text-xs" onClick={() => setRoomCode(generateRoomCode())}>
+              Random
+            </Button>
+          )}
+        </>
+      )}
+      {mode !== 'spectate' && (
+        <>
+          <select
+            aria-label="Time control"
+            value={tcId}
+            onChange={(e) => setTcId(e.target.value)}
+            className="h-8 rounded border border-border bg-card/60 px-1 text-xs"
+          >
+            {TIME_CONTROLS.map((t) => (
+              <option key={t.id} value={t.id}>{t.label}</option>
+            ))}
+          </select>
+          <select
+            aria-label="Colour"
+            value={colorPref}
+            onChange={(e) => setColorPref(e.target.value as 'white' | 'black' | 'random')}
+            className="h-8 rounded border border-border bg-card/60 px-1 text-xs"
+          >
+            <option value="random">Random</option>
+            <option value="white">White</option>
+            <option value="black">Black</option>
+          </select>
+        </>
+      )}
+      <Button
+        type="button"
+        size="sm"
+        variant="secondary"
+        className="h-8 px-3 text-xs"
+        onClick={onStart}
+        disabled={(mode === 'room' || mode === 'spectate') && roomCode.trim() === ''}
+      >
+        {mode === 'quick' ? 'Find match' : mode === 'spectate' ? 'Watch' : 'Create / Join'}
+      </Button>
+    </div>
+  )
+}
+
+function ClockCard({ label, ms, active, timed }: { label: string; ms: number; active: boolean; timed: boolean }) {
+  return (
+    <div
+      className={cn(
+        'flex-1 rounded-md border px-2 py-1 text-center',
+        active ? 'border-primary/70 bg-primary/10' : 'border-border bg-card/60',
+      )}
+    >
+      <div className="text-[9px] uppercase tracking-wider text-muted-foreground">{label}</div>
+      <div className="text-lg font-bold tabular-nums leading-tight">
+        {timed ? formatClock(ms) : '∞'}
+      </div>
+    </div>
+  )
+}

--- a/src/ui/src/dashboard/widgets/NetChessPanel.tsx
+++ b/src/ui/src/dashboard/widgets/NetChessPanel.tsx
@@ -47,8 +47,11 @@ import {
 const NETCHESS_GAME_ID = 'netchess'
 
 const BOARD_CHROME_PX = 10
-const CELL_MIN_PX = 22
-const CELL_MAX_PX = 64
+// See ChessPanel.tsx for the rationale: an 8x8 board hits the
+// auto-fit ceiling quickly, so the clamps that gate ZOOM_MIN/ZOOM_MAX
+// need to be wider than the defaults used by the Tetris-shaped games.
+const CELL_MIN_PX = 16
+const CELL_MAX_PX = 160
 const SIDEBAR_PX = 220
 
 type ConnState =

--- a/src/ui/src/dashboard/widgets/chessCore.test.ts
+++ b/src/ui/src/dashboard/widgets/chessCore.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest'
+import {
+  STARTING_FEN,
+  describeUciOnFen,
+  fromPGN,
+  isValidFen,
+  legalMoves,
+  newGame,
+  parseUci,
+  snapshot,
+  status,
+  toPGN,
+  tryMove,
+  tryUci,
+  turn,
+  undoMove,
+} from './chessCore'
+
+describe('parseUci', () => {
+  it('parses 4-letter coordinates', () => {
+    expect(parseUci('e2e4')).toEqual({ from: 'e2', to: 'e4' })
+  })
+  it('parses promotion suffix', () => {
+    expect(parseUci('e7e8q')).toEqual({ from: 'e7', to: 'e8', promotion: 'q' })
+  })
+  it('rejects bad inputs', () => {
+    expect(parseUci('')).toBeNull()
+    expect(parseUci('e2')).toBeNull()
+    expect(parseUci('z9z1')).toBeNull()
+    expect(parseUci('e2e4x')).toBeNull()
+    expect(parseUci('e7e8k')).toBeNull() // king promotion is not legal in chess
+  })
+  it('is case-insensitive and trims', () => {
+    expect(parseUci('  E2E4  ')).toEqual({ from: 'e2', to: 'e4' })
+  })
+})
+
+describe('newGame / isValidFen', () => {
+  it('starts at the standard position by default', () => {
+    const g = newGame()
+    expect(g.fen()).toBe(STARTING_FEN)
+    expect(turn(g)).toBe('w')
+  })
+  it('accepts a valid mid-game FEN', () => {
+    const fen = 'rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2'
+    const g = newGame(fen)
+    expect(g.fen()).toBe(fen)
+  })
+  it('rejects a malformed FEN', () => {
+    expect(() => newGame('not a fen at all')).toThrow()
+    expect(isValidFen('not a fen at all')).toBe(false)
+    expect(isValidFen(STARTING_FEN)).toBe(true)
+  })
+})
+
+describe('legalMoves', () => {
+  it('returns 20 moves from the starting position', () => {
+    const g = newGame()
+    expect(legalMoves(g)).toHaveLength(20)
+  })
+  it('filters by from-square', () => {
+    const g = newGame()
+    const fromE2 = legalMoves(g, 'e2')
+    expect(fromE2.map((m) => m.to).sort()).toEqual(['e3', 'e4'])
+  })
+  it('returns empty for an empty square', () => {
+    const g = newGame()
+    expect(legalMoves(g, 'e4')).toEqual([])
+  })
+})
+
+describe('tryMove', () => {
+  it('plays a legal move and returns a descriptor', () => {
+    const g = newGame()
+    const m = tryMove(g, { from: 'e2', to: 'e4' })
+    expect(m).not.toBeNull()
+    expect(m!.san).toBe('e4')
+    expect(m!.uci).toBe('e2e4')
+    expect(m!.piece).toBe('p')
+    expect(m!.color).toBe('w')
+    expect(turn(g)).toBe('b')
+  })
+  it('rejects an illegal move without mutating the game', () => {
+    const g = newGame()
+    const before = g.fen()
+    const m = tryMove(g, { from: 'e2', to: 'e5' })
+    expect(m).toBeNull()
+    expect(g.fen()).toBe(before)
+  })
+  it('handles promotions', () => {
+    const fen = '8/4P3/8/8/8/8/k7/4K3 w - - 0 1'
+    const g = newGame(fen)
+    const m = tryMove(g, { from: 'e7', to: 'e8', promotion: 'q' })
+    expect(m).not.toBeNull()
+    expect(m!.promotion).toBe('q')
+    expect(m!.san).toMatch(/^e8=Q/)
+  })
+})
+
+describe('tryUci', () => {
+  it('parses and plays in one shot', () => {
+    const g = newGame()
+    const m = tryUci(g, 'e2e4')
+    expect(m?.uci).toBe('e2e4')
+  })
+  it('returns null on garbage UCI', () => {
+    const g = newGame()
+    expect(tryUci(g, 'zzzz')).toBeNull()
+  })
+})
+
+describe('undoMove', () => {
+  it('reverts the last move and restores turn', () => {
+    const g = newGame()
+    tryMove(g, { from: 'e2', to: 'e4' })
+    expect(turn(g)).toBe('b')
+    const u = undoMove(g)
+    expect(u).not.toBeNull()
+    expect(u!.uci).toBe('e2e4')
+    expect(g.fen()).toBe(STARTING_FEN)
+    expect(turn(g)).toBe('w')
+  })
+  it('returns null on an empty history', () => {
+    const g = newGame()
+    expect(undoMove(g)).toBeNull()
+  })
+})
+
+describe('status', () => {
+  it('reports ongoing for a fresh game', () => {
+    expect(status(newGame())).toBe('ongoing')
+  })
+  it('reports checkmate after Fool\'s Mate', () => {
+    const g = newGame()
+    tryMove(g, { from: 'f2', to: 'f3' })
+    tryMove(g, { from: 'e7', to: 'e5' })
+    tryMove(g, { from: 'g2', to: 'g4' })
+    tryMove(g, { from: 'd8', to: 'h4' })
+    expect(status(g)).toBe('checkmate')
+  })
+  it('reports stalemate', () => {
+    // Classic stalemate position: black king h8, white king f7, white queen g6, black to move.
+    const stalemateFen = '7k/5K2/6Q1/8/8/8/8/8 b - - 0 1'
+    const g = newGame(stalemateFen)
+    expect(status(g)).toBe('stalemate')
+  })
+  it('reports insufficient material with K vs K', () => {
+    const kvk = '8/8/8/8/4k3/8/8/4K3 w - - 0 1'
+    const g = newGame(kvk)
+    expect(status(g)).toBe('draw_insufficient')
+  })
+})
+
+describe('PGN round-trip', () => {
+  it('exports a played game to PGN and reloads it', () => {
+    const g = newGame()
+    tryMove(g, { from: 'e2', to: 'e4' })
+    tryMove(g, { from: 'e7', to: 'e5' })
+    tryMove(g, { from: 'g1', to: 'f3' })
+    const pgn = toPGN(g, { White: 'Player', Black: 'Bot', Event: 'Test' })
+    expect(pgn).toContain('1. e4 e5 2. Nf3')
+
+    const restored = fromPGN(pgn)
+    expect(restored.game.fen()).toBe(g.fen())
+    expect(restored.history.map((m) => m.san)).toEqual(['e4', 'e5', 'Nf3'])
+  })
+  it('throws on invalid PGN input', () => {
+    expect(() => fromPGN('this is not pgn at all')).toThrow()
+    expect(() => fromPGN('1. e9 e5')).toThrow()
+  })
+  it('accepts an empty PGN as a fresh game', () => {
+    const { game, history } = fromPGN('')
+    expect(game.fen()).toBe(STARTING_FEN)
+    expect(history).toEqual([])
+  })
+})
+
+describe('describeUciOnFen', () => {
+  it('describes a move without mutating any persistent game', () => {
+    const m = describeUciOnFen(STARTING_FEN, 'e2e4')
+    expect(m?.san).toBe('e4')
+  })
+  it('returns null for illegal moves on the given FEN', () => {
+    expect(describeUciOnFen(STARTING_FEN, 'e2e5')).toBeNull()
+  })
+  it('returns null for malformed FEN', () => {
+    expect(describeUciOnFen('not a fen', 'e2e4')).toBeNull()
+  })
+})
+
+describe('snapshot', () => {
+  it('returns an 8x8 grid with starting pieces', () => {
+    const board = snapshot(newGame())
+    expect(board).toHaveLength(8)
+    expect(board[0]).toHaveLength(8)
+    expect(board[0]![0]).toEqual({ type: 'r', color: 'b', square: 'a8' })
+    expect(board[7]![4]).toEqual({ type: 'k', color: 'w', square: 'e1' })
+    expect(board[3]![3]).toBeNull()
+  })
+})

--- a/src/ui/src/dashboard/widgets/chessCore.ts
+++ b/src/ui/src/dashboard/widgets/chessCore.ts
@@ -1,0 +1,306 @@
+/**
+ * chessCore — thin typed wrapper around `chess.js`.
+ *
+ * One place that knows about chess rules on the UI side. Used by both
+ * the single-player `ChessPanel` and the multi-player `NetChessPanel`,
+ * by `chessEngine` (minimax), and by the worker. Re-exports the
+ * `chess.js` types we actually consume so consumers only need this
+ * file. Keep it framework-free (no React).
+ *
+ * On chess.js 1.x:
+ *   - `new Chess(fen?)` throws on an invalid FEN; we wrap it.
+ *   - `chess.move(...)` throws on an illegal move; we wrap it so the
+ *     caller gets a typed `null` instead of having to litter try/catch.
+ *   - `chess.history({ verbose: true })` returns `Move[]` (the verbose
+ *     descriptor objects, not just SAN strings).
+ */
+
+import { Chess, type Color, type PieceSymbol, type Square, validateFen } from 'chess.js'
+
+export type ChessColor = Color // 'w' | 'b'
+export type ChessPieceType = PieceSymbol // 'p' | 'n' | 'b' | 'r' | 'q' | 'k'
+export type ChessSquare = Square
+
+export interface ChessPiece {
+  color: ChessColor
+  type: ChessPieceType
+}
+
+export type Promotion = 'q' | 'r' | 'b' | 'n'
+
+export interface UciMove {
+  from: ChessSquare
+  to: ChessSquare
+  promotion?: Promotion
+}
+
+/** Descriptor for a move that already happened on a board. */
+export interface SanMove extends UciMove {
+  san: string
+  /** UCI long-algebraic notation: `e2e4`, `e7e8q`. */
+  uci: string
+  color: ChessColor
+  piece: ChessPieceType
+  captured?: ChessPieceType
+  /** FEN after the move was applied. */
+  fenAfter: string
+  /** FEN before the move was applied. */
+  fenBefore: string
+  isCapture: boolean
+  isCheck: boolean
+  isCheckmate: boolean
+  isCastleKingside: boolean
+  isCastleQueenside: boolean
+  isEnPassant: boolean
+}
+
+export type GameStatus =
+  | 'ongoing'
+  | 'checkmate'
+  | 'stalemate'
+  | 'draw_50'
+  | 'draw_3fold'
+  | 'draw_insufficient'
+  | 'draw'
+
+/** Standard chess starting position. */
+export const STARTING_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1'
+
+/** Construct a new game. Throws if `fen` is provided but invalid so the
+ *  caller can decide whether to fall back to the default. */
+export function newGame(fen?: string): Chess {
+  if (fen && fen !== STARTING_FEN) {
+    const check = validateFen(fen)
+    if (!check.ok) {
+      throw new Error(`invalid fen: ${check.error ?? 'unknown'}`)
+    }
+  }
+  return fen ? new Chess(fen) : new Chess()
+}
+
+/** Cheap FEN-only validation; useful when surface-level rejecting
+ *  server frames before constructing a Chess instance. */
+export function isValidFen(fen: string): boolean {
+  return validateFen(fen).ok
+}
+
+/** UCI long-algebraic for a verbose Move: `from` + `to` + optional promotion letter. */
+function moveToUci(m: { from: Square; to: Square; promotion?: PieceSymbol }): string {
+  return `${m.from}${m.to}${m.promotion ?? ''}`
+}
+
+/** Parse a UCI string (`e2e4`, `e7e8q`) into our `UciMove`. Returns null
+ *  on malformed input. We do NOT consult board state here — legality
+ *  is checked by `tryMove`. */
+export function parseUci(uci: string): UciMove | null {
+  if (typeof uci !== 'string') return null
+  const trimmed = uci.trim().toLowerCase()
+  if (trimmed.length !== 4 && trimmed.length !== 5) return null
+  const from = trimmed.slice(0, 2)
+  const to = trimmed.slice(2, 4)
+  const promo = trimmed.length === 5 ? trimmed.charAt(4) : undefined
+  if (!/^[a-h][1-8]$/.test(from) || !/^[a-h][1-8]$/.test(to)) return null
+  if (promo !== undefined && !/^[qrbn]$/.test(promo)) return null
+  return {
+    from: from as ChessSquare,
+    to: to as ChessSquare,
+    promotion: promo as Promotion | undefined,
+  }
+}
+
+/** Build a fully-typed SanMove descriptor from a chess.js verbose Move
+ *  and the FEN snapshots we captured around the call site. Kept here so
+ *  every caller produces the same shape. */
+function buildSan(
+  m: {
+    color: Color
+    from: Square
+    to: Square
+    piece: PieceSymbol
+    captured?: PieceSymbol
+    promotion?: PieceSymbol
+    san: string
+    isCapture: () => boolean
+    isPromotion: () => boolean
+    isEnPassant: () => boolean
+    isKingsideCastle: () => boolean
+    isQueensideCastle: () => boolean
+  },
+  fenBefore: string,
+  fenAfter: string,
+  isCheck: boolean,
+  isCheckmate: boolean,
+): SanMove {
+  return {
+    from: m.from,
+    to: m.to,
+    promotion: m.promotion as Promotion | undefined,
+    san: m.san,
+    uci: moveToUci(m),
+    color: m.color,
+    piece: m.piece,
+    captured: m.captured,
+    fenBefore,
+    fenAfter,
+    isCapture: m.isCapture(),
+    isCheck,
+    isCheckmate,
+    isCastleKingside: m.isKingsideCastle(),
+    isCastleQueenside: m.isQueensideCastle(),
+    isEnPassant: m.isEnPassant(),
+  }
+}
+
+/** All legal moves from the given square (or from any square when
+ *  `from` is undefined). The returned descriptors include SAN — handy
+ *  for highlighting target squares and rendering hints. */
+export function legalMoves(game: Chess, from?: ChessSquare): SanMove[] {
+  const verbose = from
+    ? game.moves({ verbose: true, square: from })
+    : game.moves({ verbose: true })
+  const fenBefore = game.fen()
+  return verbose.map((m) => ({
+    from: m.from,
+    to: m.to,
+    promotion: m.promotion as Promotion | undefined,
+    san: m.san,
+    uci: moveToUci(m),
+    color: m.color,
+    piece: m.piece,
+    captured: m.captured,
+    fenBefore,
+    // We don't *play* the move here — fenAfter is m.after, which
+    // chess.js v1.x populates on verbose moves.
+    fenAfter: (m as unknown as { after?: string }).after ?? fenBefore,
+    isCapture: m.isCapture(),
+    isCheck: false, // computed only after the move is actually played
+    isCheckmate: false,
+    isCastleKingside: m.isKingsideCastle(),
+    isCastleQueenside: m.isQueensideCastle(),
+    isEnPassant: m.isEnPassant(),
+  }))
+}
+
+/** Try to play `move` on `game`. Returns the resulting `SanMove`
+ *  descriptor on success, or `null` if the move is illegal in the
+ *  current position. Mutates `game`. */
+export function tryMove(game: Chess, move: UciMove): SanMove | null {
+  const fenBefore = game.fen()
+  let m: ReturnType<Chess['move']> | null = null
+  try {
+    m = game.move({ from: move.from, to: move.to, promotion: move.promotion })
+  } catch {
+    return null
+  }
+  if (!m) return null
+  const fenAfter = game.fen()
+  return buildSan(m, fenBefore, fenAfter, game.isCheck(), game.isCheckmate())
+}
+
+/** Same as `tryMove` but parses UCI first. Convenience for handlers
+ *  that receive UCI off the wire. */
+export function tryUci(game: Chess, uci: string): SanMove | null {
+  const parsed = parseUci(uci)
+  if (!parsed) return null
+  return tryMove(game, parsed)
+}
+
+/** Roll back the last half-move. Returns the popped descriptor or null
+ *  if the history is empty. */
+export function undoMove(game: Chess): SanMove | null {
+  const before = game.fen()
+  const undone = game.undo()
+  if (!undone) return null
+  const after = game.fen()
+  // history's "before" is the position we just restored to — i.e.
+  // chess.js's notion of `before` for the undone move. We flip the
+  // FEN labelling so the descriptor still reads "fenBefore → fenAfter"
+  // in the direction of game progression.
+  return buildSan(undone, after, before, game.isCheck(), game.isCheckmate())
+}
+
+/** Inspect the current game status. `ongoing` if no terminal condition
+ *  has triggered. */
+export function status(game: Chess): GameStatus {
+  if (game.isCheckmate()) return 'checkmate'
+  if (game.isStalemate()) return 'stalemate'
+  if (game.isInsufficientMaterial()) return 'draw_insufficient'
+  if (game.isThreefoldRepetition()) return 'draw_3fold'
+  if (game.isDrawByFiftyMoves()) return 'draw_50'
+  if (game.isDraw()) return 'draw'
+  return 'ongoing'
+}
+
+/** Whose turn it is — exposed so widgets don't have to import chess.js
+ *  directly. */
+export function turn(game: Chess): ChessColor {
+  return game.turn()
+}
+
+/** Export the played-so-far game as PGN. `headers` lets the caller
+ *  inject metadata (Event/Site/White/Black/Result) without touching
+ *  chess.js internals. */
+export function toPGN(game: Chess, headers?: Record<string, string>): string {
+  if (headers) {
+    for (const [k, v] of Object.entries(headers)) {
+      game.header(k, v)
+    }
+  }
+  return game.pgn()
+}
+
+/** Reconstruct a game from PGN. Returns the Chess instance plus the
+ *  history as our SanMove descriptors. Throws if the PGN is invalid. */
+export function fromPGN(pgn: string): { game: Chess; history: SanMove[] } {
+  const game = new Chess()
+  game.loadPgn(pgn)
+  const verbose = game.history({ verbose: true })
+  // chess.js verbose history items carry `before` / `after` FENs we
+  // can lean on; we still recompute check/mate by replaying.
+  const replay = new Chess()
+  const history: SanMove[] = []
+  for (const v of verbose) {
+    const fenBefore = replay.fen()
+    const m = replay.move({ from: v.from, to: v.to, promotion: v.promotion })
+    if (!m) {
+      // Defensive: PGN parsed but a move from history fails to replay.
+      // Treat as corrupt input.
+      throw new Error(`pgn replay failed at ${v.san}`)
+    }
+    const fenAfter = replay.fen()
+    history.push(buildSan(m, fenBefore, fenAfter, replay.isCheck(), replay.isCheckmate()))
+  }
+  return { game, history }
+}
+
+/** Convenience: parse a UCI string against a position FEN and return
+ *  the descriptor without mutating any persistent game. Returns null
+ *  for malformed UCI or illegal moves. Used by the server-bound LLM
+ *  validator path on the UI side and by tests. */
+export function describeUciOnFen(fen: string, uci: string): SanMove | null {
+  const parsed = parseUci(uci)
+  if (!parsed) return null
+  let game: Chess
+  try {
+    game = new Chess(fen)
+  } catch {
+    return null
+  }
+  return tryMove(game, parsed)
+}
+
+/** Cell of a board snapshot — same shape as chess.js's verbose board
+ *  cells (`type`, `color`, `square`), with explicit nulls. */
+export interface BoardCell {
+  type: ChessPieceType
+  color: ChessColor
+  square: ChessSquare
+}
+
+/** 8x8 board snapshot — outer index 0 = rank 8 (top), inner index 0 =
+ *  file a (left). Mirrors chess.js's `board()` shape. */
+export type BoardSnapshot = (BoardCell | null)[][]
+
+export function snapshot(game: Chess): BoardSnapshot {
+  return game.board().map((row) => row.map((cell) => (cell ? { ...cell } : null)))
+}

--- a/src/ui/src/dashboard/widgets/chessEngine.test.ts
+++ b/src/ui/src/dashboard/widgets/chessEngine.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import { newGame, tryMove } from './chessCore'
+import { playEngineMove, search, whiteRelativeCp } from './chessEngine'
+
+describe('engine: starting position is sane', () => {
+  it('returns a legal first move for white at depth 2', () => {
+    const r = search(newGame().fen(), { depth: 2 })
+    expect(r.uci).toBeTruthy()
+    expect(r.uci!.length).toBeGreaterThanOrEqual(4)
+  })
+  it('never reports a mate score in the opening', () => {
+    const r = search(newGame().fen(), { depth: 2 })
+    expect(Math.abs(r.evalCp)).toBeLessThan(50_000)
+  })
+})
+
+describe('engine: tactics', () => {
+  it('finds mate-in-1: classic back-rank', () => {
+    // Black to move; ...Rxe1 is mate.  Setup: White king on g1, no escape;
+    // Black rook coming to e1 mates because c1 is blocked by the white knight.
+    // Position: rnbqkbnr/pppp1ppp/8/8/8/8/PPPPPPPP/RNBQKBNR — replaced by a
+    // hand-crafted FEN that guarantees mate-in-1.
+    //   Pieces: white K g1, R a1, N c1, P f2 g2 h2; black R e8 a8, K g8.
+    //   Black to move, ...Re1#.
+    const fen = 'r3r1k1/8/8/8/8/8/5PPP/R1N3K1 b - - 0 1'
+    const r = search(fen, { depth: 2 })
+    expect(r.uci).toBe('e8e1')
+  })
+
+  it('does not give away a piece for nothing at depth 2', () => {
+    // After 1.e4 e5 2.Nf3 Nc6 3.Bc4 Bc5, the engine as White should not
+    // play 4.Nxe5? because Nxe5 loses a piece to ...Nxe5 (no fork available).
+    const g = newGame()
+    tryMove(g, { from: 'e2', to: 'e4' })
+    tryMove(g, { from: 'e7', to: 'e5' })
+    tryMove(g, { from: 'g1', to: 'f3' })
+    tryMove(g, { from: 'b8', to: 'c6' })
+    tryMove(g, { from: 'f1', to: 'c4' })
+    tryMove(g, { from: 'f8', to: 'c5' })
+    const r = search(g.fen(), { depth: 3 })
+    expect(r.uci).not.toBe('f3e5')
+  })
+
+  it('takes a free queen when offered', () => {
+    // Black queen sits on d4, undefended (back-rank bishops blocked
+    // by pawns, no pawn on c5/e5). White knight on b3 attacks d4 and
+    // can capture for free. White to move.
+    const fen = 'rnb1kbnr/pppppppp/8/8/3q4/1N6/PPPPPPPP/R1BQKBNR w KQkq - 0 1'
+    const r = search(fen, { depth: 2 })
+    expect(r.uci).toBe('b3d4')
+  })
+})
+
+describe('engine: terminal positions', () => {
+  it('returns null UCI when there are no legal moves (stalemate)', () => {
+    // 7k/5K2/6Q1/8/8/8/8/8 b - - 0 1 is stalemate for black to move.
+    const r = search('7k/5K2/6Q1/8/8/8/8/8 b - - 0 1', { depth: 2 })
+    expect(r.uci).toBeNull()
+  })
+})
+
+describe('engine: depth 0 is random-legal', () => {
+  it('returns *some* legal move with seed reproducibility', () => {
+    const r1 = search(newGame().fen(), { depth: 0, seed: 42 })
+    const r2 = search(newGame().fen(), { depth: 0, seed: 42 })
+    expect(r1.uci).toBe(r2.uci)
+    expect(r1.uci).toBeTruthy()
+  })
+})
+
+describe('engine: playEngineMove', () => {
+  it('applies the chosen move to the supplied game', () => {
+    const g = newGame()
+    const { result, move } = playEngineMove(g, { depth: 1 })
+    expect(result.uci).toBeTruthy()
+    expect(move).not.toBeNull()
+    expect(g.fen()).not.toBe(newGame().fen())
+  })
+})
+
+describe('whiteRelativeCp', () => {
+  it('flips sign for black', () => {
+    expect(whiteRelativeCp('w', 120)).toBe(120)
+    expect(whiteRelativeCp('b', 120)).toBe(-120)
+  })
+})
+
+describe('engine: cancellation', () => {
+  it('honours an aborted signal and still returns a legal move', () => {
+    const ctrl = new AbortController()
+    // Abort immediately to force the abort path.
+    ctrl.abort()
+    const r = search(newGame().fen(), { depth: 4, signal: ctrl.signal })
+    expect(r.uci).toBeTruthy()
+    expect(r.aborted).toBe(true)
+  })
+})

--- a/src/ui/src/dashboard/widgets/chessEngine.ts
+++ b/src/ui/src/dashboard/widgets/chessEngine.ts
@@ -1,0 +1,400 @@
+/**
+ * chessEngine — minimax + alpha-beta search with a small evaluator.
+ *
+ * Synchronous, pure-function entrypoint (`search`). The Web-Worker
+ * wrapper lives in `chessEngine.worker.ts`; this module has no DOM
+ * or worker dependencies so it can be unit-tested directly.
+ *
+ * Evaluator: material + Michniewski piece-square tables (public-
+ * domain, originally from chessprogramming.org). White-relative
+ * centipawns; the score is negated for black's turn at the search
+ * root so we can call it from either side.
+ *
+ * Search:
+ *   - alpha-beta negamax with move ordering by MVV-LVA
+ *   - depth 1..4 from the UI slider; the worker can also pass a
+ *     deadline so the search aborts early
+ *   - "level 0" returns a random legal move (for the easiest setting)
+ *   - on mate, score is sign(depth_to_mate) * (MATE_SCORE - distance)
+ *     so shorter mates beat longer ones
+ *
+ * Not designed to be strong — strong enough to be a credible opponent
+ * to a casual player at the deepest level.
+ */
+
+import { Chess } from 'chess.js'
+import {
+  type ChessColor,
+  type ChessPieceType,
+  type ChessSquare,
+  type SanMove,
+  newGame,
+  tryMove,
+} from './chessCore'
+
+export interface SearchOptions {
+  /** Half-move plies. 0 = random legal, 1..4 = minimax depth. */
+  depth: number
+  /** Deterministic mode for tests — fixes the tie-break ordering. */
+  seed?: number
+  /** If set, the search aborts and returns the best move found so
+   *  far when this signal fires. The worker uses it for cancellation. */
+  signal?: AbortSignal
+}
+
+export interface SearchResult {
+  /** UCI of the best move, or null if the position has no legal moves
+   *  (mate / stalemate — caller should react accordingly). */
+  uci: string | null
+  /** Evaluation from the perspective of the side to move at the root,
+   *  in centipawns. Positive = good for the side to move. */
+  evalCp: number
+  /** Principal variation in UCI strings (best line found). May be
+   *  shorter than `depth` when the line is forced or pruned. */
+  pv: string[]
+  /** Number of nodes searched — useful for diagnostics. */
+  nodes: number
+  /** True if the search was aborted via `signal` and returned a
+   *  best-so-far rather than the depth-complete result. */
+  aborted: boolean
+}
+
+const PIECE_VALUE: Record<ChessPieceType, number> = {
+  p: 100,
+  n: 320,
+  b: 330,
+  r: 500,
+  q: 900,
+  k: 20000,
+}
+
+/** Michniewski piece-square tables, indexed [rank0=8th_rank..rank7=1st_rank][file_a..file_h]
+ *  from White's perspective. Black squares are mirrored at lookup. */
+const PST: Record<ChessPieceType, number[][]> = {
+  p: [
+    [ 0,  0,  0,  0,  0,  0,  0,  0],
+    [50, 50, 50, 50, 50, 50, 50, 50],
+    [10, 10, 20, 30, 30, 20, 10, 10],
+    [ 5,  5, 10, 25, 25, 10,  5,  5],
+    [ 0,  0,  0, 20, 20,  0,  0,  0],
+    [ 5, -5,-10,  0,  0,-10, -5,  5],
+    [ 5, 10, 10,-20,-20, 10, 10,  5],
+    [ 0,  0,  0,  0,  0,  0,  0,  0],
+  ],
+  n: [
+    [-50,-40,-30,-30,-30,-30,-40,-50],
+    [-40,-20,  0,  0,  0,  0,-20,-40],
+    [-30,  0, 10, 15, 15, 10,  0,-30],
+    [-30,  5, 15, 20, 20, 15,  5,-30],
+    [-30,  0, 15, 20, 20, 15,  0,-30],
+    [-30,  5, 10, 15, 15, 10,  5,-30],
+    [-40,-20,  0,  5,  5,  0,-20,-40],
+    [-50,-40,-30,-30,-30,-30,-40,-50],
+  ],
+  b: [
+    [-20,-10,-10,-10,-10,-10,-10,-20],
+    [-10,  0,  0,  0,  0,  0,  0,-10],
+    [-10,  0,  5, 10, 10,  5,  0,-10],
+    [-10,  5,  5, 10, 10,  5,  5,-10],
+    [-10,  0, 10, 10, 10, 10,  0,-10],
+    [-10, 10, 10, 10, 10, 10, 10,-10],
+    [-10,  5,  0,  0,  0,  0,  5,-10],
+    [-20,-10,-10,-10,-10,-10,-10,-20],
+  ],
+  r: [
+    [ 0,  0,  0,  0,  0,  0,  0,  0],
+    [ 5, 10, 10, 10, 10, 10, 10,  5],
+    [-5,  0,  0,  0,  0,  0,  0, -5],
+    [-5,  0,  0,  0,  0,  0,  0, -5],
+    [-5,  0,  0,  0,  0,  0,  0, -5],
+    [-5,  0,  0,  0,  0,  0,  0, -5],
+    [-5,  0,  0,  0,  0,  0,  0, -5],
+    [ 0,  0,  0,  5,  5,  0,  0,  0],
+  ],
+  q: [
+    [-20,-10,-10, -5, -5,-10,-10,-20],
+    [-10,  0,  0,  0,  0,  0,  0,-10],
+    [-10,  0,  5,  5,  5,  5,  0,-10],
+    [ -5,  0,  5,  5,  5,  5,  0, -5],
+    [  0,  0,  5,  5,  5,  5,  0, -5],
+    [-10,  5,  5,  5,  5,  5,  0,-10],
+    [-10,  0,  5,  0,  0,  0,  0,-10],
+    [-20,-10,-10, -5, -5,-10,-10,-20],
+  ],
+  // Middlegame king table; we don't bother switching to an endgame
+  // table — strength loss is small for a 4-ply search.
+  k: [
+    [-30,-40,-40,-50,-50,-40,-40,-30],
+    [-30,-40,-40,-50,-50,-40,-40,-30],
+    [-30,-40,-40,-50,-50,-40,-40,-30],
+    [-30,-40,-40,-50,-50,-40,-40,-30],
+    [-20,-30,-30,-40,-40,-30,-30,-20],
+    [-10,-20,-20,-20,-20,-20,-20,-10],
+    [ 20, 20,  0,  0,  0,  0, 20, 20],
+    [ 20, 30, 10,  0,  0, 10, 30, 20],
+  ],
+}
+
+const MATE_SCORE = 100_000
+
+interface AbortChecker {
+  hit: boolean
+}
+
+class AbortedError extends Error {
+  constructor() { super('search aborted') }
+}
+
+function squareToRC(sq: ChessSquare): { rank: number; file: number } {
+  // chess.js squares are file-letter + rank-digit, e.g. "e2".
+  // We index PSTs as [rank_from_top_for_white][file] where
+  // file 'a' = 0..'h' = 7 and rank '8' = 0..'1' = 7.
+  const file = sq.charCodeAt(0) - 97
+  const rankDigit = sq.charCodeAt(1) - 48
+  const rank = 8 - rankDigit
+  return { rank, file }
+}
+
+/** Static evaluation in centipawns from White's perspective.
+ *  Positive = White is better. Side-relative scoring is applied at
+ *  the search root by the caller of `evaluate`. */
+function evaluate(game: Chess): number {
+  // Terminal positions first — we want big positive/negative numbers
+  // so the search prefers (or avoids) them irrespective of material.
+  if (game.isCheckmate()) {
+    // Side to move is checkmated → bad for that side. The leaf-side
+    // is the *to-move* side, so return negative for the side to move,
+    // which in white-relative terms is:
+    //   - if it's white's turn and white is mated, return -MATE
+    //   - if it's black's turn and black is mated, return +MATE
+    return game.turn() === 'w' ? -MATE_SCORE : MATE_SCORE
+  }
+  if (
+    game.isStalemate() ||
+    game.isInsufficientMaterial() ||
+    game.isThreefoldRepetition() ||
+    game.isDrawByFiftyMoves()
+  ) {
+    return 0
+  }
+
+  let score = 0
+  const board = game.board()
+  for (let r = 0; r < 8; r++) {
+    const row = board[r]
+    if (!row) continue
+    for (let f = 0; f < 8; f++) {
+      const cell = row[f]
+      if (!cell) continue
+      const v = PIECE_VALUE[cell.type as ChessPieceType]
+      // PST index: for white pieces, use [r][f]; for black, mirror rank.
+      const pst = PST[cell.type as ChessPieceType]
+      const pstVal = cell.color === 'w' ? pst[r]![f]! : pst[7 - r]![f]!
+      const total = v + pstVal
+      score += cell.color === 'w' ? total : -total
+    }
+  }
+  return score
+}
+
+/** Compose a verbose Move into a sortable key for move ordering.
+ *  Captures by least-valued attacker on most-valued victim go first;
+ *  promotions go before plain quiet moves. */
+function moveOrderKey(m: {
+  captured?: ChessPieceType
+  piece: ChessPieceType
+  promotion?: ChessPieceType
+}): number {
+  let score = 0
+  if (m.captured) {
+    score += 10 * PIECE_VALUE[m.captured] - PIECE_VALUE[m.piece]
+  }
+  if (m.promotion) {
+    score += PIECE_VALUE[m.promotion]
+  }
+  return score
+}
+
+interface OrderedMove {
+  from: ChessSquare
+  to: ChessSquare
+  promotion?: 'q' | 'r' | 'b' | 'n'
+  key: number
+}
+
+function orderedLegalMoves(game: Chess): OrderedMove[] {
+  // chess.js v1.x: moves({verbose:true}) on a position with no legal
+  // moves returns []. The caller is responsible for treating that as
+  // a terminal position.
+  const verbose = game.moves({ verbose: true })
+  const out: OrderedMove[] = verbose.map((m) => ({
+    from: m.from as ChessSquare,
+    to: m.to as ChessSquare,
+    promotion: m.promotion as 'q' | 'r' | 'b' | 'n' | undefined,
+    key: moveOrderKey({
+      captured: m.captured as ChessPieceType | undefined,
+      piece: m.piece as ChessPieceType,
+      promotion: m.promotion as ChessPieceType | undefined,
+    }),
+  }))
+  out.sort((a, b) => b.key - a.key)
+  return out
+}
+
+/** Negamax with alpha-beta. Returns side-to-move-relative cp. */
+function negamax(
+  game: Chess,
+  depth: number,
+  alpha: number,
+  beta: number,
+  ply: number,
+  abort: AbortChecker,
+): { score: number; pv: OrderedMove[] } {
+  if (abort.hit) throw new AbortedError()
+
+  if (depth <= 0 || game.isGameOver()) {
+    // Evaluate from the perspective of the side to move.
+    const whiteRel = evaluate(game)
+    const side = game.turn() === 'w' ? 1 : -1
+    // Adjust mate scores by ply so shallower mates win.
+    if (whiteRel >= MATE_SCORE / 2) {
+      return { score: side * (whiteRel - ply), pv: [] }
+    }
+    if (whiteRel <= -MATE_SCORE / 2) {
+      return { score: side * (whiteRel + ply), pv: [] }
+    }
+    return { score: side * whiteRel, pv: [] }
+  }
+
+  const moves = orderedLegalMoves(game)
+  if (moves.length === 0) {
+    // No legal moves: either mate or stalemate. evaluate() captures it.
+    const whiteRel = evaluate(game)
+    const side = game.turn() === 'w' ? 1 : -1
+    return { score: side * whiteRel, pv: [] }
+  }
+
+  let bestScore = -Infinity
+  let bestPv: OrderedMove[] = []
+  let bestMove: OrderedMove | null = null
+
+  for (const m of moves) {
+    game.move({ from: m.from, to: m.to, promotion: m.promotion })
+    const child = negamax(game, depth - 1, -beta, -alpha, ply + 1, abort)
+    game.undo()
+    const score = -child.score
+    if (score > bestScore) {
+      bestScore = score
+      bestMove = m
+      bestPv = [m, ...child.pv]
+    }
+    if (score > alpha) alpha = score
+    if (alpha >= beta) break
+  }
+
+  if (!bestMove) {
+    // Shouldn't be reachable — moves was non-empty.
+    return { score: 0, pv: [] }
+  }
+  return { score: bestScore, pv: bestPv }
+}
+
+/** Best legal move for the current side to move on `fen`. */
+export function search(fen: string, opts: SearchOptions): SearchResult {
+  const game = newGame(fen)
+  const moves = orderedLegalMoves(game)
+  if (moves.length === 0) {
+    return { uci: null, evalCp: 0, pv: [], nodes: 0, aborted: false }
+  }
+  // Level 0 → random legal move (intended for absolute-beginner mode).
+  if (opts.depth <= 0) {
+    const pick = pickDeterministic(moves, opts.seed)
+    return { uci: moveUci(pick), evalCp: 0, pv: [moveUci(pick)], nodes: 1, aborted: false }
+  }
+  const abort: AbortChecker = { hit: false }
+  // Honour a signal that was already aborted by the time we got
+  // called (e.g. immediate cancellation right before the call).
+  if (opts.signal?.aborted) {
+    abort.hit = true
+  }
+  const listener = () => { abort.hit = true }
+  opts.signal?.addEventListener('abort', listener)
+  try {
+    const { score, pv } = negamax(game, opts.depth, -Infinity, Infinity, 0, abort)
+    return {
+      uci: pv[0] ? moveUci(pv[0]) : null,
+      evalCp: score,
+      pv: pv.map(moveUci),
+      nodes: 0, // node counting kept for future; not needed for tests yet
+      aborted: false,
+    }
+  } catch (e) {
+    if (e instanceof AbortedError) {
+      // Return a shallow best-move at the root by re-searching depth=1.
+      const shallow = negamax(newGame(fen), 1, -Infinity, Infinity, 0, { hit: false })
+      return {
+        uci: shallow.pv[0] ? moveUci(shallow.pv[0]) : moveUci(moves[0]!),
+        evalCp: shallow.score,
+        pv: shallow.pv.map(moveUci),
+        nodes: 0,
+        aborted: true,
+      }
+    }
+    throw e
+  } finally {
+    opts.signal?.removeEventListener('abort', listener)
+  }
+}
+
+function moveUci(m: { from: ChessSquare; to: ChessSquare; promotion?: string }): string {
+  return `${m.from}${m.to}${m.promotion ?? ''}`
+}
+
+/** Deterministic pick from a small array. The "deterministic" bit
+ *  matters only for tests; in production seed is undefined and we use
+ *  `Math.random()`. */
+function pickDeterministic<T>(arr: T[], seed?: number): T {
+  if (arr.length === 0) throw new Error('pickDeterministic: empty array')
+  if (seed === undefined) return arr[Math.floor(Math.random() * arr.length)]!
+  // Tiny xorshift just so seed actually changes the pick.
+  let x = (seed | 0) || 1
+  x ^= x << 13
+  x ^= x >>> 17
+  x ^= x << 5
+  const idx = Math.abs(x) % arr.length
+  return arr[idx]!
+}
+
+/** Surface side-by-side helpers for tests / UI hints. */
+export const __internal = {
+  evaluate,
+  PIECE_VALUE,
+  MATE_SCORE,
+  squareToRC,
+}
+
+/** Play one engine move on `game` and return the descriptor — used by
+ *  unit tests and (optionally) by the panel when running the engine
+ *  synchronously. The panel normally goes through the worker. */
+export function playEngineMove(
+  game: Chess,
+  opts: SearchOptions,
+): { result: SearchResult; move: SanMove | null } {
+  const result = search(game.fen(), opts)
+  if (!result.uci) return { result, move: null }
+  const parsed = result.uci
+  const from = parsed.slice(0, 2) as ChessSquare
+  const to = parsed.slice(2, 4) as ChessSquare
+  const promotion = parsed.length === 5
+    ? (parsed.charAt(4) as 'q' | 'r' | 'b' | 'n')
+    : undefined
+  const move = tryMove(game, { from, to, promotion })
+  return { result, move }
+}
+
+/** Convert a side-relative cp score to a White-relative number for UI
+ *  display. Caller passes the colour that the score belongs to (the
+ *  side to move at the position scored). */
+export function whiteRelativeCp(side: ChessColor, sideToMoveScore: number): number {
+  return side === 'w' ? sideToMoveScore : -sideToMoveScore
+}

--- a/src/ui/src/dashboard/widgets/chessEngine.worker.ts
+++ b/src/ui/src/dashboard/widgets/chessEngine.worker.ts
@@ -1,0 +1,46 @@
+/// <reference lib="webworker" />
+/**
+ * chessEngine.worker — Web Worker around `chessEngine.search`.
+ *
+ * Wire format:
+ *   in  → { id: number, fen: string, depth: number }
+ *   out ← { id: number, uci: string|null, evalCp: number, pv: string[] }
+ *
+ * The worker is single-threaded by definition and we don't pre-empt
+ * a running search — the panel cancels by terminating the worker and
+ * spawning a fresh one (cheap; the minimax has no warm-up state).
+ *
+ * Loaded via the Vite `new Worker(new URL(...), {type:"module"})`
+ * pattern from `ChessPanel.tsx`.
+ */
+
+import { search } from './chessEngine'
+
+interface InMsg {
+  id: number
+  fen: string
+  depth: number
+}
+
+const ctx: DedicatedWorkerGlobalScope = self as unknown as DedicatedWorkerGlobalScope
+
+ctx.onmessage = (e: MessageEvent<InMsg>) => {
+  const { id, fen, depth } = e.data
+  try {
+    const r = search(fen, { depth })
+    ctx.postMessage({
+      id,
+      uci: r.uci,
+      evalCp: r.evalCp,
+      pv: r.pv,
+    })
+  } catch (err) {
+    ctx.postMessage({
+      id,
+      uci: null,
+      evalCp: 0,
+      pv: [],
+      error: err instanceof Error ? err.message : 'engine error',
+    })
+  }
+}

--- a/src/ui/src/dashboard/widgets/registry.ts
+++ b/src/ui/src/dashboard/widgets/registry.ts
@@ -18,6 +18,8 @@ const SIPDialogMasterPanel = lazy(() => import('./SIPDialogMasterPanel.jsx'))
 const JitterBufferHeroPanel = lazy(() => import('./JitterBufferHeroPanel.jsx'))
 const SIPetrisPanel = lazy(() => import('./SIPetrisPanel'))
 const NetrisPanel = lazy(() => import('./NetrisPanel'))
+const ChessPanel = lazy(() => import('./ChessPanel'))
+const NetChessPanel = lazy(() => import('./NetChessPanel'))
 
 /**
  * Preset variant of a base widget type. Lets the AddWidgetDialog show a
@@ -271,6 +273,26 @@ export const widgetRegistry: Record<string, WidgetMeta> = {
   netris: {
     component: NetrisPanel,
     label: 'Netris',
+    icon: 'game',
+    category: 'Games',
+    minW: 8,
+    minH: 8,
+    defaultW: 12,
+    defaultH: 14,
+  },
+  chess: {
+    component: ChessPanel,
+    label: 'Chess',
+    icon: 'game',
+    category: 'Games',
+    minW: 6,
+    minH: 8,
+    defaultW: 8,
+    defaultH: 12,
+  },
+  netchess: {
+    component: NetChessPanel,
+    label: 'NetChess',
     icon: 'game',
     category: 'Games',
     minW: 8,

--- a/src/ui/src/dashboard/widgets/registry.ts
+++ b/src/ui/src/dashboard/widgets/registry.ts
@@ -295,10 +295,13 @@ export const widgetRegistry: Record<string, WidgetMeta> = {
     label: 'NetChess',
     icon: 'game',
     category: 'Games',
-    minW: 8,
+    // Mirror the `chess` widget — the 220 px sidebar is identical and
+    // the board itself is 8x8, so there is no good reason for the
+    // NetChess board to render wider than the single-player one.
+    minW: 6,
     minH: 8,
-    defaultW: 12,
-    defaultH: 14,
+    defaultW: 8,
+    defaultH: 12,
   },
 }
 


### PR DESCRIPTION
## Summary

Two independent changes on one branch:

1. **`feat(games)`**: add two new dashboard widgets under the **Games** category.
   - **`chess`** — single-player. Built-in minimax bot (Web Worker, depth 1–4) or — when `mcp.llm.enable=true` — an LLM opponent via the existing `src/mcp/llm.go` bridge with server-side validation and a fallback engine when the model emits an illegal move. Clocks (Fischer), takeback, PGN export, resume across reloads.
   - **`netchess`** — two-player over a coordinator-hosted WebSocket. Unlike Netris the server is **authoritative**: it holds the `*notnil/chess.Game` per room, validates every move, manages clocks via `time.AfterFunc`, and emits `game_over`. Lobby: quick-match, named room, read-only spectator (cap 8). Draw / takeback / resign flows.
2. **`fix(coordinator)`**: stop publishing LP `mapping_schema` rows for DuckLake catalog tables (`ducklake_table`, `ducklake_column`, `ducklake_column_tag`, …) and other internal schemas. `discoverTables` now applies a shared `discoveryExclusions` predicate; `SyncOnce` runs an idempotent `purgeInternalLPMappings` so a freshly-upgraded coordinator wipes the historical mess without an operator migration.

## Surface area

- **New Go packages**: `src/coordinator/games/chess` (greedy engine + LLM wrapper) and `src/coordinator/games/netchess` (Hub + Room + protocol). 21 new unit tests.
- **HTTP/WS handlers** in `src/coordinator/handlers/games_v4.go`: `V4NetChess` (WS, `/api/v4/games/netchess`), `V4ChessLLMMove` (POST), `V4ChessLLMStatus` (GET). Wired in `coordinator.go` with the standard nil-hub stub pattern used by Netris.
- **UI**: `chessCore.ts` (typed wrapper around `chess.js`), `chessEngine.ts` + Worker, `ChessBoard.tsx`, `ChessPanel.tsx`, `NetChessPanel.tsx`; `openNetChessSocket`, `fetchChessLLMStatus`, `postChessLLMMove` in `api.ts`; registry entries. 45 new widget tests.
- **Docs**: new sections in `docs/VOIPGames.md` (controls, LLM mode, wire protocol, source map). Design spec at `docs/superpowers/specs/2026-05-16-chess-netchess-widgets-design.md`.
- **LP fix**: `src/coordinator/services/lp_mapping_sync.go` + a new `TestLPMappingSync_PurgeInternalMappings`.

## Dependencies

- `chess.js@1.4.0` (MIT, UI)
- `github.com/notnil/chess v1.10.0` (BSD-2, Go)

## Test plan

CI / local validation already run:

- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test ./coordinator/...` — all green (incl. 14 netchess hub tests, 7 chess engine/LLM tests, 1 new LP purge test, all existing services tests)
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 77/77 pass (incl. 28 chessCore, 10 chessEngine, 7 ChessBoard)
- [x] `npx eslint` on all new files — clean

Manual smoke (recommended before merge):

- [ ] Boot a coordinator with the build, open the dashboard, add the **Chess** widget, play a few moves vs bot, change level, takeback, export PGN.
- [ ] With `mcp.llm.enable=true`, toggle to LLM mode and verify the `Status` pill shows `<model> thinking…` and that bot moves arrive within the LLM timeout. Force an illegal-move response if you can mock the LLM, and confirm the `fallback` pill appears.
- [ ] Open two browsers, add the **NetChess** widget in each, pair via room code (`Random` button) or `Quick`, both `Ready`, play to checkmate. Verify clocks tick, draw/takeback/resign UI works, and game-over overlay reports the correct result/reason.
- [ ] Optional: open a third browser as spectator (`Spectate` + room code) and verify it receives moves but its frames are dropped server-side.
- [ ] On an existing coordinator with stale `main__ducklake_*` mapping rows, deploy this build and confirm those rows disappear on the next sync tick (default ≤60s) and never come back, while operator-curated mappings under real HEP types are untouched.

## Out of scope

- Pre-moves / drag-and-drop on `ChessBoard.tsx` (click-to-move is shipped).
- Stockfish.js or other strong engines for the single-player widget.
- Spectator chat — spectators are mute by design.
- UI tests for `ChessPanel.tsx` / `NetChessPanel.tsx` (state machines are covered indirectly by board + core + hub tests).