### PR TITLE
fix(scripting): safe uint32 parse in Lua SetHEPField (CodeQL #20)

### DIFF
--- a/src/scripting/luaengine.go
+++ b/src/scripting/luaengine.go
@@ -210,6 +210,15 @@ func (d *LuaEngine) SetCustomSIPHeader(m *map[string]string) {
 	}
 }
 
+// parseUint32HEPField parses a decimal string into uint32 (CodeQL: avoid Atoi→uint32 truncation).
+func parseUint32HEPField(value string) (uint32, bool) {
+	u, err := strconv.ParseUint(strings.TrimSpace(value), 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return uint32(u), true
+}
+
 func (d *LuaEngine) SetHEPField(field string, value string) {
 	if (*d.hepPkt) == nil {
 		logger.Error("Scripting: Cannot set HEP field - HEP struct is nil")
@@ -219,24 +228,24 @@ func (d *LuaEngine) SetHEPField(field string, value string) {
 
 	switch field {
 	case "ProtoType":
-		if i, err := strconv.Atoi(value); err == nil {
-			hepPkt.ProtoType = uint32(i)
+		if u, ok := parseUint32HEPField(value); ok {
+			hepPkt.ProtoType = u
 		}
 	case "SrcIP":
 		hepPkt.SrcIP = value
 	case "SrcPort":
-		if i, err := strconv.Atoi(value); err == nil {
-			hepPkt.SrcPort = uint32(i)
+		if u, ok := parseUint32HEPField(value); ok {
+			hepPkt.SrcPort = u
 		}
 	case "DstIP":
 		hepPkt.DstIP = value
 	case "DstPort":
-		if i, err := strconv.Atoi(value); err == nil {
-			hepPkt.DstPort = uint32(i)
+		if u, ok := parseUint32HEPField(value); ok {
+			hepPkt.DstPort = u
 		}
 	case "NodeID":
-		if i, err := strconv.Atoi(value); err == nil {
-			hepPkt.NodeID = uint32(i)
+		if u, ok := parseUint32HEPField(value); ok {
+			hepPkt.NodeID = u
 		}
 	case "CID":
 		hepPkt.CID = value

--- a/src/scripting/luaengine_parse_test.go
+++ b/src/scripting/luaengine_parse_test.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package scripting
+
+import (
+	"math"
+	"strconv"
+	"testing"
+)
+
+func TestParseUint32HEPField(t *testing.T) {
+	u, ok := parseUint32HEPField("42")
+	if !ok || u != 42 {
+		t.Fatalf("got %d ok=%v", u, ok)
+	}
+
+	_, ok = parseUint32HEPField("not-a-number")
+	if ok {
+		t.Fatal("expected parse failure")
+	}
+
+	overflow := strconv.FormatUint(uint64(math.MaxUint32)+1, 10)
+	_, ok = parseUint32HEPField(overflow)
+	if ok {
+		t.Fatal("expected overflow rejection")
+	}
+
+	u, ok = parseUint32HEPField(strconv.FormatUint(math.MaxUint32, 10))
+	if !ok || u != math.MaxUint32 {
+		t.Fatalf("max uint32: got %d ok=%v", u, ok)
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes [CodeQL alert #20](https://github.com/sipcapture/homer/security/code-scanning/20): `strconv.Atoi` → `uint32` without bounds in `SetHEPField` (`NodeID`).
- Adds `parseUint32HEPField` using `strconv.ParseUint(value, 10, 32)` for `ProtoType`, `SrcPort`, `DstPort`, and `NodeID` (also closes alerts [#17–#19](https://github.com/sipcapture/homer/security/code-scanning/17) in the same switch).

## Test plan
- [x] `luaengine_parse_test.go` — valid, invalid, overflow, max uint32
- [x] CI CodeQL re-scan should clear go/incorrect-integer-conversion for `luaengine.go`