### PR TITLE
chore: release 11.0.216

### DIFF
--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.215"
+	VERSION_APPLICATION = "11.0.216"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
Version bump after #736 (Chess / NetChess widgets + DuckLake LP mapping fix). No code changes.