### PR TITLE
fix(ci): use go-version-file in Compile Check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       go_version:
-        description: Go version override (e.g. 1.26.3)
+        description: Go version override (empty = use src/go.mod)
         required: false
-        default: "1.26.3"
+        default: ""
 
 permissions:
   contents: read
@@ -28,7 +28,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ github.event_name == 'workflow_dispatch' && inputs.go_version || '1.26.3' }}
+          # Empty go-version falls back to go-version-file, so PR checks always
+          # match the toolchain required by src/go.mod (manual dispatch can override).
+          go-version: ${{ github.event_name == 'workflow_dispatch' && inputs.go_version || '' }}
+          go-version-file: src/go.mod
+          cache-dependency-path: src/go.sum
 
       - name: Set up Node.js
         uses: actions/setup-node@v5


### PR DESCRIPTION
## Summary
- The PR "Compile Check" workflow hardcodes `go-version: 1.26.3`; after #778 bumped `src/go.mod` to `go 1.26.4`, every PR fails with `go: go.mod requires go >= 1.26.4 (running go 1.26.3; GOTOOLCHAIN=local)` (e.g. #782).
- Resolve the toolchain from `src/go.mod` via `go-version-file` — same as `release.yml` / `dev-release.yml` / `devel-homer11-packages.yml` — so future Go bumps cannot break PR checks.
- Add `cache-dependency-path: src/go.sum` to fix the "Restore cache failed: Dependencies file is not found" warning (go.mod lives in `src/`, not the repo root).
- `workflow_dispatch` can still override the Go version; empty input falls back to go.mod.

## Test plan
- [ ] Compile Check on this PR runs with Go 1.26.4 and passes
- [ ] Re-run checks on #782 after merge — green