### PR TITLE
fix(ducklake): validate TableKey and where before dynamic SQL

### DIFF
--- a/src/storage/ducklake/README.md
+++ b/src/storage/ducklake/README.md
@@ -275,8 +275,20 @@ Response:
 
 ### List Snapshots (per proto_type)
 
+Allowed `proto_type` / `sub_type` pairs match the canonical DuckLake schemas (see `GetTableSchemas()` in `tables.go`):
+
+| proto_type | sub_type | Table |
+|------------|----------|-------|
+| 1 (SIP) | `call` (default), `registration`, `default` | SIP call / registration / other |
+| 5 | _(empty)_ | RTCP JSON |
+| 34, 35 | _(empty)_ | RTCP / RTP |
+| 53 | _(empty)_ | DNS |
+| 100 | _(empty)_ | LOG |
+
+Invalid keys return **HTTP 400**. `limit` is clamped to 1000.
+
 ```bash
-GET /api/v1/ducklake/snapshots?proto_type=1&limit=10
+GET /api/v1/ducklake/snapshots?proto_type=1&sub_type=call&limit=10
 ```
 
 Response:
@@ -300,6 +312,12 @@ Response:
 
 ### Query
 
+The `where` field is **not** arbitrary SQL. It must be a simple expression built from allowed columns for the target table(s):
+
+- Predicates: `column = 'value'`, comparisons with integers, `column IS NULL`, combined with `AND` / `OR`
+- Column names must exist on the schema (e.g. `session_id`, `src_ip`, `timestamp`)
+- Max length 512; blocklisted tokens (`;`, `--`, `UNION`, `SELECT`, etc.) return **HTTP 400**
+
 Query specific proto_type:
 
 ```bash
@@ -308,6 +326,7 @@ Content-Type: application/json
 
 {
   "proto_type": 1,
+  "sub_type": "call",
   "where": "session_id = 'abc123@host'",
   "limit": 100
 }

--- a/src/storage/ducklake/api.go
+++ b/src/storage/ducklake/api.go
@@ -14,6 +14,18 @@ import (
 	"time"
 )
 
+func writeDuckLakeHandlerError(w http.ResponseWriter, err error, serverMsg string) {
+	if err == nil {
+		http.Error(w, serverMsg, http.StatusInternalServerError)
+		return
+	}
+	if IsClientInputError(err) {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	http.Error(w, serverMsg, http.StatusInternalServerError)
+}
+
 // API provides HTTP API for DuckLake operations (legacy single-table)
 type API struct {
 	reader *Reader
@@ -148,12 +160,13 @@ func (a *API) HandleSnapshots(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	limit := 100
+	limit := DefaultQueryLimit
 	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
-		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
+		if l, err := strconv.Atoi(limitStr); err == nil {
 			limit = l
 		}
 	}
+	limit = ClampLimit(limit, DefaultQueryLimit, MaxQueryLimit)
 
 	snapshots, err := a.reader.ListSnapshots(limit)
 	if err != nil {
@@ -194,9 +207,7 @@ func (a *API) HandleQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Limit <= 0 || req.Limit > 1000 {
-		req.Limit = 100
-	}
+	req.Limit = ClampLimit(req.Limit, DefaultQueryLimit, MaxQueryLimit)
 
 	var records []HEPRecord
 	var err error
@@ -218,7 +229,7 @@ func (a *API) HandleQuery(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		http.Error(w, "Query failed: "+err.Error(), http.StatusInternalServerError)
+		writeDuckLakeHandlerError(w, err, "Query failed")
 		return
 	}
 
@@ -382,28 +393,32 @@ func (a *MultiTableAPI) HandleSnapshots(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Build TableKey from query params
-	key := TableKey{ProtoType: 1, SubType: SIPTypeCall} // Default to SIP calls
-
+	protoType := uint32(ProtoTypeSIP)
 	if ptStr := r.URL.Query().Get("proto_type"); ptStr != "" {
-		if pt, err := strconv.ParseUint(ptStr, 10, 32); err == nil {
-			key.ProtoType = uint32(pt)
+		pt, err := strconv.ParseUint(ptStr, 10, 32)
+		if err != nil {
+			http.Error(w, "invalid proto_type", http.StatusBadRequest)
+			return
 		}
+		protoType = uint32(pt)
 	}
-	if subType := r.URL.Query().Get("sub_type"); subType != "" {
-		key.SubType = subType
+	key, err := ParseTableKey(protoType, r.URL.Query().Get("sub_type"))
+	if err != nil {
+		writeDuckLakeHandlerError(w, err, "invalid table key")
+		return
 	}
 
-	limit := 100
+	limit := DefaultQueryLimit
 	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
-		if l, err := strconv.Atoi(limitStr); err == nil && l > 0 {
+		if l, err := strconv.Atoi(limitStr); err == nil {
 			limit = l
 		}
 	}
+	limit = ClampLimit(limit, DefaultQueryLimit, MaxQueryLimit)
 
 	snapshots, err := a.reader.ListSnapshots(key, limit)
 	if err != nil {
-		http.Error(w, "Failed to list snapshots", http.StatusInternalServerError)
+		writeDuckLakeHandlerError(w, err, "Failed to list snapshots")
 		return
 	}
 
@@ -442,24 +457,24 @@ func (a *MultiTableAPI) HandleQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Limit <= 0 || req.Limit > 1000 {
-		req.Limit = 100
-	}
+	req.Limit = ClampLimit(req.Limit, DefaultQueryLimit, MaxQueryLimit)
 
 	var records []map[string]interface{}
 	var err error
 
 	if req.ProtoType != nil {
-		// Query specific table by TableKey
-		key := TableKey{ProtoType: *req.ProtoType, SubType: req.SubType}
+		key, keyErr := ParseTableKey(*req.ProtoType, req.SubType)
+		if keyErr != nil {
+			writeDuckLakeHandlerError(w, keyErr, "invalid table key")
+			return
+		}
 		records, err = a.reader.Query(key, req.Where, req.Limit)
 	} else {
-		// Query all tables
 		records, err = a.reader.QueryAll(req.Where, req.Limit)
 	}
 
 	if err != nil {
-		http.Error(w, "Query failed: "+err.Error(), http.StatusInternalServerError)
+		writeDuckLakeHandlerError(w, err, "Query failed")
 		return
 	}
 

--- a/src/storage/ducklake/timetravel.go
+++ b/src/storage/ducklake/timetravel.go
@@ -31,6 +31,10 @@ func NewReader(w *Writer) *Reader {
 
 // Query executes a query on current data
 func (r *Reader) Query(whereClause string, limit int) ([]HEPRecord, error) {
+	if err := ValidateWhereClause(whereClause, AllQueryColumns()); err != nil {
+		return nil, err
+	}
+	limit = ClampLimit(limit, DefaultQueryLimit, MaxQueryLimit)
 	query := fmt.Sprintf("SELECT * FROM %s", r.tableFQN)
 	if whereClause != "" {
 		query += " WHERE " + whereClause
@@ -45,6 +49,10 @@ func (r *Reader) Query(whereClause string, limit int) ([]HEPRecord, error) {
 
 // QueryAtSnapshot queries data at a specific snapshot
 func (r *Reader) QueryAtSnapshot(snapshotID int64, whereClause string, limit int) ([]HEPRecord, error) {
+	if err := ValidateWhereClause(whereClause, AllQueryColumns()); err != nil {
+		return nil, err
+	}
+	limit = ClampLimit(limit, DefaultQueryLimit, MaxQueryLimit)
 	// DuckLake syntax: SELECT * FROM table AT SNAPSHOT snapshot_id
 	query := fmt.Sprintf("SELECT * FROM %s AT SNAPSHOT %d", r.tableFQN, snapshotID)
 	if whereClause != "" {
@@ -60,6 +68,10 @@ func (r *Reader) QueryAtSnapshot(snapshotID int64, whereClause string, limit int
 
 // QueryAtTime queries data as it was at a specific timestamp
 func (r *Reader) QueryAtTime(asOf time.Time, whereClause string, limit int) ([]HEPRecord, error) {
+	if err := ValidateWhereClause(whereClause, AllQueryColumns()); err != nil {
+		return nil, err
+	}
+	limit = ClampLimit(limit, DefaultQueryLimit, MaxQueryLimit)
 	// DuckLake syntax: SELECT * FROM table AT TIMESTAMP 'timestamp'
 	timestamp := asOf.Format("2006-01-02 15:04:05")
 	query := fmt.Sprintf("SELECT * FROM %s AT TIMESTAMP '%s'", r.tableFQN, timestamp)
@@ -108,9 +120,7 @@ func (r *Reader) executeQuery(query string) ([]HEPRecord, error) {
 
 // ListSnapshots returns all available snapshots
 func (r *Reader) ListSnapshots(limit int) ([]Snapshot, error) {
-	if limit <= 0 {
-		limit = 100
-	}
+	limit = ClampLimit(limit, DefaultQueryLimit, MaxQueryLimit)
 
 	// DuckLake provides snapshot info via system function
 	query := fmt.Sprintf(`
