### PR TITLE
fix(auth): read auth-token user_group key with correct underscore

### DIFF
--- a/src/coordinator/handlers/auth.go
+++ b/src/coordinator/handlers/auth.go
@@ -393,7 +393,7 @@ func (h *AuthHandler) authenticateWithAuthTokenHeader(c echo.Context) bool {
 
 type authTokenUserObject struct {
 	Username  string `json:"username"`
-	Usergroup string `json:"usergroup"`
+	UserGroup string `json:"user_group"`
 }
 
 func (h *AuthHandler) jwtTokenFromAuthTokenItem(item *services.AuthTokenItem) *jwt.Token {
@@ -405,7 +405,7 @@ func (h *AuthHandler) jwtTokenFromAuthTokenItem(item *services.AuthTokenItem) *j
 			if uo.Username != "" {
 				userName = uo.Username
 			}
-			if strings.EqualFold(uo.Usergroup, "admin") {
+			if strings.EqualFold(uo.UserGroup, "admin") {
 				isAdmin = true
 			}
 		}

--- a/src/coordinator/handlers/auth_v4_test.go
+++ b/src/coordinator/handlers/auth_v4_test.go
@@ -204,3 +204,40 @@ func TestV4PatchMe_Unauthenticated(t *testing.T) {
 		t.Fatalf("status: got %d want 401", rec.Code)
 	}
 }
+
+func TestJWTTokenFromAuthTokenItem_AdminUserGroupGrantsAdmin(t *testing.T) {
+	h := &AuthHandler{}
+	item := &services.AuthTokenItem{
+		GUID:       "tok-1",
+		UserObject: json.RawMessage(`{"username":"alice","user_group":"admin"}`),
+	}
+
+	tok := h.jwtTokenFromAuthTokenItem(item)
+	claims, ok := tok.Claims.(*JWTClaims)
+	if !ok {
+		t.Fatalf("claims type: got %T", tok.Claims)
+	}
+	if claims.Username != "alice" {
+		t.Fatalf("username: got %q want %q", claims.Username, "alice")
+	}
+	if !claims.Admin {
+		t.Fatal("admin: got false want true (user_group=admin should grant admin scope)")
+	}
+}
+
+func TestJWTTokenFromAuthTokenItem_NonAdminUserGroup(t *testing.T) {
+	h := &AuthHandler{}
+	item := &services.AuthTokenItem{
+		GUID:       "tok-2",
+		UserObject: json.RawMessage(`{"username":"bob","user_group":"user"}`),
+	}
+
+	tok := h.jwtTokenFromAuthTokenItem(item)
+	claims := tok.Claims.(*JWTClaims)
+	if claims.Username != "bob" {
+		t.Fatalf("username: got %q want %q", claims.Username, "bob")
+	}
+	if claims.Admin {
+		t.Fatal("admin: got true want false")
+	}
+}


### PR DESCRIPTION
The auth-token write path stores the creator's group as `user_group`, matching the convention used everywhere else in the codebase (users CRUD, config, LDAP, UI). The read path in jwtTokenFromAuthTokenItem unmarshaled the key as `usergroup` (no underscore), so the admin check never matched and tokens created by an admin were silently downgraded to non-admin scope.

Align the struct tag and field name with the rest of the codebase.