### PR TITLE
chore: bump VERSION_APPLICATION to 11.0.229

### DIFF
--- a/docs/UI_COORDINATOR_AUTH_AND_TOKENS.md
+++ b/docs/UI_COORDINATOR_AUTH_AND_TOKENS.md
@@ -89,7 +89,7 @@ Separate from JWT login, the coordinator can accept **static tokens** stored in 
 | **`enable_token_access`** | If `true`, the JWT middleware first checks the configured header for a raw token matching an `auth_token` row. |
 | **`auth_token_header`** | Header name (default **`Auth-Token`**). |
 
-When a valid row is found, the request is treated as authenticated with a **synthetic** user derived from the row’s **`user_object`** JSON: **`username`** and admin if **`usergroup`** equals **`admin`** (case-insensitive) — see `authenticateWithAuthTokenHeader` in `src/coordinator/handlers/auth.go`.
+When a valid row is found, the request is treated as authenticated with a **synthetic** user derived from the row’s **`user_object`** JSON: **`username`** and admin if **`user_group`** equals **`admin`** (case-insensitive) — see `authenticateWithAuthTokenHeader` in `src/coordinator/handlers/auth.go`.
 
 **How to use:**
 

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.228"
+	VERSION_APPLICATION = "11.0.229"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Bump `VERSION_APPLICATION` to `11.0.229` (follow-up after #751 auth-token `user_group` fix).
- Align `docs/UI_COORDINATOR_AUTH_AND_TOKENS.md` with the `user_group` key used in coordinator v4 auth-token `user_object`.

## Test plan
- [x] Docs-only + version bump; no runtime behavior change beyond version string.