### PR TITLE
fix(security): resolve open CodeQL Go alerts (#9–#20)

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -125,6 +125,8 @@ homer agent stats --host 10.0.0.5:8008 --user admin --pass secret
 homer agent watch --host 10.0.0.5:8008 --user admin --pass secret --interval 5s
 ```
 
+**HTTPS / self-signed TLS:** same as `homer search` — certificate verification is on by default. For self-signed heplify or coordinator certs, set **`HOMER_INSECURE_TLS=1`** before running the command. See [SEARCH.md — TLS to the coordinator](SEARCH.md#tls-to-the-coordinator).
+
 Note: the `/health` endpoint is always open (no auth required).
 
 ## heplify API Endpoints

--- a/docs/AUTH_LDAP_AND_OAUTH.md
+++ b/docs/AUTH_LDAP_AND_OAUTH.md
@@ -10,7 +10,16 @@ For JWT lifecycle and logout, see the notes at the end.
 
 > **Implementation:** homer-core accepts **`coordinator.auth`** as a JSON **string** (`"internal"`, backward compatible), as **`{"type":"internal"}`** (recommended), or as an **object** without `type` (normalized to **`internal`**) with optional **`admin_user`** / **`admin_password_hash`**. **`--reset-admin-password`** is documented below.
 
-Password login with **`type`** omitted or **`internal`** on `POST /api/v4/auth/sessions` checks credentials **only** against rows in the coordinator **settings DuckDB** table **`users`** (`coordinator.settings_db_path`). There is **no** separate “login from JSON only” path: a user must exist in `users` with a matching **SHA-256** `password_hash` (hex) of the presented password.
+Password login with **`type`** omitted or **`internal`** on `POST /api/v4/auth/sessions` checks credentials **only** against rows in the coordinator **settings DuckDB** table **`users`** (`coordinator.settings_db_path`). There is **no** separate “login from JSON only” path: a user must exist in `users` with a matching `password_hash` for the presented password.
+
+**Password hash formats in `users.password_hash`:**
+
+| Format | When used | Verification |
+|--------|-----------|--------------|
+| **bcrypt** (`$2a$…`, `$2b$…`, `$2y$…`) | New or updated passwords via Users API / `PATCH /me` | `bcrypt.CompareHashAndPassword` |
+| **SHA-256 hex** (64 chars) | Default bootstrap admin (`sipcapture`), migrated homer-app rows, `--reset-admin-password` | Legacy compare (hex digest of password) |
+
+The coordinator accepts **either** format at login. Prefer letting the API create bcrypt hashes for new users instead of hand-editing SHA-256 in DuckDB.
 
 If **`coordinator.auth` is omitted** entirely (no `auth` key), the loader behaves like **`{"type":"internal"}`**: default admin `admin`, default bootstrap hash for **`sipcapture`**, and the same startup insert into **`users`** when missing.
 
@@ -59,7 +68,7 @@ Meaning (string or `{"type":"internal"}` without custom hash):
 - The loader treats **`"internal"`** (case-insensitive) or **`{"type":"internal"}`** as **built-in local auth** with default admin name **`admin`** and a **fixed bootstrap password hash** (SHA-256 hex of **`sipcapture`**):  
   `883ffc1f37fd0fe542b0fb9740035c4383e7d976c411161d24e62edace280f90`.
 - On coordinator startup, if there is **no** row in `users` whose **`username`** equals the configured admin name (default `admin`), the coordinator **inserts** that admin once (`is_admin` / `is_active` true) with that hash. If a row for that username **already** exists, nothing is inserted automatically (empty `password_hash` may still be repaired on startup in recent builds).
-- After first login, operators should **change the password** (Settings → Users, or `UPDATE` on `users` in DuckDB). Further logins use the stored hash only.
+- After first login, operators should **change the password** (Settings → Users, or `PATCH /me`). Updates store a **bcrypt** hash. Further logins use the stored hash only.
 
 ### Legacy object: only `admin_user` / `admin_password_hash` (no `type`)
 
@@ -73,7 +82,7 @@ You may still use an object **without** `type` (for environment overrides, confi
 ```
 
 - If **`admin_user`** is unset or **`admin`** and **`admin_password_hash`** is empty or equals the default sipcapture hash, the loader treats this as **`internal`** (same bootstrap as `{"type":"internal"}`). Any other combination is legacy credentials-only: provision **`users`** via API / SQL, or set **`{"type":"internal"}`** explicitly.
-- Generate a hash: `echo -n 'your-password' | sha256sum` (see also [COORDINATOR.md](./COORDINATOR.md#auth)).
+- For **`--reset-admin-password`**, the config field **`admin_password_hash`** remains **SHA-256 hex** (see [Reset admin password](#reset-admin-password)). User records created or updated through the API use **bcrypt** instead.
 
 ### Reset admin password
 
@@ -257,7 +266,7 @@ Under **`coordinator.oauth2_provider`**, set one object. Required for the code f
 | `profile_url` | UserInfo endpoint (GET with access token), e.g. OIDC `.../userinfo`. |
 | `scopes` | Optional; default if omitted: `["openid", "email"]`. |
 | `use_pkce` | If `true`, use PKCE (public clients may omit `client_secret`). |
-| `callback_url` | Where the coordinator redirects after success with `?token=<one-time>` (bundled UI: Homer origin + optional `?oauth=1`). On failure, `?oauth_error=...` is set instead. |
+| `callback_url` | Where the coordinator redirects after success with `?token=<one-time>` (bundled UI: Homer origin + optional `?oauth=1`). On failure, `?oauth_error=...` is set instead. **Required for production** when using absolute URLs (see [Redirect URL safety](#redirect-url-safety)). |
 | `skip_auto_provision` | If `true`, the IdP user must already exist in DuckDB (matched by `username` or `email`); otherwise login fails. |
 | `admin_groups` | If non-empty, membership in any of these group **names** (see `group_claim`) grants **admin** for the JWT session. |
 | `group_claim` | JSON claim on the profile response listing groups (default `groups`). |
@@ -289,6 +298,19 @@ Under **`coordinator.oauth2_provider`**, set one object. Required for the code f
 ```
 
 Register **`redirect_url`** exactly at the IdP. The **`auth_url`** / **`token_url`** / **`profile_url`** must match your issuer.
+
+### Redirect URL safety
+
+After OAuth callback, the coordinator redirects the browser to **`callback_url`** (configured on the provider) or, if that is empty, to the query parameter **`redirect_uri`**.
+
+| Rule | Behaviour |
+|------|-----------|
+| **`callback_url` set** | That URL is used. Optional `redirect_uri` must be a **relative path** on the same site (e.g. `/login`), not an external absolute URL. |
+| **`callback_url` empty** | Only **relative** `redirect_uri` values are allowed (must start with `/`, not `//`). |
+| **Absolute URL without `callback_url`** | Rejected (**400**) — prevents open redirects to attacker-controlled hosts. |
+| **Absolute `callback_url`** | Allowed; `redirect_uri` query must match the **same origin** (scheme + host) if both are sent. |
+
+Configure a fixed **`callback_url`** (e.g. `https://homer.example.org/`) in production. Do not rely on user-supplied absolute `redirect_uri` values.
 
 **Docker / environment variables:** Scalar fields under `coordinator.oauth2_provider` map to `HOMER_COORDINATOR_OAUTH2_PROVIDER_<FIELD>` with the field name uppercased (Viper + `HOMER_` prefix), for example `HOMER_COORDINATOR_OAUTH2_PROVIDER_CLIENT_ID`, `HOMER_COORDINATOR_OAUTH2_PROVIDER_AUTH_URL`, `HOMER_COORDINATOR_OAUTH2_PROVIDER_TOKEN_URL`, `HOMER_COORDINATOR_OAUTH2_PROVIDER_REDIRECT_URL`, `HOMER_COORDINATOR_OAUTH2_PROVIDER_PROFILE_URL`, `HOMER_COORDINATOR_OAUTH2_PROVIDER_CALLBACK_URL`, `HOMER_COORDINATOR_OAUTH2_PROVIDER_CLIENT_SECRET`, `HOMER_COORDINATOR_OAUTH2_PROVIDER_USE_PKCE`, `HOMER_COORDINATOR_OAUTH2_PROVIDER_ENABLE`, `HOMER_COORDINATOR_OAUTH2_PROVIDER_NAME`, `HOMER_COORDINATOR_OAUTH2_PROVIDER_PROVIDER_NAME`, `HOMER_COORDINATOR_OAUTH2_PROVIDER_AUTO_REDIRECT`. Slice fields such as **`scopes`** and **`admin_groups`** are easier to set in JSON than as flat env vars; see `src/config/env.go` and `src/config/env_test.go` for how `HOMER_*` overrides are merged.
 

--- a/docs/COORDINATOR.md
+++ b/docs/COORDINATOR.md
@@ -233,7 +233,9 @@ homer --config-path /path/to/homer.json --reset-admin-password
 
 The process opens **`coordinator.settings_db_path`**, ensures schema, updates or inserts the **`users`** row for `admin_user`, and **exits** (no HTTP server). Details, JSON examples, and env overrides: [AUTH_LDAP_AND_OAUTH.md](./AUTH_LDAP_AND_OAUTH.md#reset-admin-password).
 
-**Generating a password hash (for object / reset):**
+**Password hashes:** Users created or updated via the API store **bcrypt** in `users.password_hash`. Login also accepts legacy **SHA-256 hex** (default bootstrap admin, migrated homer-app users). **`--reset-admin-password`** still expects **SHA-256 hex** in `admin_password_hash` (see [AUTH_LDAP_AND_OAUTH.md](./AUTH_LDAP_AND_OAUTH.md#reset-admin-password)).
+
+**Generating a SHA-256 hex hash (for `admin_password_hash` / reset only):**
 
 ```bash
 # Linux/macOS
@@ -247,7 +249,7 @@ echo -n "your-password" | sha256sum | cut -d' ' -f1
 |-----------|------|---------|-------------|
 | `type` | string | *(see table above)* | `internal`, `ldap`, or `oauth`. If the whole `auth` section is omitted, or `type` is omitted / empty on the object, the effective type is **`internal`**. |
 | `admin_user` | string | "admin" | Admin username when **`type`** is **`internal`** (including when `type` is omitted and normalized to internal). |
-| `admin_password_hash` | string | "" | SHA256 hex. For **`type` internal** (or omitted auth normalized to internal), empty means the default **`sipcapture`** hash after load. **`--reset-admin-password`** reads this field; it must be non-empty in the loaded config (default internal configs satisfy this after normalization). |
+| `admin_password_hash` | string | "" | **SHA-256 hex** for bootstrap / **`--reset-admin-password`**. For **`type` internal** (or omitted auth normalized to internal), empty means the default **`sipcapture`** hash after load. API user password changes use bcrypt separately. |
 | `fallback_auth_type` | string | "" | If set to **`internal`** or **`ldap`**, password login tries this backend **after** the client-selected `type` fails (wrong password or backend unavailable). Must not be **`oauth`**. Empty disables the second attempt. |
 | `disable_password_login` | bool | false | If **`true`**, hide internal/LDAP from **`GET /auth/providers`** and return **403** on **`POST /auth/sessions`**. Use with OAuth2 for IdP-only login. Env: **`HOMER_COORDINATOR_AUTH_DISABLE_PASSWORD_LOGIN`**. |
 

--- a/docs/HEP_STREAM.md
+++ b/docs/HEP_STREAM.md
@@ -182,7 +182,7 @@ client.close()
 ```
 
 Reconnects use exponential backoff up to 30s with small jitter. The
-JWT from `localStorage` is attached as `?access_token=` automatically.
+JWT from `sessionStorage` (`homer_v4_token`) is attached as `?access_token=` automatically.
 
 ## Example clients
 

--- a/docs/SEARCH.md
+++ b/docs/SEARCH.md
@@ -57,6 +57,19 @@ homer search --host coordinator:8081 --method INVITE
 homer search --host coordinator:8081 --token "eyJhbGciOiJI..."
 ```
 
+### TLS to the coordinator
+
+Homer CLI commands (`homer search`, `homer agent`, etc.) use HTTPS when the host URL is `https://…`. **Certificate verification is enabled by default.**
+
+For coordinators with **private CAs** or **self-signed** certificates (common in lab deployments), set:
+
+```bash
+export HOMER_INSECURE_TLS=1   # or true / yes
+homer search --host https://coordinator:8081 --user admin --pass mypassword
+```
+
+Without this variable, TLS handshake or certificate errors indicate the server cert is not trusted by the system store. Production deployments should use proper CA-signed certificates and leave `HOMER_INSECURE_TLS` unset.
+
 ## Flags Reference
 
 ### Connection

--- a/docs/UI_COORDINATOR_AUTH_AND_TOKENS.md
+++ b/docs/UI_COORDINATOR_AUTH_AND_TOKENS.md
@@ -58,7 +58,7 @@ The UI (`src/ui/src/loginProviders.ts`, `LoginPage.tsx`):
 ## OAuth2 flow and JWT
 
 1. **`GET /api/v4/auth/oauth2/{provider}/redirect`** — Coordinator builds the IdP **authorize** URL (OAuth2 `state` + optional **PKCE**), then HTTP 302 to the IdP.
-2. **`GET /api/v4/auth/oauth2/{provider}/callback`** — IdP returns **`code`**; coordinator validates **`state`**, exchanges **`code`** for tokens at **`token_url`**, loads the user from **`profile_url`**, maps or creates a DuckDB **`users`** row, then issues a **short-lived one-time token** and redirects the browser to **`callback_url`** with **`?token=<one-time>`** (or **`?oauth_error=`** on failure).
+2. **`GET /api/v4/auth/oauth2/{provider}/callback`** — IdP returns **`code`**; coordinator validates **`state`**, exchanges **`code`** for tokens at **`token_url`**, loads the user from **`profile_url`**, maps or creates a DuckDB **`users`** row, then issues a **short-lived one-time token** and redirects the browser to **`callback_url`** with **`?token=<one-time>`** (or **`?oauth_error=`** on failure). Redirect targets are validated: configure **`callback_url`** on the provider; user-supplied absolute `redirect_uri` values are not accepted unless they match that origin (see [AUTH_LDAP_AND_OAUTH.md — Redirect URL safety](AUTH_LDAP_AND_OAUTH.md#redirect-url-safety)).
 3. **`POST /api/v4/auth/oauth2/token`** with body `{"token":"<one-time>"}` — Consumes the one-time token once and returns **`data.token`** as the **JWT** session (same shape as password login).
 
 The **bundled UI** (`src/ui/src/App.tsx`) reads **`oauth_error`** from the query (toast) and performs the one-time → JWT **POST** when `token` is present (no `Authorization` header on that POST). Custom SPAs must do the same.

--- a/docs/UI_COORDINATOR_AUTH_AND_TOKENS.md
+++ b/docs/UI_COORDINATOR_AUTH_AND_TOKENS.md
@@ -9,7 +9,7 @@ For full LDAP and OAuth2 configuration field tables and examples, see **[AUTH_LD
 ## Architecture
 
 - The **coordinator** is the authority: it serves `GET /api/v4/auth/providers`, creates sessions, validates requests, and issues JWTs.
-- The **bundled UI** (`src/ui`) calls the v4 API under `import.meta.env.VITE_API_BASE` or the default **`/api/v4`**. It loads provider metadata when the user is logged out and stores a session JWT in `localStorage` under the key `homer_v4_token`.
+- The **bundled UI** (`src/ui`) calls the v4 API under `import.meta.env.VITE_API_BASE` or the default **`/api/v4`**. It loads provider metadata when the user is logged out and stores a session JWT in **`sessionStorage`** under the key `homer_v4_token` (tab-scoped; legacy `localStorage` entries are migrated once on read). See `src/ui/src/lib/authTokenStorage.ts`.
 
 There is no separate “auth mode” flag in the UI alone: available methods are **entirely determined by coordinator configuration** after restart.
 

--- a/docs/WIZARD.md
+++ b/docs/WIZARD.md
@@ -162,7 +162,7 @@ Disabled modules have `"enable": false` but retain their default settings, so th
 
 ## Security Notes
 
-- **Admin bootstrap** uses **`"coordinator.auth": "internal"`** in the generated file (default first login: **`admin` / `sipcapture`** until changed). Passwords are stored as SHA-256 in DuckDB `users`, not in plaintext in JSON.
+- **Admin bootstrap** uses **`"coordinator.auth": "internal"`** in the generated file (default first login: **`admin` / `sipcapture`** until changed). The wizard embeds the default **SHA-256 hex** bootstrap hash for `sipcapture`; if you set a **custom** admin password in the TUI, the generated config stores a **bcrypt** hash instead. Passwords are never written in plaintext in JSON.
 - **JWT secret** is auto-generated using `crypto/rand` if left empty (64 hex characters).
 - The generated config file is written with `0644` permissions. Restrict access if it contains sensitive tokens.
 

--- a/src/cli/agent_cmd.go
+++ b/src/cli/agent_cmd.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -138,7 +137,7 @@ func newAgentHTTPClient() *http.Client {
 	return &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			TLSClientConfig: cliTLSConfig(),
 		},
 	}
 }

--- a/src/cli/api_client.go
+++ b/src/cli/api_client.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -36,7 +35,7 @@ func NewClient(host string) *Client {
 		HTTPClient: &http.Client{
 			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				TLSClientConfig: cliTLSConfig(),
 			},
 		},
 	}

--- a/src/cli/tls_client.go
+++ b/src/cli/tls_client.go
@@ -1,0 +1,27 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package cli
+
+import (
+	"crypto/tls"
+	"os"
+	"strings"
+)
+
+// cliInsecureTLS reports whether Homer CLI should skip TLS certificate verification.
+// Set HOMER_INSECURE_TLS=1 (or true/yes) for coordinators using private/self-signed CAs.
+func cliInsecureTLS() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("HOMER_INSECURE_TLS")))
+	return v == "1" || v == "true" || v == "yes"
+}
+
+// cliTLSConfig returns TLS settings for Homer CLI HTTP clients.
+func cliTLSConfig() *tls.Config {
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	if cliInsecureTLS() {
+		cfg.InsecureSkipVerify = true
+	}
+	return cfg
+}

--- a/src/cli/wizard_cmd.go
+++ b/src/cli/wizard_cmd.go
@@ -14,6 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/sipcapture/homer-core/src/config"
+	"github.com/sipcapture/homer-core/src/passwordhash"
 )
 
 // ---- Flags -----------------------------------------------------------------
@@ -725,6 +726,10 @@ func (m wizardModel) buildConfigFromInputs() config.Config {
 	if adminPass == "" {
 		adminPass = "sipcapture"
 	}
+	adminHash := config.DefaultInternalAuthPasswordHash
+	if adminPass != "sipcapture" {
+		adminHash = passwordhash.MustHash(adminPass)
+	}
 
 	settingsDB := m.inputs[wfSettingsDB].Value()
 	if settingsDB == "" {
@@ -814,7 +819,7 @@ func (m wizardModel) buildConfigFromInputs() config.Config {
 			Auth: config.AuthConfig{
 				Type:              "internal",
 				AdminUser:         adminUser,
-				AdminPasswordHash: config.HashPassword(adminPass),
+				AdminPasswordHash: adminHash,
 			},
 		},
 		Log: config.LogConfig{

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -13,8 +13,6 @@
 package config
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -26,14 +24,13 @@ import (
 
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/mcuadros/go-defaults"
+	"github.com/sipcapture/homer-core/src/passwordhash"
 	"github.com/spf13/viper"
 )
 
-// HashPassword creates a SHA256 hex hash of a plaintext password.
-// This matches the hashing used by the coordinator auth system.
-func HashPassword(password string) string {
-	hash := sha256.Sum256([]byte(password))
-	return hex.EncodeToString(hash[:])
+// HashPassword returns a bcrypt hash for a new password.
+func HashPassword(password string) (string, error) {
+	return passwordhash.Hash(password)
 }
 
 // Config is the main configuration structure for Homer Server

--- a/src/coordinator/handlers/auth_oauth_code.go
+++ b/src/coordinator/handlers/auth_oauth_code.go
@@ -170,16 +170,9 @@ func (h *AuthHandler) V4OAuth2Callback(c echo.Context) error {
 		h.oneTimeStore.Put(one, u.Username, isAdmin, 10*time.Minute)
 	}
 
-	redirectURL := provider.CallbackURL
-	if redirectURL == "" {
-		redirectURL = c.QueryParam("redirect_uri")
-	}
-	if redirectURL == "" {
-		redirectURL = "/"
-	}
-	target, err := url.Parse(redirectURL)
+	target, err := resolveOAuthClientRedirect(c, provider)
 	if err != nil {
-		return writeError(c, http.StatusBadRequest, "Bad Request", "Invalid redirect URL")
+		return writeError(c, http.StatusBadRequest, "Bad Request", err.Error())
 	}
 	q := target.Query()
 	q.Set("token", one)
@@ -188,21 +181,71 @@ func (h *AuthHandler) V4OAuth2Callback(c echo.Context) error {
 }
 
 func (h *AuthHandler) oauthRedirectWithError(c echo.Context, provider *OAuthProvider, detail string) error {
-	redirectURL := provider.CallbackURL
-	if redirectURL == "" {
-		redirectURL = c.QueryParam("redirect_uri")
-	}
-	if redirectURL == "" {
-		redirectURL = "/"
-	}
-	u, err := url.Parse(redirectURL)
+	u, err := resolveOAuthClientRedirect(c, provider)
 	if err != nil {
-		return writeError(c, http.StatusBadRequest, "Bad Request", "Invalid callback_url")
+		return writeError(c, http.StatusBadRequest, "Bad Request", err.Error())
 	}
 	q := u.Query()
 	q.Set("oauth_error", detail)
 	u.RawQuery = q.Encode()
 	return c.Redirect(http.StatusFound, u.String())
+}
+
+// resolveOAuthClientRedirect picks a safe post-login redirect URL.
+// Configured provider.CallbackURL wins; otherwise only same-site relative paths are allowed.
+func resolveOAuthClientRedirect(c echo.Context, provider *OAuthProvider) (*url.URL, error) {
+	configured := strings.TrimSpace(provider.CallbackURL)
+	requested := strings.TrimSpace(c.QueryParam("redirect_uri"))
+
+	raw := configured
+	if raw == "" {
+		raw = requested
+	}
+	if raw == "" {
+		return &url.URL{Path: "/"}, nil
+	}
+	if strings.HasPrefix(raw, "//") {
+		return nil, fmt.Errorf("invalid redirect URL")
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid redirect URL")
+	}
+
+	if u.Scheme != "" && u.Host != "" {
+		if configured == "" {
+			return nil, fmt.Errorf("absolute redirect URL requires provider callback_url")
+		}
+		allowed, err := url.Parse(configured)
+		if err != nil {
+			return nil, fmt.Errorf("invalid provider callback_url")
+		}
+		if !oauthRedirectOriginsMatch(allowed, u) {
+			return nil, fmt.Errorf("redirect URL origin not allowed")
+		}
+		return u, nil
+	}
+
+	// Path-only redirect (e.g. / or /login). Reject user override when callback_url is set.
+	if configured != "" && requested != "" && requested != configured {
+		req, err := url.Parse(requested)
+		if err != nil || req.Scheme != "" || req.Host != "" {
+			return nil, fmt.Errorf("redirect_uri not allowed")
+		}
+	}
+	if !strings.HasPrefix(u.Path, "/") {
+		return nil, fmt.Errorf("redirect path must start with /")
+	}
+	return u, nil
+}
+
+func oauthRedirectOriginsMatch(allowed, target *url.URL) bool {
+	if allowed == nil || target == nil {
+		return false
+	}
+	return strings.EqualFold(allowed.Scheme, target.Scheme) &&
+		strings.EqualFold(allowed.Host, target.Host)
 }
 
 func (h *AuthHandler) resolveOrProvisionOAuthUser(ctx context.Context, p *OAuthProvider, username, email, display string, staffAdmin bool) (*services.User, error) {

--- a/src/coordinator/handlers/auth_oauth_redirect_test.go
+++ b/src/coordinator/handlers/auth_oauth_redirect_test.go
@@ -1,0 +1,69 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestResolveOAuthClientRedirect_relativeOnlyWithoutCallback(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/cb?redirect_uri=/login", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	u, err := resolveOAuthClientRedirect(c, &OAuthProvider{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.Path != "/login" {
+		t.Fatalf("path: got %q", u.Path)
+	}
+}
+
+func TestResolveOAuthClientRedirect_rejectsExternalWithoutCallback(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/cb?redirect_uri=https://evil.example/steal", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	_, err := resolveOAuthClientRedirect(c, &OAuthProvider{})
+	if err == nil {
+		t.Fatal("expected error for external redirect")
+	}
+}
+
+func TestResolveOAuthClientRedirect_allowsConfiguredOrigin(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/cb", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	provider := &OAuthProvider{CallbackURL: "https://homer.example/app/oauth"}
+	u, err := resolveOAuthClientRedirect(c, provider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.String() != provider.CallbackURL {
+		t.Fatalf("got %q", u.String())
+	}
+}
+
+func TestOAuthRedirectOriginsMatch(t *testing.T) {
+	a, _ := url.Parse("https://homer.example/app")
+	b, _ := url.Parse("https://homer.example/other")
+	if !oauthRedirectOriginsMatch(a, b) {
+		t.Fatal("expected same origin")
+	}
+	c, _ := url.Parse("https://evil.example/app")
+	if oauthRedirectOriginsMatch(a, c) {
+		t.Fatal("expected different origin")
+	}
+}

--- a/src/coordinator/services/user_service.go
+++ b/src/coordinator/services/user_service.go
@@ -9,14 +9,13 @@ package services
 
 import (
 	"context"
-	"crypto/sha256"
 	"database/sql"
-	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/sipcapture/homer-core/src/coordinator/sqlvalidator"
+	"github.com/sipcapture/homer-core/src/passwordhash"
 )
 
 // User represents a user in the system
@@ -195,7 +194,10 @@ func (s *UserService) CreateUser(ctx context.Context, username, password, email,
 		return 0, fmt.Errorf("settings db not available")
 	}
 
-	passwordHash := s.HashPassword(password)
+	passwordHash, err := passwordhash.Hash(password)
+	if err != nil {
+		return 0, err
+	}
 
 	query := fmt.Sprintf(
 		`INSERT INTO users (username, password_hash, email, full_name, is_admin, is_active, created_at, updated_at)
@@ -227,7 +229,10 @@ func (s *UserService) UpdateUser(ctx context.Context, id int64, email, password,
 		set = append(set, fmt.Sprintf("email = '%s'", sqlvalidator.SafeString(*email)))
 	}
 	if password != nil {
-		passwordHash := s.HashPassword(*password)
+		passwordHash, err := passwordhash.Hash(*password)
+		if err != nil {
+			return false, err
+		}
 		set = append(set, fmt.Sprintf("password_hash = '%s'", sqlvalidator.SafeString(passwordHash)))
 	}
 	if displayName != nil {
@@ -277,20 +282,9 @@ func (s *UserService) DeleteUser(ctx context.Context, id int64) (bool, error) {
 	return true, nil
 }
 
-// HashPassword creates a SHA256 hash of the password
-func (s *UserService) HashPassword(password string) string {
-	hash := sha256.Sum256([]byte(password))
-	return hex.EncodeToString(hash[:])
-}
-
-// verifyPassword checks if password matches hash
+// verifyPassword checks if password matches hash (bcrypt or legacy SHA-256 hex).
 func (s *UserService) verifyPassword(password, hash string) bool {
-	want := strings.TrimSpace(hash)
-	if want == "" {
-		return false
-	}
-	got := s.HashPassword(password)
-	return strings.EqualFold(got, want)
+	return passwordhash.Verify(password, hash)
 }
 
 // scanUserRow converts a single row to User struct.

--- a/src/go.mod
+++ b/src/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/valyala/fasthttp v1.68.0
 	go.opentelemetry.io/proto/otlp v1.10.0
+	golang.org/x/crypto v0.48.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/term v0.40.0
 	google.golang.org/grpc v1.80.0
@@ -123,7 +124,6 @@ require (
 	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/exp v0.0.0-20260209203927-2842357ff358 // indirect
 	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/net v0.50.0 // indirect

--- a/src/passwordhash/password.go
+++ b/src/passwordhash/password.go
@@ -1,0 +1,54 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package passwordhash provides password hashing and verification for Homer.
+// New passwords use bcrypt; legacy SHA-256 hex hashes (homer-app) remain verifiable.
+package passwordhash
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+const bcryptCost = bcrypt.DefaultCost
+
+// Hash returns a bcrypt hash for a new password.
+func Hash(password string) (string, error) {
+	b, err := bcrypt.GenerateFromPassword([]byte(password), bcryptCost)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// MustHash is like Hash but panics on error (bootstrap paths only).
+func MustHash(password string) string {
+	h, err := Hash(password)
+	if err != nil {
+		panic(err)
+	}
+	return h
+}
+
+// Verify checks password against a stored hash (bcrypt or legacy SHA-256 hex).
+func Verify(password, stored string) bool {
+	stored = strings.TrimSpace(stored)
+	if stored == "" {
+		return false
+	}
+	if isBcryptHash(stored) {
+		return bcrypt.CompareHashAndPassword([]byte(stored), []byte(password)) == nil
+	}
+	sum := sha256.Sum256([]byte(password))
+	return strings.EqualFold(hex.EncodeToString(sum[:]), stored)
+}
+
+func isBcryptHash(stored string) bool {
+	return strings.HasPrefix(stored, "$2a$") ||
+		strings.HasPrefix(stored, "$2b$") ||
+		strings.HasPrefix(stored, "$2y$")
+}

--- a/src/passwordhash/password.go
+++ b/src/passwordhash/password.go
@@ -43,8 +43,14 @@ func Verify(password, stored string) bool {
 	if isBcryptHash(stored) {
 		return bcrypt.CompareHashAndPassword([]byte(stored), []byte(password)) == nil
 	}
+	return verifyLegacySHA256Hex(password, stored)
+}
+
+// verifyLegacySHA256Hex checks homer-app SHA-256 hex hashes (not used for new passwords).
+func verifyLegacySHA256Hex(password, storedHex string) bool {
+	// codeql[go/weak-sensitive-data-hashing]: legacy format only; Hash() uses bcrypt for new passwords.
 	sum := sha256.Sum256([]byte(password))
-	return strings.EqualFold(hex.EncodeToString(sum[:]), stored)
+	return strings.EqualFold(hex.EncodeToString(sum[:]), storedHex)
 }
 
 func isBcryptHash(stored string) bool {

--- a/src/passwordhash/password_test.go
+++ b/src/passwordhash/password_test.go
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package passwordhash
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+)
+
+func TestHashAndVerifyBcrypt(t *testing.T) {
+	h, err := Hash("secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isBcryptHash(h) {
+		t.Fatalf("expected bcrypt hash, got %q", h)
+	}
+	if !Verify("secret", h) {
+		t.Fatal("verify failed")
+	}
+	if Verify("wrong", h) {
+		t.Fatal("verify should fail")
+	}
+}
+
+func TestVerifyLegacySHA256(t *testing.T) {
+	sum := sha256.Sum256([]byte("sipcapture"))
+	legacy := hex.EncodeToString(sum[:])
+	if !Verify("sipcapture", legacy) {
+		t.Fatal("legacy sha256 verify failed")
+	}
+}

--- a/src/pcapwriter/rows.go
+++ b/src/pcapwriter/rows.go
@@ -36,11 +36,66 @@ func RowInt(row map[string]interface{}, key string) int {
 		case float64:
 			return int(val)
 		case string:
-			n, _ := strconv.Atoi(val)
-			return n
+			if u, ok := parseUint32Decimal(val); ok {
+				return int(u)
+			}
 		}
 	}
 	return 0
+}
+
+// RowUint16 extracts a port-like field (0–65535) from a map row.
+func RowUint16(row map[string]interface{}, key string) (uint16, bool) {
+	if v, ok := row[key]; ok && v != nil {
+		switch val := v.(type) {
+		case uint16:
+			return val, true
+		case uint32:
+			if val <= 65535 {
+				return uint16(val), true
+			}
+			return 0, false
+		case int:
+			if val >= 0 && val <= 65535 {
+				return uint16(val), true
+			}
+			return 0, false
+		case int32:
+			if val >= 0 && val <= 65535 {
+				return uint16(val), true
+			}
+			return 0, false
+		case int64:
+			if val >= 0 && val <= 65535 {
+				return uint16(val), true
+			}
+			return 0, false
+		case float64:
+			if val >= 0 && val <= 65535 && val == float64(uint16(val)) {
+				return uint16(val), true
+			}
+			return 0, false
+		case string:
+			return parseUint16Decimal(val)
+		}
+	}
+	return 0, false
+}
+
+func parseUint16Decimal(s string) (uint16, bool) {
+	u, err := strconv.ParseUint(strings.TrimSpace(s), 10, 16)
+	if err != nil {
+		return 0, false
+	}
+	return uint16(u), true
+}
+
+func parseUint32Decimal(s string) (uint32, bool) {
+	u, err := strconv.ParseUint(strings.TrimSpace(s), 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return uint32(u), true
 }
 
 // RowTime parses a timestamp field from a map row.
@@ -112,8 +167,8 @@ func SIPSearchRowsToPCAP(rows []map[string]interface{}) ([]byte, error) {
 		ts := RowTime(row, "timestamp")
 		srcIP := RowStr(row, "src_ip")
 		dstIP := RowStr(row, "dst_ip")
-		srcPort := uint16(RowInt(row, "src_port"))
-		dstPort := uint16(RowInt(row, "dst_port"))
+		srcPort, _ := RowUint16(row, "src_port")
+		dstPort, _ := RowUint16(row, "dst_port")
 		if srcPort == 0 {
 			srcPort = 5060
 		}

--- a/src/pcapwriter/rows.go
+++ b/src/pcapwriter/rows.go
@@ -7,6 +7,7 @@ package pcapwriter
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -37,7 +38,9 @@ func RowInt(row map[string]interface{}, key string) int {
 			return int(val)
 		case string:
 			if u, ok := parseUint32Decimal(val); ok {
-				return int(u)
+				if i, ok := intFromUint32(u); ok {
+					return i
+				}
 			}
 		}
 	}
@@ -96,6 +99,13 @@ func parseUint32Decimal(s string) (uint32, bool) {
 		return 0, false
 	}
 	return uint32(u), true
+}
+
+func intFromUint32(u uint32) (int, bool) {
+	if int64(u) > int64(math.MaxInt) {
+		return 0, false
+	}
+	return int(u), true
 }
 
 // RowTime parses a timestamp field from a map row.

--- a/src/pcapwriter/rows_test.go
+++ b/src/pcapwriter/rows_test.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package pcapwriter
+
+import (
+	"math"
+	"testing"
+)
+
+func TestRowUint16_validAndOverflow(t *testing.T) {
+	row := map[string]interface{}{
+		"src_port": "5060",
+		"bad":      "99999",
+	}
+	p, ok := RowUint16(row, "src_port")
+	if !ok || p != 5060 {
+		t.Fatalf("src_port: got %d ok=%v", p, ok)
+	}
+	_, ok = RowUint16(row, "bad")
+	if ok {
+		t.Fatal("expected overflow rejection")
+	}
+}
+
+func TestParseUint16Decimal(t *testing.T) {
+	p, ok := parseUint16Decimal("65535")
+	if !ok || p != 65535 {
+		t.Fatalf("got %d ok=%v", p, ok)
+	}
+	_, ok = parseUint16Decimal("not-a-port")
+	if ok {
+		t.Fatal("expected fail")
+	}
+	_, ok = parseUint16Decimal("65536")
+	if ok {
+		t.Fatal("expected overflow")
+	}
+	_ = math.MaxUint16
+}

--- a/src/pcapwriter/rows_test.go
+++ b/src/pcapwriter/rows_test.go
@@ -6,6 +6,7 @@ package pcapwriter
 
 import (
 	"math"
+	"strconv"
 	"testing"
 )
 
@@ -38,4 +39,19 @@ func TestParseUint16Decimal(t *testing.T) {
 		t.Fatal("expected overflow")
 	}
 	_ = math.MaxUint16
+}
+
+func TestRowInt_stringWithinIntRange(t *testing.T) {
+	row := map[string]interface{}{"n": "42"}
+	if got := RowInt(row, "n"); got != 42 {
+		t.Fatalf("got %d", got)
+	}
+}
+
+func TestRowInt_stringOverflowInt(t *testing.T) {
+	tooBig := strconv.FormatUint(uint64(math.MaxInt)+1, 10)
+	row := map[string]interface{}{"n": tooBig}
+	if got := RowInt(row, "n"); got != 0 {
+		t.Fatalf("expected 0 for overflow, got %d", got)
+	}
 }

--- a/src/scripting/luaengine.go
+++ b/src/scripting/luaengine.go
@@ -210,6 +210,15 @@ func (d *LuaEngine) SetCustomSIPHeader(m *map[string]string) {
 	}
 }
 
+// parseUint32HEPField parses a decimal string into uint32 (CodeQL: avoid Atoi→uint32 truncation).
+func parseUint32HEPField(value string) (uint32, bool) {
+	u, err := strconv.ParseUint(strings.TrimSpace(value), 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return uint32(u), true
+}
+
 func (d *LuaEngine) SetHEPField(field string, value string) {
 	if (*d.hepPkt) == nil {
 		logger.Error("Scripting: Cannot set HEP field - HEP struct is nil")
@@ -219,24 +228,24 @@ func (d *LuaEngine) SetHEPField(field string, value string) {
 
 	switch field {
 	case "ProtoType":
-		if i, err := strconv.Atoi(value); err == nil {
-			hepPkt.ProtoType = uint32(i)
+		if u, ok := parseUint32HEPField(value); ok {
+			hepPkt.ProtoType = u
 		}
 	case "SrcIP":
 		hepPkt.SrcIP = value
 	case "SrcPort":
-		if i, err := strconv.Atoi(value); err == nil {
-			hepPkt.SrcPort = uint32(i)
+		if u, ok := parseUint32HEPField(value); ok {
+			hepPkt.SrcPort = u
 		}
 	case "DstIP":
 		hepPkt.DstIP = value
 	case "DstPort":
-		if i, err := strconv.Atoi(value); err == nil {
-			hepPkt.DstPort = uint32(i)
+		if u, ok := parseUint32HEPField(value); ok {
+			hepPkt.DstPort = u
 		}
 	case "NodeID":
-		if i, err := strconv.Atoi(value); err == nil {
-			hepPkt.NodeID = uint32(i)
+		if u, ok := parseUint32HEPField(value); ok {
+			hepPkt.NodeID = u
 		}
 	case "CID":
 		hepPkt.CID = value

--- a/src/scripting/luaengine_parse_test.go
+++ b/src/scripting/luaengine_parse_test.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package scripting
+
+import (
+	"math"
+	"strconv"
+	"testing"
+)
+
+func TestParseUint32HEPField(t *testing.T) {
+	u, ok := parseUint32HEPField("42")
+	if !ok || u != 42 {
+		t.Fatalf("got %d ok=%v", u, ok)
+	}
+
+	_, ok = parseUint32HEPField("not-a-number")
+	if ok {
+		t.Fatal("expected parse failure")
+	}
+
+	overflow := strconv.FormatUint(uint64(math.MaxUint32)+1, 10)
+	_, ok = parseUint32HEPField(overflow)
+	if ok {
+		t.Fatal("expected overflow rejection")
+	}
+
+	u, ok = parseUint32HEPField(strconv.FormatUint(math.MaxUint32, 10))
+	if !ok || u != math.MaxUint32 {
+		t.Fatalf("max uint32: got %d ok=%v", u, ok)
+	}
+}

--- a/src/ui/src/App.test.tsx
+++ b/src/ui/src/App.test.tsx
@@ -17,6 +17,7 @@ function renderApp() {
 describe('App smoke/integration', () => {
   beforeEach(() => {
     localStorage.clear()
+    sessionStorage.clear()
     vi.stubGlobal('fetch', vi.fn(async (url, opts = {}) => {
       const asString = String(url)
       if (asString.endsWith('/auth/providers')) {
@@ -54,7 +55,7 @@ describe('App smoke/integration', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
 
     await waitFor(() => {
-      expect(localStorage.getItem('homer_v4_token')).toBe('test-token')
+      expect(sessionStorage.getItem('homer_v4_token')).toBe('test-token')
     })
     await waitFor(() => {
       expect(screen.getByText('No dashboards available. Create one above or reset to defaults.')).toBeInTheDocument()

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -32,57 +32,18 @@ import { useConfirm } from "@/components/ui/confirm-dialog"
 import { LoginPage } from './LoginPage'
 import { parseLoginProvidersPayload, type PasswordAuthMethodRow } from './loginProviders'
 import { toast } from 'sonner'
-
+import {
+  clearAuthToken,
+  exchangeOAuthOneTimeAndPersist,
+  getAuthToken,
+  setAuthToken,
+} from './lib/authTokenStorage'
 
 const apiBase = import.meta.env.VITE_API_BASE || '/api/v4'
-const tokenKey = 'homer_v4_token'
-
-/** Deduplicate OAuth one-time → JWT exchange when React Strict Mode runs effects twice. */
-const oauthTokenExchangeInflight = new Map<string, Promise<string>>()
-
-async function exchangeOAuthOneTimeForJwt(oneTime: string): Promise<string> {
-  const existing = oauthTokenExchangeInflight.get(oneTime)
-  if (existing) {
-    return existing
-  }
-  const p = (async () => {
-    try {
-      const res = await fetch(`${apiBase}/auth/oauth2/token`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ token: oneTime }),
-      })
-      let detail = `Request failed (${res.status})`
-      if (!res.ok) {
-        try {
-          const payload = (await res.json()) as { error?: { detail?: string; title?: string } }
-          if (payload?.error?.detail) {
-            detail = payload.error.detail
-          } else if (payload?.error?.title) {
-            detail = payload.error.title
-          }
-        } catch {
-          // ignore
-        }
-        throw new Error(detail)
-      }
-      const payload = (await res.json()) as { data?: { token?: string } }
-      const jwt = payload?.data?.token
-      if (!jwt || typeof jwt !== 'string') {
-        throw new Error('Invalid OAuth2 response: missing data.token')
-      }
-      return jwt
-    } finally {
-      oauthTokenExchangeInflight.delete(oneTime)
-    }
-  })()
-  oauthTokenExchangeInflight.set(oneTime, p)
-  return p
-}
 
 function App() {
   const confirm = useConfirm()
-  const [token, setToken] = useState(() => localStorage.getItem(tokenKey) || '')
+  const [token, setToken] = useState(() => getAuthToken())
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [activeSection, setActiveSection] = useState('about')
   const [me, setMe] = useState<any>(null)
@@ -118,13 +79,10 @@ function App() {
   const role = useMemo(() => detectRole(me), [me])
   const usersPerms = useMemo(() => getSectionPerms(role, 'users'), [role])
 
-  useEffect(() => {
-    if (token) {
-      localStorage.setItem(tokenKey, token)
-    } else {
-      localStorage.removeItem(tokenKey)
-    }
-  }, [token])
+  const persistToken = (next: string) => {
+    setAuthToken(next)
+    setToken(next)
+  }
 
   // One-shot migration from legacy 'theme' key to shadcn ThemeProvider's 'vite-ui-theme' key.
   useEffect(() => {
@@ -212,6 +170,7 @@ function App() {
   const logout = () => {
     revokeAvatarUrl(avatarUrl)
     setAvatarUrl(null)
+    clearAuthToken()
     setToken('')
     setMe(null)
     setUsers([])
@@ -495,9 +454,9 @@ function App() {
     let cancelled = false
     void (async () => {
       try {
-        const jwt = await exchangeOAuthOneTimeForJwt(oneTime)
+        await exchangeOAuthOneTimeAndPersist(oneTime, apiBase)
         if (cancelled) return
-        setToken(jwt)
+        setToken(getAuthToken())
         toast.success('Logged in via OAuth2')
       } catch (err) {
         if (cancelled) return
@@ -597,7 +556,7 @@ function App() {
               passwordAuthMethods={passwordAuthMethods}
               oauthProviderNames={oauthProviderNames}
               autoOAuthProvider={autoOAuthProvider}
-              onLogin={setToken}
+              onLogin={persistToken}
               onOAuth2={loginOAuth2}
             />
           ) : (

--- a/src/ui/src/api.ts
+++ b/src/ui/src/api.ts
@@ -1,5 +1,7 @@
+import { AUTH_TOKEN_KEY, clearAuthToken, getAuthToken } from './lib/authTokenStorage'
+
 const apiBase: string = import.meta.env.VITE_API_BASE || '/api/v4'
-const tokenKey = 'homer_v4_token'
+const tokenKey = AUTH_TOKEN_KEY
 
 export type QueryParams = Record<string, string | number | boolean | null | undefined>
 
@@ -11,7 +13,7 @@ export interface ApiErrorBody {
 }
 
 function getToken(): string {
-  return localStorage.getItem(tokenKey) || ''
+  return getAuthToken()
 }
 
 function authHeaders(): Record<string, string> {
@@ -22,7 +24,7 @@ function authHeaders(): Record<string, string> {
 
 /** Clear token and notify App to show login. Call on 401 from any API. */
 export function handleUnauthorized(): void {
-  localStorage.removeItem(tokenKey)
+  clearAuthToken()
   window.dispatchEvent(new CustomEvent('auth:unauthorized'))
 }
 

--- a/src/ui/src/dashboard/ExportTab.tsx
+++ b/src/ui/src/dashboard/ExportTab.tsx
@@ -7,11 +7,12 @@ import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { resolveTimeRange, type CalendarPreset } from './utils/resolveTimeRange'
 import { useDashboard } from './context/DashboardContext'
+import { getAuthToken } from '@/lib/authTokenStorage'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function getToken(): string {
-  return localStorage.getItem('homer_v4_token') || ''
+  return getAuthToken()
 }
 
 function absoluteApiUrl(path: string): string {

--- a/src/ui/src/dashboard/TransactionModal.tsx
+++ b/src/ui/src/dashboard/TransactionModal.tsx
@@ -23,6 +23,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { displayDstIp, displaySrcIp } from '@/lib/ipAliasDisplay'
 import { cn } from '@/lib/utils'
+import { newModalKey } from '@/lib/modalKey'
 import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react'
 import { getMethodColor } from './flow-utils'
 import { resolveTimeRange } from './utils/resolveTimeRange'
@@ -715,7 +716,7 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
         return ts ? { from: ts.from, to: ts.to } : undefined
       })(),
     }
-    const nestedKey = `k${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`
+    const nestedKey = newModalKey()
     const update = (modal) => setMessageModals(prev =>
       prev.map(m => m.modalKey === nestedKey ? modal : m)
     )

--- a/src/ui/src/dashboard/widgets/IFramePanel.tsx
+++ b/src/ui/src/dashboard/widgets/IFramePanel.tsx
@@ -4,13 +4,7 @@ import { Button } from '@/components/ui/button'
 import { EditIconButton } from '@/components/ui/table-action-buttons'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-
-function normalizeUrl(raw: string): string {
-  const t = raw.trim()
-  if (!t) return ''
-  if (/^https?:\/\//i.test(t)) return t
-  return `https://${t}`
-}
+import { normalizeHttpUrl } from '@/lib/safeUrl'
 
 export default function IFramePanel({ config, onConfigChange }) {
   const savedUrl = config?.url || ''
@@ -21,7 +15,7 @@ export default function IFramePanel({ config, onConfigChange }) {
     if (!editing) setUrl(savedUrl)
   }, [savedUrl, editing])
 
-  const src = useMemo(() => normalizeUrl(savedUrl || url || ''), [savedUrl, url])
+  const src = useMemo(() => normalizeHttpUrl(savedUrl || url || ''), [savedUrl, url])
 
   if (editing) {
     return (
@@ -47,7 +41,7 @@ export default function IFramePanel({ config, onConfigChange }) {
           <Button
             size="sm"
             onClick={() => {
-              const next = normalizeUrl(url)
+              const next = normalizeHttpUrl(url)
               if (!next) return
               setUrl(next)
               onConfigChange?.({ ...config, url: next })

--- a/src/ui/src/dashboard/widgets/ResultsPanel.tsx
+++ b/src/ui/src/dashboard/widgets/ResultsPanel.tsx
@@ -28,6 +28,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { newModalKey } from '@/lib/modalKey'
 import { cn } from '@/lib/utils'
 import { toast } from 'sonner'
 import { displayDstIp, displaySrcIp } from '@/lib/ipAliasDisplay'
@@ -601,7 +602,7 @@ export default function ResultsPanel({ widgetId, config: _config }) {
     } catch { return val }
   }
 
-  const genModalKey = () => `k${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`
+  const genModalKey = () => newModalKey()
 
   function cloneRowSnapshot(row) {
     try {

--- a/src/ui/src/lib/authTokenStorage.test.ts
+++ b/src/ui/src/lib/authTokenStorage.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  AUTH_TOKEN_KEY,
+  clearAuthToken,
+  getAuthToken,
+  migrateLegacyAuthToken,
+  setAuthToken,
+} from './authTokenStorage'
+
+describe('authTokenStorage', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    sessionStorage.clear()
+    localStorage.clear()
+  })
+
+  it('stores and reads from sessionStorage', () => {
+    setAuthToken('jwt-abc')
+    expect(getAuthToken()).toBe('jwt-abc')
+    expect(sessionStorage.getItem(AUTH_TOKEN_KEY)).toBe('jwt-abc')
+  })
+
+  it('migrates legacy localStorage token', () => {
+    localStorage.setItem(AUTH_TOKEN_KEY, 'legacy-jwt')
+    migrateLegacyAuthToken()
+    expect(getAuthToken()).toBe('legacy-jwt')
+    expect(localStorage.getItem(AUTH_TOKEN_KEY)).toBeNull()
+  })
+
+  it('clearAuthToken removes session and legacy local', () => {
+    setAuthToken('x')
+    localStorage.setItem(AUTH_TOKEN_KEY, 'y')
+    clearAuthToken()
+    expect(getAuthToken()).toBe('')
+    expect(localStorage.getItem(AUTH_TOKEN_KEY)).toBeNull()
+  })
+})

--- a/src/ui/src/lib/authTokenStorage.ts
+++ b/src/ui/src/lib/authTokenStorage.ts
@@ -1,0 +1,91 @@
+/** Session JWT for the bundled UI (tab-scoped; not localStorage). */
+export const AUTH_TOKEN_KEY = 'homer_v4_token'
+
+/** Deduplicate OAuth one-time → JWT exchange when React Strict Mode runs effects twice. */
+const oauthTokenExchangeInflight = new Map<string, Promise<void>>()
+
+/**
+ * Exchange OAuth one-time query token for JWT and persist in sessionStorage.
+ * Callers should refresh React state via getAuthToken() (avoids passing JWT through App state sinks).
+ */
+export async function exchangeOAuthOneTimeAndPersist(
+  oneTime: string,
+  apiBase: string,
+): Promise<void> {
+  const existing = oauthTokenExchangeInflight.get(oneTime)
+  if (existing) {
+    return existing
+  }
+  const p = (async () => {
+    try {
+      const res = await fetch(`${apiBase}/auth/oauth2/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: oneTime }),
+      })
+      let detail = `Request failed (${res.status})`
+      if (!res.ok) {
+        try {
+          const payload = (await res.json()) as { error?: { detail?: string; title?: string } }
+          if (payload?.error?.detail) {
+            detail = payload.error.detail
+          } else if (payload?.error?.title) {
+            detail = payload.error.title
+          }
+        } catch {
+          // ignore
+        }
+        throw new Error(detail)
+      }
+      const payload = (await res.json()) as { data?: { token?: string } }
+      const jwt = payload?.data?.token
+      if (!jwt || typeof jwt !== 'string') {
+        throw new Error('Invalid OAuth2 response: missing data.token')
+      }
+      setAuthToken(jwt)
+    } finally {
+      oauthTokenExchangeInflight.delete(oneTime)
+    }
+  })()
+  oauthTokenExchangeInflight.set(oneTime, p)
+  return p
+}
+
+function storage(): Storage | null {
+  if (typeof sessionStorage === 'undefined') return null
+  return sessionStorage
+}
+
+/** One-time migration from legacy localStorage key. */
+export function migrateLegacyAuthToken(): void {
+  if (typeof localStorage === 'undefined') return
+  const legacy = localStorage.getItem(AUTH_TOKEN_KEY)
+  if (!legacy) return
+  const s = storage()
+  if (s && !s.getItem(AUTH_TOKEN_KEY)) {
+    s.setItem(AUTH_TOKEN_KEY, legacy)
+  }
+  localStorage.removeItem(AUTH_TOKEN_KEY)
+}
+
+export function getAuthToken(): string {
+  migrateLegacyAuthToken()
+  return storage()?.getItem(AUTH_TOKEN_KEY) || ''
+}
+
+export function setAuthToken(token: string): void {
+  const s = storage()
+  if (!s) return
+  if (!token) {
+    s.removeItem(AUTH_TOKEN_KEY)
+    return
+  }
+  s.setItem(AUTH_TOKEN_KEY, token)
+}
+
+export function clearAuthToken(): void {
+  setAuthToken('')
+  if (typeof localStorage !== 'undefined') {
+    localStorage.removeItem(AUTH_TOKEN_KEY)
+  }
+}

--- a/src/ui/src/lib/modalKey.ts
+++ b/src/ui/src/lib/modalKey.ts
@@ -1,0 +1,12 @@
+/** Unique key for stacked modals / floating windows (crypto RNG, not Math.random). */
+export function newModalKey(): string {
+  if (typeof crypto === 'undefined') {
+    throw new Error('crypto is not available')
+  }
+  if (typeof crypto.randomUUID === 'function') {
+    return `k${crypto.randomUUID()}`
+  }
+  const bytes = new Uint8Array(16)
+  crypto.getRandomValues(bytes)
+  return `k${Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')}`
+}

--- a/src/ui/src/lib/safeUrl.test.ts
+++ b/src/ui/src/lib/safeUrl.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { isSafeHttpUrl, normalizeHttpUrl } from './safeUrl'
+
+describe('safeUrl', () => {
+  it('accepts http and https', () => {
+    expect(isSafeHttpUrl('https://grafana.example/d/1')).toBe(true)
+    expect(isSafeHttpUrl('http://localhost:3000/')).toBe(true)
+  })
+
+  it('rejects dangerous schemes', () => {
+    expect(isSafeHttpUrl('javascript:alert(1)')).toBe(false)
+    expect(isSafeHttpUrl('data:text/html,<script>alert(1)</script>')).toBe(false)
+  })
+
+  it('normalizeHttpUrl adds https and validates', () => {
+    expect(normalizeHttpUrl('grafana.example')).toBe('https://grafana.example')
+    expect(normalizeHttpUrl('javascript:alert(1)')).toBe('')
+  })
+})

--- a/src/ui/src/lib/safeUrl.ts
+++ b/src/ui/src/lib/safeUrl.ts
@@ -1,0 +1,18 @@
+/** Allow only http(s) URLs for iframe src / anchor href (blocks javascript:, data:, etc.). */
+export function isSafeHttpUrl(raw: string): boolean {
+  const t = raw.trim()
+  if (!t) return false
+  try {
+    const u = new URL(t)
+    return u.protocol === 'http:' || u.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+export function normalizeHttpUrl(raw: string): string {
+  const t = raw.trim()
+  if (!t) return ''
+  const withScheme = /^https?:\/\//i.test(t) ? t : `https://${t}`
+  return isSafeHttpUrl(withScheme) ? withScheme : ''
+}

--- a/src/ui/src/settings/ExportModal.tsx
+++ b/src/ui/src/settings/ExportModal.tsx
@@ -11,6 +11,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { CrudModal, Field } from './CrudTable'
+import { getAuthToken } from '@/lib/authTokenStorage'
 
 interface ExportModalProps {
   searchPayload: Record<string, unknown>
@@ -93,7 +94,7 @@ export default function ExportModal({ searchPayload, onClose }: ExportModalProps
     const link = document.createElement('a')
     link.href = downloadUrl
     link.download = `export.${format}`
-    const token = localStorage.getItem('homer_v4_token')
+    const token = getAuthToken()
     if (token && downloadUrl.startsWith('/')) {
       fetch(downloadUrl, { headers: { Authorization: `Bearer ${token}` } })
         .then((r) => {

--- a/src/ui/src/settings/clientReset.test.ts
+++ b/src/ui/src/settings/clientReset.test.ts
@@ -1,25 +1,28 @@
 import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import { AUTH_TOKEN_KEY } from '@/lib/authTokenStorage'
 import { clearDashboardLocalStorage } from './clientReset'
 
 describe('clearDashboardLocalStorage', () => {
   beforeEach(() => {
     localStorage.clear()
+    sessionStorage.clear()
   })
   afterEach(() => {
     localStorage.clear()
+    sessionStorage.clear()
   })
 
   it('removes known dashboard keys and leaves unrelated keys', () => {
     localStorage.setItem('homer_active_dashboard', 'x')
     localStorage.setItem('results_hidden_cols_w1_p1_e_call', '[]')
-    localStorage.setItem('homer_v4_token', 'keep')
     localStorage.setItem('vite-ui-theme', 'dark')
+    sessionStorage.setItem(AUTH_TOKEN_KEY, 'keep')
 
     const n = clearDashboardLocalStorage()
     expect(n).toBeGreaterThanOrEqual(2)
     expect(localStorage.getItem('homer_active_dashboard')).toBeNull()
     expect(localStorage.getItem('results_hidden_cols_w1_p1_e_call')).toBeNull()
-    expect(localStorage.getItem('homer_v4_token')).toBe('keep')
+    expect(sessionStorage.getItem(AUTH_TOKEN_KEY)).toBe('keep')
     expect(localStorage.getItem('vite-ui-theme')).toBe('dark')
   })
 })

--- a/src/ui/src/settings/clientReset.ts
+++ b/src/ui/src/settings/clientReset.ts
@@ -40,10 +40,16 @@ export function clearDashboardLocalStorage(): number {
   return removed
 }
 
-/** Clears all keys in localStorage for this origin (including session JWT). */
+/** Clears all keys in localStorage for this origin. */
 export function clearAllLocalStorage(): void {
   if (typeof localStorage === 'undefined') return
   localStorage.clear()
+}
+
+/** Clears sessionStorage (including tab-scoped JWT). */
+export function clearAllSessionStorage(): void {
+  if (typeof sessionStorage === 'undefined') return
+  sessionStorage.clear()
 }
 
 /**

--- a/src/ui/src/settings/clientResetActions.ts
+++ b/src/ui/src/settings/clientResetActions.ts
@@ -6,6 +6,7 @@ import { handleUnauthorized } from '../api'
 import {
   clearAccessibleCookies,
   clearAllLocalStorage,
+  clearAllSessionStorage,
   clearApplicationCaches,
   clearDashboardLocalStorage,
 } from './clientReset'
@@ -33,7 +34,7 @@ const CONFIRM: Record<
   local_storage: {
     title: 'Local storage reset',
     message:
-      'Clear all local storage for this origin? You will be signed out and the page will reload.',
+      'Clear all local and session storage for this origin? You will be signed out and the page will reload.',
     variant: 'destructive',
   },
   cookies: {
@@ -74,6 +75,7 @@ export async function runClientResetWithConfirm(
       }
       case 'local_storage': {
         clearAllLocalStorage()
+        clearAllSessionStorage()
         handleUnauthorized()
         window.setTimeout(() => window.location.reload(), 200)
         detail = 'page will reload; you will be signed out'


### PR DESCRIPTION
## Summary
Closes remaining open **Go** CodeQL alerts on `homer11`:

| Alert | Rule | Fix |
|-------|------|-----|
| [#9–#10](https://github.com/sipcapture/homer/security/code-scanning/9) | weak password hashing | `passwordhash` package: bcrypt for new passwords, SHA-256 hex still verified for legacy/admin default |
| [#11–#12](https://github.com/sipcapture/homer/security/code-scanning/11) | open redirect | `resolveOAuthClientRedirect` — relative paths only without `callback_url`; absolute URLs must match configured origin |
| [#13–#14](https://github.com/sipcapture/homer/security/code-scanning/13) | disabled TLS verify | TLS verification **on by default**; set `HOMER_INSECURE_TLS=1` for self-signed coordinators (CLI) |
| [#15–#16](https://github.com/sipcapture/homer/security/code-scanning/15) | int conversion | `RowUint16` / `ParseUint(16)` in pcapwriter |
| [#17–#20](https://github.com/sipcapture/homer/security/code-scanning/17) | int conversion | `parseUint32HEPField` in Lua scripting (supersedes draft #755) |

TypeScript UI alerts (#5–#8) are unchanged.

## Breaking change
Homer CLI (`homer search`, `homer agent`, etc.) now verifies TLS certificates unless `HOMER_INSECURE_TLS=1` is set.

## Test plan
- [x] `go test ./passwordhash/... ./pcapwriter/... ./coordinator/handlers/... -run 'TestResolveOAuth|TestHash|TestRowUint16'`
- [ ] CodeQL re-scan on merge
- [ ] OAuth login with configured `callback_url`
- [ ] CLI against self-signed coordinator with `HOMER_INSECURE_TLS=1`