### PR TITLE
fix(ducklake): upstream Appender JSON after DuckDB 1.5.3 bump (11.0.236)

### DIFF
--- a/src/storage/ducklake/extra_json_test.go
+++ b/src/storage/ducklake/extra_json_test.go
@@ -7,7 +7,6 @@ package ducklake
 import (
 	"testing"
 
-	duckdb "github.com/duckdb/duckdb-go/v2"
 	"github.com/sipcapture/homer-core/src/decoder"
 )
 
@@ -30,16 +29,16 @@ func TestBuildExtraJSONCell_PooledBuffer(t *testing.T) {
 	releaseExtraJSONCell(cell)
 }
 
-func TestCellToDriverValue_pooledJSONIsAppendBytesUnsafe(t *testing.T) {
+func TestCellToDriverValue_pooledJSONIsString(t *testing.T) {
 	b := []byte(`{"version":3}`)
 	cell := any(&b)
 	dv := cellToDriverValue(cell)
-	ab, ok := dv.(duckdb.AppendBytesUnsafe)
+	s, ok := dv.(string)
 	if !ok {
-		t.Fatalf("expected duckdb.AppendBytesUnsafe, got %T", dv)
+		t.Fatalf("expected string, got %T", dv)
 	}
-	if string(ab) != string(b) {
-		t.Fatalf("got %q", ab)
+	if s != string(b) {
+		t.Fatalf("got %q", s)
 	}
 }
 

--- a/src/storage/ducklake/hep_adapter.go
+++ b/src/storage/ducklake/hep_adapter.go
@@ -17,7 +17,6 @@ import (
 	"time"
 	"unsafe"
 
-	duckdb "github.com/duckdb/duckdb-go/v2"
 	"github.com/sipcapture/homer-core/src/decoder"
 )
 
@@ -622,13 +621,13 @@ func releaseExtraJSONCell(v interface{}) {
 }
 
 // cellToDriverValue converts a batch cell to a driver value. Pooled JSON
-// buffers use duckdb.AppendBytesUnsafe (zero-copy) instead of string/json.RawMessage.
+// buffers are copied to string at flush time (Appender copies again internally).
 func cellToDriverValue(v interface{}) interface{} {
 	if bp, ok := v.(*[]byte); ok {
 		if bp == nil || len(*bp) == 0 {
-			return duckdb.AppendBytesUnsafe([]byte("{}"))
+			return "{}"
 		}
-		return duckdb.AppendBytesUnsafe(*bp)
+		return string(*bp)
 	}
 	return v
 }

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.235"
+	VERSION_APPLICATION = "11.0.236"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary

- Fixes compile failure after #773 (DuckDB 1.5.3 / upstream `duckdb-go/v2`): replaces `duckdb.AppendBytesUnsafe` (adubovikov fork only) with `string()` in `cellToDriverValue` at Appender flush time.
- Bumps `VERSION_APPLICATION` to **11.0.236**.

## Context

PR #773 merged the DuckDB 1.5.3 upgrade but CI still failed with `undefined: duckdb.AppendBytesUnsafe` because that API exists only on the removed adubovikov fork.

## Test plan

- [x] CI `compile` job passes
- [x] `go test ./storage/ducklake/ -run 'TestCellToDriverValue|TestBuildExtraJSONCell'`