### PR TITLE
chore: bump VERSION_APPLICATION to 11.0.230

### DIFF
--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.229"
+	VERSION_APPLICATION = "11.0.230"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary

Bump `VERSION_APPLICATION` to **11.0.230** after security releases merged into `homer11` (#754 DuckLake SQL validation, #756–#757 CodeQL fixes).

## Test plan

- [ ] CI / compile check green
- [ ] `grep VERSION_APPLICATION src/version.go` → `11.0.230`