### PR TITLE
fix(ui): hono 4.12.23 — close Dependabot alerts (11.0.238)

### DIFF
--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -7191,9 +7191,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -66,6 +66,6 @@
   "overrides": {
     "express-rate-limit": "8.5.1",
     "ip-address": "10.2.0",
-    "hono": "4.12.18"
+    "hono": "4.12.23"
   }
 }

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.237"
+	VERSION_APPLICATION = "11.0.238"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Bump npm `overrides.hono` from `4.12.18` to `4.12.23` to resolve four open moderate [Dependabot alerts](https://github.com/sipcapture/homer/security/dependabot) on transitive `hono` (via `shadcn` / MCP SDK).
- Regenerate `package-lock.json`; `npm audit` reports **0 vulnerabilities**.
- Bump `VERSION_APPLICATION` to **11.0.238**.

## Advisories addressed
- GHSA-f577-qrjj-4474 — JWT middleware accepts non-Bearer schemes
- GHSA-3hrh-pfw6-9m5x — Set-Cookie injection via unsanitized sameSite/priority
- GHSA-xrhx-7g5j-rcj5 — IPv6 IP restriction bypass
- GHSA-2gcr-mfcq-wcc3 — `app.mount()` percent-encoding routing issue

## Test plan
- [x] `npm audit` — 0 vulnerabilities
- [x] `npm run build` — UI builds successfully