### PR TITLE
feat(ui): persist search filters across dashboard tabs (discussion #779)

### DIFF
--- a/src/ui/src/dashboard/SearchDeepLinkBootstrap.tsx
+++ b/src/ui/src/dashboard/SearchDeepLinkBootstrap.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { useDashboard } from './context/DashboardContext'
-import { useSearchStore } from './stores/search-store'
+import { useSearchStore, searchStoreKey } from './stores/search-store'
 import {
   buildSearchPayload,
   deepLinkSpecToFormFields,
@@ -18,7 +18,6 @@ export default function SearchDeepLinkBootstrap() {
   const {
     widgets,
     loading,
-    activeDashboardId,
     publishSearch,
     requestTimeRange,
   } = useDashboard()
@@ -36,9 +35,7 @@ export default function SearchDeepLinkBootstrap() {
     appliedRef.current = true
 
     const searchWidget = widgets.find((w) => w.type === 'search')
-    const storeKey = searchWidget
-      ? `${activeDashboardId || '_'}:${searchWidget.id}`
-      : null
+    const storeKey = searchWidget ? searchStoreKey(searchWidget.config) : null
 
     const ts = resolveDeepLinkTimestamp(spec)
     requestTimeRange(null, ts.from, ts.to)
@@ -57,7 +54,7 @@ export default function SearchDeepLinkBootstrap() {
     const payload = buildSearchPayload(spec, { from: ts.from, to: ts.to }, spec.limit ?? 50)
     publishSearch(resultWidget.id, payload)
     stripDeepLinkParamsFromURL()
-  }, [widgets, loading, activeDashboardId, publishSearch, requestTimeRange])
+  }, [widgets, loading, publishSearch, requestTimeRange])
 
   return null
 }

--- a/src/ui/src/dashboard/stores/search-store.test.ts
+++ b/src/ui/src/dashboard/stores/search-store.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { searchStoreKey, useSearchStore } from './search-store'
+
+describe('searchStoreKey', () => {
+  it('keys configured widgets by protocol and profile', () => {
+    expect(
+      searchStoreKey({
+        protocol_id: { value: 1 },
+        protocol_profile: 'call',
+        fields: [{ id: 'call_id' }],
+      }),
+    ).toBe('proto:1:call')
+  })
+
+  it('is stable across dashboards/widgets for the same protocol', () => {
+    const a = searchStoreKey({
+      protocol_id: { value: 1 },
+      protocol_profile: 'registration',
+      fields: [{ id: 'aor' }],
+    })
+    const b = searchStoreKey({
+      protocol_id: { value: 1 },
+      protocol_profile: 'registration',
+      fields: [{ id: 'call_id' }, { id: 'aor' }],
+    })
+    expect(a).toBe(b)
+  })
+
+  it('separates different protocols and profiles', () => {
+    const sipCall = searchStoreKey({
+      protocol_id: { value: 1 },
+      protocol_profile: 'call',
+      fields: [{ id: 'call_id' }],
+    })
+    const sipReg = searchStoreKey({
+      protocol_id: { value: 1 },
+      protocol_profile: 'registration',
+      fields: [{ id: 'aor' }],
+    })
+    const otlp = searchStoreKey({
+      protocol_id: { value: 200 },
+      protocol_profile: 'default',
+      fields: [{ id: 'trace_id' }],
+    })
+    expect(new Set([sipCall, sipReg, otlp]).size).toBe(3)
+  })
+
+  it('falls back to default profile when profile is empty', () => {
+    expect(
+      searchStoreKey({ protocol_id: { value: 5 }, fields: [{ id: 'x' }] }),
+    ).toBe('proto:5:default')
+  })
+
+  it('uses the shared legacy key for unconfigured widgets', () => {
+    expect(searchStoreKey(undefined)).toBe('legacy:sip')
+    expect(searchStoreKey({})).toBe('legacy:sip')
+    expect(searchStoreKey({ fields: [] })).toBe('legacy:sip')
+    // protocol set but no fields yet (bootstrap pending) — still legacy
+    expect(searchStoreKey({ protocol_id: { value: 1 } })).toBe('legacy:sip')
+  })
+})
+
+describe('useSearchStore persistence behaviour', () => {
+  it('persists fields under a protocol key and survives unrelated keys', () => {
+    const { setField, getForm, clearForm } = useSearchStore.getState()
+    const key = 'proto:1:call'
+
+    setField(key, 'call_id', 'abc-123')
+    setField(key, 'from_user', 'alice')
+    setField('proto:1:registration', 'aor', 'bob')
+
+    expect(getForm(key).form.call_id).toBe('abc-123')
+    expect(getForm(key).form.from_user).toBe('alice')
+    expect(getForm('proto:1:registration').form.aor).toBe('bob')
+
+    clearForm(key)
+    expect(getForm(key).form.call_id).toBe('')
+    // other protocol untouched
+    expect(getForm('proto:1:registration').form.aor).toBe('bob')
+    clearForm('proto:1:registration')
+  })
+})