@@ -259,8 +269,12 @@ func NewMultiTableReader(w *MultiTableWriter) *MultiTableReader {
 
 // allTablesForKey returns the DuckLake table and, when search_buffer is enabled,
 // both in-memory buffer tables for a key.
-func (r *MultiTableReader) allTablesForKey(key TableKey) []string {
-	tables := []string{r.writer.GetTableFQN(key)}
+func (r *MultiTableReader) allTablesForKey(key TableKey) ([]string, error) {
+	fqn, err := ResolveTableFQN(r.writer, key)
+	if err != nil {
+		return nil, err
+	}
+	tables := []string{fqn}
 	if r.searchBuffer {
 		if tw := r.writer.GetTable(key); tw != nil {
 			for _, mem := range tw.MemTableNames() {
@@ -268,7 +282,7 @@ func (r *MultiTableReader) allTablesForKey(key TableKey) []string {
 			}
 		}
 	}
-	return tables
+	return tables, nil
 }
 
 // GetTimeRange returns min/max timestamps across all tables including buffers
@@ -279,7 +293,11 @@ func (r *MultiTableReader) GetTimeRange() (minTs, maxTs int64, err error) {
 	}
 
 	for _, key := range keys {
-		for _, tbl := range r.allTablesForKey(key) {
+		tbls, tblErr := r.allTablesForKey(key)
+		if tblErr != nil {
+			continue
+		}
+		for _, tbl := range tbls {
 			query := fmt.Sprintf("SELECT MIN(timestamp), MAX(timestamp) FROM %s", tbl)
 			var minNull, maxNull sql.NullInt64
 			if err := r.db.QueryRow(query).Scan(&minNull, &maxNull); err != nil {
@@ -299,7 +317,14 @@ func (r *MultiTableReader) GetTimeRange() (minTs, maxTs int64, err error) {
 
 // GetTimeRangeForTableKey returns time range for specific TableKey including buffers
 func (r *MultiTableReader) GetTimeRangeForTableKey(key TableKey) (minTs, maxTs int64, err error) {
-	for _, tbl := range r.allTablesForKey(key) {
+	if err := ValidateTableKey(key); err != nil {
+		return 0, 0, err
+	}
+	tbls, err := r.allTablesForKey(key)
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, tbl := range tbls {
 		query := fmt.Sprintf("SELECT MIN(timestamp), MAX(timestamp) FROM %s", tbl)
 		var minNull, maxNull sql.NullInt64
 		if err := r.db.QueryRow(query).Scan(&minNull, &maxNull); err != nil {
@@ -338,7 +363,11 @@ func (r *MultiTableReader) GetRowCount() (int64, error) {
 	var total int64
 
 	for _, key := range keys {
-		for _, tbl := range r.allTablesForKey(key) {
+		tbls, tblErr := r.allTablesForKey(key)
+		if tblErr != nil {
+			continue
+		}
+		for _, tbl := range tbls {
 			var count int64
 			query := fmt.Sprintf("SELECT COUNT(*) FROM %s", tbl)
 			if err := r.db.QueryRow(query).Scan(&count); err != nil {
@@ -353,8 +382,15 @@ func (r *MultiTableReader) GetRowCount() (int64, error) {
 
 // GetRowCountForTableKey returns row count for specific TableKey including buffers
 func (r *MultiTableReader) GetRowCountForTableKey(key TableKey) (int64, error) {
+	if err := ValidateTableKey(key); err != nil {
+		return 0, err
+	}
+	tbls, err := r.allTablesForKey(key)
+	if err != nil {
+		return 0, err
+	}
 	var total int64
-	for _, tbl := range r.allTablesForKey(key) {
+	for _, tbl := range tbls {
 		var count int64
 		query := fmt.Sprintf("SELECT COUNT(*) FROM %s", tbl)
 		if err := r.db.QueryRow(query).Scan(&count); err != nil {
@@ -369,8 +405,12 @@ func (r *MultiTableReader) GetRowCountForTableKey(key TableKey) (int64, error) {
 // is enabled, it builds a UNION ALL across the DuckLake persistent table and
 // both in-memory buffer tables so queries see the freshest data even before
 // flush. When search_buffer is disabled, it queries only the DuckLake table.
-func (r *MultiTableReader) buildUnionQuery(key TableKey, whereClause string, limit int) string {
-	tables := r.allTablesForKey(key)
+func (r *MultiTableReader) buildUnionQuery(key TableKey, whereClause string, limit int) (string, error) {
+	tables, err := r.allTablesForKey(key)
+	if err != nil {
+		return "", err
+	}
+	limit = ClampLimit(limit, DefaultQueryLimit, MaxQueryLimit)
 
 	if len(tables) == 1 {
 		query := fmt.Sprintf("SELECT * FROM %s", tables[0])
@@ -381,7 +421,7 @@ func (r *MultiTableReader) buildUnionQuery(key TableKey, whereClause string, lim
 		if limit > 0 {
 			query += fmt.Sprintf(" LIMIT %d", limit)
 		}
-		return query
+		return query, nil
 	}
 
 	var parts []string
@@ -398,20 +438,37 @@ func (r *MultiTableReader) buildUnionQuery(key TableKey, whereClause string, lim
 	if limit > 0 {
 		query += fmt.Sprintf(" LIMIT %d", limit)
 	}
-	return query
+	return query, nil
 }
 
 // Query executes a query on specific table by TableKey.
 // Includes data from both in-memory buffers via UNION ALL so that
 // un-flushed records are visible to search.
 func (r *MultiTableReader) Query(key TableKey, whereClause string, limit int) ([]map[string]interface{}, error) {
-	query := r.buildUnionQuery(key, whereClause, limit)
+	if err := ValidateTableKey(key); err != nil {
+		return nil, err
+	}
+	cols, err := ColumnsForTableKey(key)
+	if err != nil {
+		return nil, err
+	}
+	if err := ValidateWhereClause(whereClause, cols); err != nil {
+		return nil, err
+	}
+	query, err := r.buildUnionQuery(key, whereClause, limit)
+	if err != nil {
+		return nil, err
+	}
 	return r.executeQueryGeneric(query)
 }
 
 // QueryAll executes a query across all tables.
 // Includes data from both in-memory buffers via UNION ALL.
 func (r *MultiTableReader) QueryAll(whereClause string, limit int) ([]map[string]interface{}, error) {
+	if err := ValidateWhereClause(whereClause, AllQueryColumns()); err != nil {
+		return nil, err
+	}
+	limit = ClampLimit(limit, DefaultQueryLimit, MaxQueryLimit)
 	keys := r.writer.ListTableKeys()
 	if len(keys) == 0 {
 		return nil, nil
@@ -419,7 +476,13 @@ func (r *MultiTableReader) QueryAll(whereClause string, limit int) ([]map[string
 
 	var allResults []map[string]interface{}
 	for _, key := range keys {
-		query := r.buildUnionQuery(key, whereClause, limit)
+		if err := ValidateTableKey(key); err != nil {
+			continue
+		}
+		query, err := r.buildUnionQuery(key, whereClause, limit)
+		if err != nil {
+			continue
+		}
 		results, err := r.executeQueryGeneric(query)
 		if err != nil {
 			continue
@@ -497,11 +560,11 @@ func extractTimestamp(row map[string]interface{}) time.Time {
 
 // ListSnapshots returns snapshots for a specific table by TableKey
 func (r *MultiTableReader) ListSnapshots(key TableKey, limit int) ([]Snapshot, error) {
-	if limit <= 0 {
-		limit = 100
+	limit = ClampLimit(limit, DefaultQueryLimit, MaxQueryLimit)
+	tableFQN, err := ResolveTableFQN(r.writer, key)
+	if err != nil {
+		return nil, err
 	}
-
-	tableFQN := r.writer.GetTableFQN(key)
 
 	query := fmt.Sprintf(`
 		SELECT snapshot_id, snapshot_time, row_count

--- a/src/storage/ducklake/validation.go
+++ b/src/storage/ducklake/validation.go
@@ -1,0 +1,188 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package ducklake
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	DefaultQueryLimit = 100
+	MaxQueryLimit     = 1000
+	maxWhereLen       = 512
+)
+
+var (
+	ErrInvalidTableKey = errors.New("invalid table key")
+	ErrInvalidWhere      = errors.New("invalid where clause")
+
+	canonicalSchemas = GetTableSchemas()
+
+	whereBlocklist = []string{
+		";", "--", "/*", "*/", "\x00",
+		" union ", " select ", " insert ", " update ", " delete ",
+		" drop ", " attach ", " copy ", " call ", " exec ", " pragma ",
+	}
+
+	whereSplitRE = regexp.MustCompile(`(?i)\s+(?:AND|OR)\s+`)
+
+	predicateCompareRE = regexp.MustCompile(`(?i)^([a-zA-Z_][a-zA-Z0-9_]*)\s*(=|!=|<>|>=|<=|>|<)\s*('(?:[^'\\]|\\.|'')*'|-?\d+)\s*$`)
+
+	predicateIsNullRE = regexp.MustCompile(`(?i)^([a-zA-Z_][a-zA-Z0-9_]*)\s+IS\s+NOT\s+NULL\s*$`)
+
+	predicateIsNullOnlyRE = regexp.MustCompile(`(?i)^([a-zA-Z_][a-zA-Z0-9_]*)\s+IS\s+NULL\s*$`)
+)
+
+// ValidateTableKey checks that key is in the static GetTableSchemas allowlist.
+func ValidateTableKey(key TableKey) error {
+	if _, ok := canonicalSchemas[key]; ok {
+		return nil
+	}
+	return fmt.Errorf("%w: proto_type=%d sub_type=%q", ErrInvalidTableKey, key.ProtoType, key.SubType)
+}
+
+// ParseTableKey builds and validates a TableKey from HTTP/API parameters.
+func ParseTableKey(protoType uint32, subType string) (TableKey, error) {
+	subType = strings.TrimSpace(subType)
+	if protoType == ProtoTypeSIP {
+		if subType == "" {
+			subType = SIPTypeCall
+		}
+		switch subType {
+		case SIPTypeCall, SIPTypeRegistration, SIPTypeDefault:
+		default:
+			return TableKey{}, fmt.Errorf("%w: invalid sub_type %q for SIP (allowed: call, registration, default)", ErrInvalidTableKey, subType)
+		}
+		return TableKey{ProtoType: protoType, SubType: subType}, nil
+	}
+	if subType != "" {
+		return TableKey{}, fmt.Errorf("%w: sub_type must be empty for proto_type %d", ErrInvalidTableKey, protoType)
+	}
+	key := TableKey{ProtoType: protoType}
+	if err := ValidateTableKey(key); err != nil {
+		return TableKey{}, err
+	}
+	return key, nil
+}
+
+// ResolveTableFQN returns the DuckLake table FQN for a canonical TableKey without
+// using GetDefaultSchema (prevents user-controlled suffix injection).
+func ResolveTableFQN(writer *MultiTableWriter, key TableKey) (string, error) {
+	if err := ValidateTableKey(key); err != nil {
+		return "", err
+	}
+	if tw := writer.GetTable(key); tw != nil {
+		return tw.TableFQN(), nil
+	}
+	schema, ok := canonicalSchemas[key]
+	if !ok {
+		return "", fmt.Errorf("%w", ErrInvalidTableKey)
+	}
+	return fmt.Sprintf("%s.hep_proto_%s", writer.GetLakeName(), schema.TableSuffix), nil
+}
+
+// ClampLimit bounds limit to [1, maxLimit], using defaultLimit when limit <= 0.
+func ClampLimit(limit, defaultLimit, maxLimit int) int {
+	if limit <= 0 {
+		return defaultLimit
+	}
+	if limit > maxLimit {
+		return maxLimit
+	}
+	return limit
+}
+
+// ColumnsForTableKey returns queryable column names for a canonical table key.
+func ColumnsForTableKey(key TableKey) ([]string, error) {
+	schema, ok := canonicalSchemas[key]
+	if !ok {
+		return nil, fmt.Errorf("%w", ErrInvalidTableKey)
+	}
+	return append([]string(nil), schema.Columns...), nil
+}
+
+// AllQueryColumns returns the union of columns across all canonical schemas.
+func AllQueryColumns() []string {
+	seen := make(map[string]struct{})
+	var cols []string
+	for _, schema := range canonicalSchemas {
+		for _, c := range schema.Columns {
+			if _, ok := seen[c]; ok {
+				continue
+			}
+			seen[c] = struct{}{}
+			cols = append(cols, c)
+		}
+	}
+	return cols
+}
+
+// ValidateWhereClause ensures where is a safe subset of SQL (column op literal predicates).
+func ValidateWhereClause(where string, allowedColumns []string) error {
+	where = strings.TrimSpace(where)
+	if where == "" {
+		return nil
+	}
+	if len(where) > maxWhereLen {
+		return fmt.Errorf("%w: too long (max %d characters)", ErrInvalidWhere, maxWhereLen)
+	}
+	lower := strings.ToLower(where)
+	for _, bad := range whereBlocklist {
+		if strings.Contains(lower, bad) {
+			return fmt.Errorf("%w: contains disallowed token", ErrInvalidWhere)
+		}
+	}
+	allowed := make(map[string]struct{}, len(allowedColumns))
+	for _, c := range allowedColumns {
+		allowed[strings.ToLower(c)] = struct{}{}
+	}
+	predicates := whereSplitRE.Split(where, -1)
+	for _, pred := range predicates {
+		pred = strings.TrimSpace(pred)
+		if pred == "" {
+			continue
+		}
+		col, err := validatePredicate(pred, allowed)
+		if err != nil {
+			return err
+		}
+		_ = col
+	}
+	return nil
+}
+
+func validatePredicate(pred string, allowed map[string]struct{}) (string, error) {
+	var col string
+	switch {
+	case predicateIsNullRE.MatchString(pred):
+		col = predicateIsNullRE.FindStringSubmatch(pred)[1]
+	case predicateIsNullOnlyRE.MatchString(pred):
+		col = predicateIsNullOnlyRE.FindStringSubmatch(pred)[1]
+	case predicateCompareRE.MatchString(pred):
+		col = predicateCompareRE.FindStringSubmatch(pred)[1]
+	default:
+		return "", fmt.Errorf("%w: invalid predicate %q", ErrInvalidWhere, pred)
+	}
+	if _, ok := allowed[strings.ToLower(col)]; !ok {
+		return "", fmt.Errorf("%w: unknown column %q", ErrInvalidWhere, col)
+	}
+	return col, nil
+}
+
+// IsInvalidTableKey reports whether err is ErrInvalidTableKey (including wrapped).
+func IsInvalidTableKey(err error) bool {
+	return errors.Is(err, ErrInvalidTableKey)
+}
+
+// IsClientInputError reports validation failures that should map to HTTP 400.
+func IsClientInputError(err error) bool {
+	return errors.Is(err, ErrInvalidTableKey) || errors.Is(err, ErrInvalidWhere)
+}

--- a/src/storage/ducklake/validation_test.go
+++ b/src/storage/ducklake/validation_test.go
@@ -1,0 +1,163 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package ducklake
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestValidateTableKey_valid(t *testing.T) {
+	cases := []TableKey{
+		{ProtoType: ProtoTypeSIP, SubType: SIPTypeCall},
+		{ProtoType: ProtoTypeRTCPJSON},
+		{ProtoType: ProtoTypeDNS},
+	}
+	for _, key := range cases {
+		if err := ValidateTableKey(key); err != nil {
+			t.Fatalf("ValidateTableKey(%+v): %v", key, err)
+		}
+	}
+}
+
+func TestValidateTableKey_injectionSubType(t *testing.T) {
+	key := TableKey{ProtoType: ProtoTypeSIP, SubType: "'); DROP--"}
+	if err := ValidateTableKey(key); err == nil {
+		t.Fatal("expected error for injected sub_type")
+	}
+}
+
+func TestParseTableKey(t *testing.T) {
+	key, err := ParseTableKey(ProtoTypeSIP, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key.SubType != SIPTypeCall {
+		t.Fatalf("default sub_type: got %q", key.SubType)
+	}
+
+	_, err = ParseTableKey(ProtoTypeRTCPJSON, "evil")
+	if err == nil {
+		t.Fatal("expected error for sub_type on non-SIP proto")
+	}
+
+	_, err = ParseTableKey(ProtoTypeSIP, "not-a-type")
+	if !errors.Is(err, ErrInvalidTableKey) {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestResolveTableFQN_canonicalWithoutTable(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.LakeName = "test_lake"
+	mtw, err := NewMultiTableWriter(cfg)
+	if err != nil {
+		t.Skipf("duckdb not available: %v", err)
+	}
+	defer mtw.Stop()
+
+	key := TableKey{ProtoType: ProtoTypeSIP, SubType: SIPTypeCall}
+	fqn, err := ResolveTableFQN(mtw, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "test_lake.hep_proto_1_call"
+	if fqn != want {
+		t.Fatalf("got %q want %q", fqn, want)
+	}
+}
+
+func TestResolveTableFQN_rejectsUnknownKey(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.LakeName = "test_lake"
+	mtw, err := NewMultiTableWriter(cfg)
+	if err != nil {
+		t.Skipf("duckdb not available: %v", err)
+	}
+	defer mtw.Stop()
+
+	_, err = ResolveTableFQN(mtw, TableKey{ProtoType: 999, SubType: "x"})
+	if !IsInvalidTableKey(err) {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestValidateWhereClause_valid(t *testing.T) {
+	cols := []string{"session_id", "src_ip", "timestamp"}
+	cases := []string{
+		"",
+		"session_id = 'abc123@host'",
+		"src_ip = '192.168.1.100' AND timestamp > 0",
+		"session_id IS NULL",
+	}
+	for _, where := range cases {
+		if err := ValidateWhereClause(where, cols); err != nil {
+			t.Fatalf("where %q: %v", where, err)
+		}
+	}
+}
+
+func TestValidateWhereClause_rejectsInjection(t *testing.T) {
+	cols := []string{"session_id", "src_ip"}
+	cases := []string{
+		"'; DROP TABLE",
+		"session_id = 'x' UNION SELECT",
+		"unknown_col = '1'",
+	}
+	for _, where := range cases {
+		err := ValidateWhereClause(where, cols)
+		if err == nil {
+			t.Fatalf("expected error for where %q", where)
+		}
+		if !errors.Is(err, ErrInvalidWhere) {
+			t.Fatalf("where %q: expected ErrInvalidWhere, got %v", where, err)
+		}
+	}
+}
+
+func TestClampLimit(t *testing.T) {
+	if got := ClampLimit(0, 100, 1000); got != 100 {
+		t.Fatalf("got %d", got)
+	}
+	if got := ClampLimit(5000, 100, 1000); got != 1000 {
+		t.Fatalf("got %d", got)
+	}
+}
+
+func TestMultiTableReader_ListSnapshots_rejectsInvalidKey(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.LakeName = "test_lake"
+	mtw, err := NewMultiTableWriter(cfg)
+	if err != nil {
+		t.Skipf("duckdb not available: %v", err)
+	}
+	defer mtw.Stop()
+
+	reader := NewMultiTableReader(mtw)
+	_, err = reader.ListSnapshots(TableKey{ProtoType: 1, SubType: "'); DROP--"}, 10)
+	if !IsInvalidTableKey(err) {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestMultiTableReader_Query_rejectsInvalidWhere(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.LakeName = "test_lake"
+	mtw, err := NewMultiTableWriter(cfg)
+	if err != nil {
+		t.Skipf("duckdb not available: %v", err)
+	}
+	defer mtw.Stop()
+
+	reader := NewMultiTableReader(mtw)
+	key := TableKey{ProtoType: ProtoTypeSIP, SubType: SIPTypeCall}
+	_, err = reader.Query(key, "'; DROP TABLE", 10)
+	if !errors.Is(err, ErrInvalidWhere) {
+		t.Fatalf("got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `validation.go`: canonical `TableKey` allowlist, `ResolveTableFQN` (no `GetDefaultSchema` fallback on API paths), `ValidateWhereClause` with column allowlist + keyword blocklist, `ClampLimit` (max 1000).
- Harden `MultiTableReader` (`ListSnapshots`, `Query`, `QueryAll`, time range, row count) and HTTP handlers (`HandleSnapshots`, `HandleQuery`) — invalid input returns **400**.
- Document allowed `proto_type`/`sub_type` and `where` format in DuckLake README.

Closes CodeQL [#29](https://github.com/sipcapture/homer/security/code-scanning/29) more completely than draft PR #753 (which only patched `ListSnapshots` and used mutable `writer.schemas`).

## Test plan
- [x] `go test ./storage/ducklake/... -run 'TestValidate|TestParse|TestClamp|TestResolve|TestMultiTableReader'`
- [ ] `GET /api/v1/ducklake/snapshots?proto_type=1&sub_type=call` returns snapshots or empty list
- [ ] `GET ...&sub_type=');DROP--` returns 400
- [ ] `POST /api/v1/ducklake/query` with `where: "session_id = 'x'"` works; `where: "'; DROP"` returns 400