### PR TITLE
fix(netris): shrink default widget width + release 11.0.217

### DIFF
--- a/src/coordinator/services/dashboard_service.go
+++ b/src/coordinator/services/dashboard_service.go
@@ -239,15 +239,16 @@ func (s *DashboardService) ResetDashboards(ctx context.Context, username string)
 
 	// Default "NetGames" dashboard with the multiplayer game widgets. They
 	// require coordinator hubs (netris, netchess), so we surface them in a
-	// dedicated tab to avoid surprising single-user installs. NetChess
-	// matches the single-player Chess widget footprint (8x12) rather than
-	// the full 12-wide arena Netris needs.
+	// dedicated tab to avoid surprising single-user installs. Both widgets
+	// share an 8x12 footprint — their boards are very different shapes
+	// (10x20 vs 8x8) but both fit comfortably in that area thanks to the
+	// per-widget useArenaCellSize auto-fit.
 	netGamesData, _ := json.Marshal(map[string]interface{}{
 		"name": "NetGames", "param": "netgames", "shared": false, "type": 3, "weight": 40,
 		"config": map[string]interface{}{"columns": 12, "grid_type": "fit", "locked": false},
 		"widgets": []map[string]interface{}{
-			{"id": "netris-1", "type": "netris", "x": 0, "y": 0, "w": 12, "h": 14, "title": "Netris"},
-			{"id": "netchess-1", "type": "netchess", "x": 0, "y": 14, "w": 8, "h": 12, "title": "NetChess"},
+			{"id": "netris-1", "type": "netris", "x": 0, "y": 0, "w": 8, "h": 12, "title": "Netris"},
+			{"id": "netchess-1", "type": "netchess", "x": 0, "y": 12, "w": 8, "h": 12, "title": "NetChess"},
 		},
 	})
 	if _, err := s.CreateDashboard(ctx, username, "netgames", netGamesData); err != nil {

--- a/src/ui/src/dashboard/widgets/registry.ts
+++ b/src/ui/src/dashboard/widgets/registry.ts
@@ -275,10 +275,14 @@ export const widgetRegistry: Record<string, WidgetMeta> = {
     label: 'Netris',
     icon: 'game',
     category: 'Games',
-    minW: 8,
+    // The 10x20 arena + 200 px opponent sidebar fits comfortably in
+    // ~8 grid columns. The previous 12-col default left a lot of
+    // empty horizontal space inside the flex-1 wrapper because the
+    // arena is `flex-shrink-0` and the cell clamp tops out at 48 px.
+    minW: 5,
     minH: 8,
-    defaultW: 12,
-    defaultH: 14,
+    defaultW: 8,
+    defaultH: 12,
   },
   chess: {
     component: ChessPanel,

--- a/src/ui/src/dashboard/widgets/registry.ts
+++ b/src/ui/src/dashboard/widgets/registry.ts
@@ -265,7 +265,10 @@ export const widgetRegistry: Record<string, WidgetMeta> = {
     label: 'SIPetris',
     icon: 'game',
     category: 'Games',
-    minW: 5,
+    // The 10x20 arena uses useArenaCellSize with CELL_MIN_PX=14 so it
+    // still renders at narrow widths — the floor is now in line with
+    // the rest of the Games widgets.
+    minW: 4,
     minH: 8,
     defaultW: 7,
     defaultH: 12,
@@ -279,7 +282,9 @@ export const widgetRegistry: Record<string, WidgetMeta> = {
     // ~8 grid columns. The previous 12-col default left a lot of
     // empty horizontal space inside the flex-1 wrapper because the
     // arena is `flex-shrink-0` and the cell clamp tops out at 48 px.
-    minW: 5,
+    // minW is permissive (4) — useArenaCellSize will scale the cells
+    // down to CELL_MIN_PX=12 when the widget is squeezed.
+    minW: 4,
     minH: 8,
     defaultW: 8,
     defaultH: 12,
@@ -289,7 +294,9 @@ export const widgetRegistry: Record<string, WidgetMeta> = {
     label: 'Chess',
     icon: 'game',
     category: 'Games',
-    minW: 6,
+    // 8x8 board + 220 px sidebar. CELL_MIN_PX=16 keeps the board
+    // legible down to ~4 grid columns where the sidebar dominates.
+    minW: 4,
     minH: 8,
     defaultW: 8,
     defaultH: 12,
@@ -302,7 +309,7 @@ export const widgetRegistry: Record<string, WidgetMeta> = {
     // Mirror the `chess` widget — the 220 px sidebar is identical and
     // the board itself is 8x8, so there is no good reason for the
     // NetChess board to render wider than the single-player one.
-    minW: 6,
+    minW: 4,
     minH: 8,
     defaultW: 8,
     defaultH: 12,

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.216"
+	VERSION_APPLICATION = "11.0.217"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary

- **`fix(netris)`**: drop the Netris widget default from `12x14` to `8x12` (`minW=5`). The inner Netris arena is `flex-shrink-0` with width = `COLS * cellPx` (10 cols, cellPx clamp ≤ 48) plus a 200 px opponent sidebar, so the previous full-row width left several hundred pixels of empty space inside the flex-1 wrapper. After this change a freshly-added Netris widget matches the NetChess footprint and the arena no longer drowns in whitespace.
- **NetGames seed**: both multiplayer widgets are now 8x12 stacked vertically (was: netris 12x14 + netchess 8x12). Matches what the user sees once the new defaults take effect.
- **`chore`**: bump `VERSION_APPLICATION` to 11.0.217.

Mirror of the same treatment NetChess got in #736.

## Test plan

- [x] `go test ./coordinator/services/...` — `TestResetDashboards_*` still green.
- [x] `tsc --noEmit` clean.
- [ ] Boot the coordinator, reset dashboards, open `NetGames` and confirm the Netris widget fits its area without horizontal dead space; resize the widget down to `minW=5` and confirm the arena still renders.