--- a/src/ui/src/dashboard/stores/search-store.ts
+++ b/src/ui/src/dashboard/stores/search-store.ts
@@ -59,6 +59,27 @@ const DEFAULT_STATE: SearchFormState = {
   limit: 50,
 }
 
+/**
+ * Persisted-form key for a search widget. Keyed by protocol + profile (not
+ * dashboard/widget id) so filters typed in e.g. SIP Call Search survive
+ * switching dashboard tabs and are shared by widgets searching the same
+ * protocol — matching the Homer 7 behaviour requested in discussion #779.
+ * Unconfigured widgets (mapping not loaded / legacy static form) share one
+ * global SIP key for the same reason.
+ */
+export function searchStoreKey(config?: {
+  protocol_id?: { value?: unknown }
+  protocol_profile?: string
+  fields?: unknown[]
+}): string {
+  const hepid = config?.protocol_id?.value
+  const configured = Array.isArray(config?.fields) && config.fields.length > 0
+  if (configured && hepid !== undefined && hepid !== null && hepid !== '') {
+    return `proto:${hepid}:${config?.protocol_profile || 'default'}`
+  }
+  return 'legacy:sip'
+}
+
 interface SearchStore {
   forms: Record<string, SearchFormState>
   getForm: (key: string) => SearchFormState

--- a/src/ui/src/dashboard/widgets/SearchPanel.tsx
+++ b/src/ui/src/dashboard/widgets/SearchPanel.tsx
@@ -23,7 +23,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { apiGet, apiPost } from '@/api'
 import { useDashboard } from '../context/DashboardContext'
 import { resolveTimeRange } from '../utils/resolveTimeRange'
-import { useSearchStore } from '../stores/search-store'
+import { useSearchStore, searchStoreKey } from '../stores/search-store'
 import { getWidgetMeta } from './registry'
 import { computeAvailableRows, fitWidgetHeight } from '../utils/grid-utils'
 import SearchWidgetSettings from '../components/SearchWidgetSettings'
@@ -199,10 +199,13 @@ function multiSelectOptionsFromMappingField(field) {
 }
 
 export default function SearchPanel({ config, onConfigChange, widgetId }) {
-  const { publishSearch, widgets, updateWidgets, setLocked, locked, timeRange, timeZone, activeDashboardId } = useDashboard()
-  // Never use '' — search-store ignores setField/setActiveTab when key is empty, so the form
-  // would not persist (SQL / filters) and Search would appear to do nothing.
-  const storeKey = `${activeDashboardId || '_'}:${widgetId ?? 'search'}`
+  const { publishSearch, widgets, updateWidgets, setLocked, locked, timeRange, timeZone } = useDashboard()
+  // Keyed by protocol+profile (searchStoreKey) so filters persist across
+  // dashboard tabs and are shared by search widgets of the same protocol
+  // (discussion #779). Never '' — search-store ignores setField/setActiveTab
+  // when key is empty, so the form would not persist and Search would appear
+  // to do nothing.
+  const storeKey = searchStoreKey(config)
   const { form, activeTab, limit } = useSearchStore((s) => s.getForm(storeKey))
   const { setField, setActiveTab, setLimit, clearForm } = useSearchStore.getState()
 

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.238"
+	VERSION_APPLICATION = "11.0.239"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Persist search form filters across dashboard tab switches, as requested in discussion #779 (Homer 7 parity).
- The persisted form is now keyed by **protocol + profile** (`proto:<hepid>:<profile>`) instead of `dashboard:widget`, so:
  - filters typed in e.g. *SIP Call Search* survive bouncing between dashboard tabs;
  - search widgets querying the same protocol share one form (call vs registration vs OTLP keep separate forms);
  - unconfigured/legacy static widgets share a single `legacy:sip` key.
- `SearchDeepLinkBootstrap` writes deep-link params into the same protocol-scoped key.
- Added unit tests for `searchStoreKey` and store persistence; bump `VERSION_APPLICATION` to **11.0.239**.

Closes the feature request from https://github.com/sipcapture/homer/discussions/779

## Notes
- Form values, active tab (Form/SQL/AI) and limit were already persisted to localStorage, but scoped per dashboard+widget — new widgets/dashboards always started empty. Protocol-scoped keys make the persistence visible in the workflow described in the discussion.
- The `Clear` button still resets only the current form (per protocol).

## Test plan
- [x] `npx vitest run src/dashboard/stores/search-store.test.ts` — 6 passed
- [x] `npm run check-types` and `npm run build` — clean
- [x] Full UI suite: only pre-existing `App.test.tsx` failures (reproduced on clean homer11)
- [ ] Manual: type filters in SIP Call Search, switch dashboard tabs, return — filters retained