### PR TITLE
Potential fix for code scanning alert no. 29: Database query built from user-controlled sources

### DIFF
--- a/src/storage/ducklake/timetravel.go
+++ b/src/storage/ducklake/timetravel.go
@@ -501,6 +501,14 @@ func (r *MultiTableReader) ListSnapshots(key TableKey, limit int) ([]Snapshot, e
 		limit = 100
 	}
 
+	// Enforce allowlist of known table schemas to prevent SQL injection via dynamic table naming.
+	r.writer.mu.RLock()
+	_, ok := r.writer.schemas[key]
+	r.writer.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("invalid table key")
+	}
+
 	tableFQN := r.writer.GetTableFQN(key)
 
 	query := fmt.Sprintf(`


### PR DESCRIPTION
Potential fix for [https://github.com/sipcapture/homer/security/code-scanning/29](https://github.com/sipcapture/homer/security/code-scanning/29)

Use a **strict allowlist validation** for `TableKey` before building SQL in `ListSnapshots`, so only known-safe table keys can be used to derive `tableFQN`. This avoids changing external behavior for valid keys and blocks malformed/injected subtype values. Keep `limit` bounded and build SQL only after validation.

Best targeted fix in shown code:
- **File:** `src/storage/ducklake/timetravel.go`
- **Region:** `ListSnapshots` method (around current lines 499–513).
- Add validation that `key` exists in `r.writer.schemas` (known configured schema set).
- If not present, return an error.
- Then proceed with existing query creation.

This preserves functionality for legitimate keys while preventing attacker-controlled fallback names from entering SQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
