### PR TITLE
fix(ducklake): data_extra double-encoded JSON broke Aleg correlation (#790)

### DIFF
--- a/examples/lua/correlation/sip_call.lua
+++ b/examples/lua/correlation/sip_call.lua
@@ -83,10 +83,29 @@ end
 -- handful of common keys so user-customised schemas keep working.
 local function row_correlation_id(row)
   if type(row) ~= "table" then return nil end
-  return row["correlation_id"]
+  local v = row["correlation_id"]
       or row["x_call_id"]
       or row["xcid"]
       or row["callid_aleg"]
+  if is_non_empty(v) then return v end
+
+  -- The default schema stores x_call_id inside the data_extra JSON
+  -- string, not as a top-level column, so extract it from there. This is
+  -- what makes B-leg -> A-leg correlation work: the B-leg row carries
+  -- x_call_id = A-leg Call-ID.
+  local de = row["data_extra"]
+  if type(de) == "string" then
+    v = de:match('"x_call_id"%s*:%s*"([^"]*)"')
+    if is_non_empty(v) then return v end
+  end
+
+  -- HEP cid column: the decoder stores the aleg id there when the
+  -- capture agent did not send its own correlation chunk. When unused it
+  -- just mirrors session_id, which we must not treat as a peer id.
+  local cid = row["cid"]
+  if is_non_empty(cid) and cid ~= row["session_id"] then return cid end
+
+  return nil
 end
 
 function correlate(data, nodes, ctx)

--- a/src/coordinator/correlation_seed.go
+++ b/src/coordinator/correlation_seed.go
@@ -10,6 +10,7 @@ package coordinator
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"database/sql"
 	_ "embed"
 	"encoding/hex"
@@ -42,6 +43,17 @@ type seedSpec struct {
 var defaultCorrelationSeeds = []seedSpec{
 	{profile: "call", hepAlias: "SIP", hepID: 1, script: defaultCallCorrelationLua},
 	{profile: "registration", hepAlias: "SIP", hepID: 1, script: defaultRegistrationCorrelationLua},
+}
+
+// legacySeedSHA256 fingerprints superseded versions of the bundled templates
+// (keyed by profile). Stored rows that still match one of these byte-for-byte
+// were never edited by an operator and are upgraded in place on start-up.
+// Operator-modified scripts never match and are left untouched.
+var legacySeedSHA256 = map[string][]string{
+	// sip_call.lua before 11.0.242: row_correlation_id only looked at
+	// top-level columns, so B-leg -> A-leg correlation never found the
+	// x_call_id stored inside the data_extra JSON.
+	"call": {"d22553459a7bd3e7ad05d68d56e9cd0fbf0343d430003995c0e356104e8559a3"},
 }
 
 // seedDefaultCorrelationScript inserts the bundled correlation templates
@@ -96,7 +108,7 @@ func seedOne(ctx context.Context, db *sql.DB, s seedSpec) error {
 			s.script, s.hepID, s.profile, mangled); err != nil {
 			return err
 		}
-		return nil
+		return upgradeLegacySeed(ctx, db, s)
 	}
 
 	guid, err := randomGUID()
@@ -114,6 +126,60 @@ func seedOne(ctx context.Context, db *sql.DB, s seedSpec) error {
 			services.CorrelationScriptsTable),
 		guid, s.profile, s.hepAlias, s.hepID, s.script)
 	return err
+}
+
+// upgradeLegacySeed replaces stored scripts that byte-for-byte match a
+// superseded bundled template (see legacySeedSHA256) with the current one.
+// status and all other columns are preserved, so an enabled script stays
+// enabled across the upgrade.
+func upgradeLegacySeed(ctx context.Context, db *sql.DB, s seedSpec) error {
+	hashes := legacySeedSHA256[s.profile]
+	if len(hashes) == 0 {
+		return nil
+	}
+	rows, err := db.QueryContext(ctx,
+		fmt.Sprintf(`SELECT guid, script FROM %s
+		 WHERE type = 'correlation' AND hepid = ? AND profile = ?`,
+			services.CorrelationScriptsTable),
+		s.hepID, s.profile)
+	if err != nil {
+		return err
+	}
+	type upd struct{ guid string }
+	var updates []upd
+	for rows.Next() {
+		var guid, script sql.NullString
+		if err := rows.Scan(&guid, &script); err != nil {
+			rows.Close()
+			return err
+		}
+		if !guid.Valid || !script.Valid || script.String == s.script {
+			continue
+		}
+		sum := sha256.Sum256([]byte(script.String))
+		hexSum := hex.EncodeToString(sum[:])
+		for _, h := range hashes {
+			if hexSum == h {
+				updates = append(updates, upd{guid: guid.String})
+				break
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	rows.Close()
+
+	for _, u := range updates {
+		if _, err := db.ExecContext(ctx,
+			fmt.Sprintf(`UPDATE %s SET script = ? WHERE guid = ?`,
+				services.CorrelationScriptsTable),
+			s.script, u.guid); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // randomGUID returns a 32-hex-char random id without pulling in uuid.

--- a/src/coordinator/correlation_seed_lua/sip_call.lua
+++ b/src/coordinator/correlation_seed_lua/sip_call.lua
@@ -83,10 +83,29 @@ end
 -- handful of common keys so user-customised schemas keep working.
 local function row_correlation_id(row)
   if type(row) ~= "table" then return nil end
-  return row["correlation_id"]
+  local v = row["correlation_id"]
       or row["x_call_id"]
       or row["xcid"]
       or row["callid_aleg"]
+  if is_non_empty(v) then return v end
+
+  -- The default schema stores x_call_id inside the data_extra JSON
+  -- string, not as a top-level column, so extract it from there. This is
+  -- what makes B-leg -> A-leg correlation work: the B-leg row carries
+  -- x_call_id = A-leg Call-ID.
+  local de = row["data_extra"]
+  if type(de) == "string" then
+    v = de:match('"x_call_id"%s*:%s*"([^"]*)"')
+    if is_non_empty(v) then return v end
+  end
+
+  -- HEP cid column: the decoder stores the aleg id there when the
+  -- capture agent did not send its own correlation chunk. When unused it
+  -- just mirrors session_id, which we must not treat as a peer id.
+  local cid = row["cid"]
+  if is_non_empty(cid) and cid ~= row["session_id"] then return cid end
+
+  return nil
 end
 
 function correlate(data, nodes, ctx)

--- a/src/coordinator/correlation_seed_test.go
+++ b/src/coordinator/correlation_seed_test.go
@@ -9,7 +9,9 @@ package coordinator
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -175,6 +177,69 @@ func TestSeedDefaultCorrelationScript_RepairsLegacyDoubleEscape(t *testing.T) {
 	if got != operatorEdited {
 		t.Errorf("operator-edited `registration` row must not be overwritten; got %q",
 			safeSlice(got, 0, 80))
+	}
+}
+
+// TestSeedDefaultCorrelationScript_UpgradesLegacyTemplate verifies that a
+// stored script matching a superseded bundled template (fingerprinted in
+// legacySeedSHA256) is upgraded in place — preserving status — while
+// operator-edited scripts whose hash does not match stay untouched.
+func TestSeedDefaultCorrelationScript_UpgradesLegacyTemplate(t *testing.T) {
+	db := openTestSettingsDB(t)
+
+	callSeed := defaultCorrelationSeeds[0] // profile=call
+
+	legacyScript := "-- legacy bundled template\nfunction correlate(data, nodes) return {} end\n"
+	operatorEdited := "-- operator tweaked\nfunction correlate(data, nodes) return {\"x\"} end\n"
+
+	sum := sha256.Sum256([]byte(legacyScript))
+	old := legacySeedSHA256["call"]
+	legacySeedSHA256["call"] = append([]string{hex.EncodeToString(sum[:])}, old...)
+	t.Cleanup(func() { legacySeedSHA256["call"] = old })
+
+	// Enabled legacy row (must be upgraded, status preserved) and an
+	// operator row under another guid (must stay).
+	for _, r := range []struct {
+		guid, script string
+		status       bool
+	}{
+		{"legacy-template-guid", legacyScript, true},
+		{"operator-call-guid", operatorEdited, false},
+	} {
+		if _, err := db.Exec(
+			fmt.Sprintf(`INSERT INTO %s (guid, profile, hep_alias, type, hepid, status, script, create_date)
+			 VALUES (?, ?, ?, 'correlation', ?, ?, ?, current_timestamp)`,
+				services.CorrelationScriptsTable),
+			r.guid, callSeed.profile, callSeed.hepAlias, callSeed.hepID, r.status, r.script); err != nil {
+			t.Fatalf("insert %s: %v", r.guid, err)
+		}
+	}
+
+	if err := seedDefaultCorrelationScript(db); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var script string
+	var status bool
+	if err := db.QueryRow(
+		fmt.Sprintf(`SELECT script, status FROM %s WHERE guid = ?`, services.CorrelationScriptsTable),
+		"legacy-template-guid").Scan(&script, &status); err != nil {
+		t.Fatalf("read upgraded row: %v", err)
+	}
+	if script != callSeed.script {
+		t.Errorf("legacy template row was not upgraded to the current template")
+	}
+	if !status {
+		t.Errorf("upgrade must preserve status=TRUE")
+	}
+
+	if err := db.QueryRow(
+		fmt.Sprintf(`SELECT script FROM %s WHERE guid = ?`, services.CorrelationScriptsTable),
+		"operator-call-guid").Scan(&script); err != nil {
+		t.Fatalf("read operator row: %v", err)
+	}
+	if script != operatorEdited {
+		t.Errorf("operator-edited row must not be overwritten")
 	}
 }
 

--- a/src/storage/ducklake/extra_json_test.go
+++ b/src/storage/ducklake/extra_json_test.go
@@ -5,8 +5,12 @@
 package ducklake
 
 import (
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
 	"testing"
 
+	duckdb "github.com/duckdb/duckdb-go/v2"
 	"github.com/sipcapture/homer-core/src/decoder"
 )
 
@@ -29,26 +33,123 @@ func TestBuildExtraJSONCell_PooledBuffer(t *testing.T) {
 	releaseExtraJSONCell(cell)
 }
 
-func TestCellToDriverValue_pooledJSONIsString(t *testing.T) {
+// The Appender json.Marshal()s values for JSON columns, so a plain Go string
+// would be stored as a double-encoded JSON string scalar. data_extra cells
+// must reach the Appender as json.RawMessage (issue #790).
+func TestCellToDriverValue_pooledJSONIsRawMessage(t *testing.T) {
 	b := []byte(`{"version":3}`)
 	cell := any(&b)
 	dv := cellToDriverValue(cell)
-	s, ok := dv.(string)
+	m, ok := dv.(json.RawMessage)
 	if !ok {
-		t.Fatalf("expected string, got %T", dv)
+		t.Fatalf("expected json.RawMessage, got %T", dv)
 	}
-	if s != string(b) {
-		t.Fatalf("got %q", s)
+	if string(m) != string(b) {
+		t.Fatalf("got %q", m)
+	}
+}
+
+func TestCellToDriverValue_emptyPooledJSONIsRawObject(t *testing.T) {
+	var b []byte
+	dv := cellToDriverValue(any(&b))
+	m, ok := dv.(json.RawMessage)
+	if !ok {
+		t.Fatalf("expected json.RawMessage, got %T", dv)
+	}
+	if string(m) != "{}" {
+		t.Fatalf("got %q", m)
 	}
 }
 
 func TestCachedSIPVersionOnlyJSON(t *testing.T) {
 	a := cachedSIPVersionOnlyJSON(7)
 	b := cachedSIPVersionOnlyJSON(7)
-	if a != b {
+	if &a[0] != &b[0] {
 		t.Fatalf("cache miss: %q vs %q", a, b)
 	}
-	if a != `{"version":7}` {
+	if string(a) != `{"version":7}` {
 		t.Fatalf("got %q", a)
+	}
+}
+
+// TestAppenderJSONColumnNotDoubleEncoded is the end-to-end regression test
+// for issue #790: data_extra written through the Appender must land as a
+// JSON object (json_type='OBJECT'), not a double-encoded string scalar
+// (json_type='VARCHAR'). With a VARCHAR scalar json_extract_string(...,
+// '$.x_call_id') returns NULL and Lua call correlation silently finds
+// nothing.
+func TestAppenderJSONColumnNotDoubleEncoded(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE t (session_id VARCHAR, data_extra JSON)`); err != nil {
+		t.Fatal(err)
+	}
+
+	pkt := decoder.BenchHEP3SIPPacket()
+	hep, err := decoder.DecodeHEP(pkt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer decoder.ReleaseHEP(hep)
+	hep.SIP.XCallID = "aleg-call-id-1"
+
+	cells := map[string]interface{}{
+		"pooled-sip-extra": buildExtraJSONCell(hep),
+		"cached-simple":    buildSimpleExtraJSONCell(hep),
+		"version-only":     cachedSIPVersionOnlyJSON(2),
+	}
+
+	conn, err := db.Conn(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	err = conn.Raw(func(driverConn interface{}) error {
+		appender, aerr := duckdb.NewAppenderFromConn(driverConn.(driver.Conn), "", "t")
+		if aerr != nil {
+			return aerr
+		}
+		for name, cell := range cells {
+			if aerr = appender.AppendRow(name, cellToDriverValue(cell)); aerr != nil {
+				appender.Close()
+				return aerr
+			}
+		}
+		return appender.Close()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	releaseExtraJSONCell(cells["pooled-sip-extra"])
+
+	rows, err := db.Query(`SELECT session_id, json_type(data_extra) FROM t`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name, jt string
+		if err := rows.Scan(&name, &jt); err != nil {
+			t.Fatal(err)
+		}
+		if jt != "OBJECT" {
+			t.Fatalf("%s: json_type = %q, want OBJECT (double-encoded data_extra)", name, jt)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	var xcid sql.NullString
+	err = db.QueryRow(`SELECT json_extract_string(data_extra, '$.x_call_id')
+		FROM t WHERE session_id = 'pooled-sip-extra'`).Scan(&xcid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !xcid.Valid || xcid.String != "aleg-call-id-1" {
+		t.Fatalf("x_call_id = %#v, want aleg-call-id-1", xcid)
 	}
 }

--- a/src/storage/ducklake/hep_adapter.go
+++ b/src/storage/ducklake/hep_adapter.go
@@ -10,6 +10,7 @@ package ducklake
 import (
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"math/rand"
 	"strconv"
 	"sync"
@@ -349,7 +350,7 @@ func (a *MultiTableAdapter) buildRTCPValues(hep *decoder.HEP, uid string, date t
 	row[9] = nodeID
 	row[10] = hep.CID
 	row[11] = hep.Payload
-	row[12] = buildSimpleExtraJSON(hep)
+	row[12] = buildSimpleExtraJSONCell(hep)
 	return row
 }
 
@@ -368,7 +369,7 @@ func (a *MultiTableAdapter) buildDNSValues(hep *decoder.HEP, uid string, date ti
 	row[7] = hep.Protocol
 	row[8] = nodeID
 	row[9] = hep.Payload
-	row[10] = buildSimpleExtraJSON(hep)
+	row[10] = buildSimpleExtraJSONCell(hep)
 	return row
 }
 
@@ -385,7 +386,7 @@ func (a *MultiTableAdapter) buildLOGValues(hep *decoder.HEP, uid string, date ti
 	row[5] = hep.DstIP
 	row[6] = nodeID
 	row[7] = hep.Payload
-	row[8] = buildSimpleExtraJSON(hep)
+	row[8] = buildSimpleExtraJSONCell(hep)
 	return row
 }
 
@@ -407,7 +408,7 @@ func (a *MultiTableAdapter) buildDefaultValues(hep *decoder.HEP, uid string, dat
 	row[9] = nodeID
 	row[10] = hep.CID
 	row[11] = hep.Payload
-	row[12] = buildSimpleExtraJSON(hep)
+	row[12] = buildSimpleExtraJSONCell(hep)
 	return row
 }
 
@@ -559,22 +560,23 @@ func appendSIPExtraFields(b *[]byte, first *bool, hep *decoder.HEP) {
 }
 
 // sipVersionOnlyCache caches {"version":N} for SIP when no optional fields are set.
-var sipVersionOnlyCache sync.Map // uint32 version -> string
+var sipVersionOnlyCache sync.Map // uint32 version -> json.RawMessage
 
-func cachedSIPVersionOnlyJSON(version uint32) string {
+func cachedSIPVersionOnlyJSON(version uint32) json.RawMessage {
 	if v, ok := sipVersionOnlyCache.Load(version); ok {
-		return v.(string)
+		return v.(json.RawMessage)
 	}
 	bp := sbPool.Get().(*[]byte)
 	b := (*bp)[:0]
 	b = append(b, `{"version":`...)
 	b = strconv.AppendUint(b, uint64(version), 10)
 	b = append(b, '}')
-	s := string(b)
+	// The cached value lives indefinitely, so copy out of the pooled buffer.
+	m := json.RawMessage(string(b))
 	*bp = b
 	sbPool.Put(bp)
-	sipVersionOnlyCache.Store(version, s)
-	return s
+	sipVersionOnlyCache.Store(version, m)
+	return m
 }
 
 func buildSIPExtraJSONInto(b []byte, hep *decoder.HEP) []byte {
@@ -588,10 +590,15 @@ func buildSIPExtraJSONInto(b []byte, hep *decoder.HEP) []byte {
 }
 
 // buildExtraJSONCell returns a value suitable for row data_extra column.
-// Either a cached string or *([]byte) (pooled; released in putRowSlice).
+// Either a cached json.RawMessage or *([]byte) (pooled; released in
+// putRowSlice). data_extra columns are JSON-typed, and the duckdb-go
+// Appender json.Marshal()s whatever it receives — a plain Go string would
+// be stored as a double-encoded JSON string scalar instead of an object
+// (breaking json_extract_string and Lua call correlation), so JSON cells
+// must always be json.RawMessage or pooled raw bytes here.
 func buildExtraJSONCell(hep *decoder.HEP) interface{} {
 	if hep.SIP == nil {
-		return buildSimpleExtraJSON(hep)
+		return buildSimpleExtraJSONCell(hep)
 	}
 	bp := sbPool.Get().(*[]byte)
 	b := buildSIPExtraJSONInto((*bp)[:0], hep)
@@ -621,22 +628,31 @@ func releaseExtraJSONCell(v interface{}) {
 }
 
 // cellToDriverValue converts a batch cell to a driver value. Pooled JSON
-// buffers are copied to string at flush time (Appender copies again internally).
+// buffers become json.RawMessage: the upstream duckdb-go Appender runs
+// json.Marshal on values destined for JSON columns, so a plain string would
+// be re-encoded into a JSON string scalar ("{\"a\":1}" instead of {"a":1}),
+// silently breaking every json_extract_* consumer (Lua call correlation,
+// data_extra virtual-field search). json.RawMessage marshals to itself.
+// The pooled buffer is only released after Appender.Close (putRowSlice),
+// so aliasing it here is safe.
 func cellToDriverValue(v interface{}) interface{} {
 	if bp, ok := v.(*[]byte); ok {
 		if bp == nil || len(*bp) == 0 {
-			return "{}"
+			return emptyJSONObject
 		}
-		return string(*bp)
+		return json.RawMessage(*bp)
 	}
 	return v
 }
 
+// emptyJSONObject is the shared driver value for empty data_extra cells.
+var emptyJSONObject = json.RawMessage("{}")
+
 // buildExtraJSON builds the data_extra JSON string (legacy single-table path).
 func buildExtraJSON(hep *decoder.HEP) string {
 	cell := buildExtraJSONCell(hep)
-	if s, ok := cell.(string); ok {
-		return s
+	if m, ok := cell.(json.RawMessage); ok {
+		return string(m)
 	}
 	bp := cell.(*[]byte)
 	s := string(*bp)
@@ -644,16 +660,18 @@ func buildExtraJSON(hep *decoder.HEP) string {
 	return s
 }
 
-// simpleExtraCache caches "{\"version\":N,\"proto_type\":M}" strings for non-SIP packets.
+// simpleExtraCache caches {"version":N,"proto_type":M} for non-SIP packets.
 // Keyed by version<<16 | protoType (both fit in 16 bits for known HEP protos).
-var simpleExtraCache sync.Map // uint32 -> string
+var simpleExtraCache sync.Map // uint32 -> json.RawMessage
 
-// buildSimpleExtraJSON builds a minimal extra JSON for non-SIP packets.
+// buildSimpleExtraJSONCell builds a minimal extra JSON cell for non-SIP packets.
 // Result is cached since version and proto_type rarely change between packets.
-func buildSimpleExtraJSON(hep *decoder.HEP) string {
+// Returned as json.RawMessage so the Appender writes it as a JSON document
+// (see cellToDriverValue).
+func buildSimpleExtraJSONCell(hep *decoder.HEP) json.RawMessage {
 	key := uint32(hep.Version)<<16 | (hep.ProtoType & 0xffff)
 	if v, ok := simpleExtraCache.Load(key); ok {
-		return v.(string)
+		return v.(json.RawMessage)
 	}
 	bp := sbPool.Get().(*[]byte)
 	b := (*bp)[:0]
@@ -662,12 +680,17 @@ func buildSimpleExtraJSON(hep *decoder.HEP) string {
 	b = append(b, `,"proto_type":`...)
 	b = strconv.AppendUint(b, uint64(hep.ProtoType), 10)
 	b = append(b, '}')
-	// For the cache we need a real heap string (lives indefinitely).
-	s := string(b)
+	// The cached value lives indefinitely, so copy out of the pooled buffer.
+	m := json.RawMessage(string(b))
 	*bp = b
 	sbPool.Put(bp)
-	simpleExtraCache.Store(key, s)
-	return s
+	simpleExtraCache.Store(key, m)
+	return m
+}
+
+// buildSimpleExtraJSON is the string variant for legacy single-table records.
+func buildSimpleExtraJSON(hep *decoder.HEP) string {
+	return string(buildSimpleExtraJSONCell(hep))
 }
 
 // GetWriter returns the underlying writer

--- a/src/storage/ducklake/sql_lake_insert.go
+++ b/src/storage/ducklake/sql_lake_insert.go
@@ -5,6 +5,7 @@
 package ducklake
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -137,10 +138,23 @@ func BuildInsertMultiValues(lakeName string, key TableKey, rows [][]interface{})
 	for ri, row := range rows {
 		parts := make([]string, len(row))
 		for ci, cell := range row {
-			// data_extra is JSON in DuckLake
+			// data_extra is JSON in DuckLake. Row builders emit it as a
+			// string, json.RawMessage or pooled *[]byte (see
+			// buildExtraJSONCell); all three carry the raw JSON text.
 			if cols[ci] == "data_extra" {
-				if s, ok := cell.(string); ok {
-					esc, err := formatSQLLiteral(s)
+				var text string
+				switch x := cell.(type) {
+				case string:
+					text = x
+				case json.RawMessage:
+					text = string(x)
+				case *[]byte:
+					if x != nil {
+						text = string(*x)
+					}
+				}
+				if text != "" {
+					esc, err := formatSQLLiteral(text)
 					if err != nil {
 						return "", err
 					}

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.241"
+	VERSION_APPLICATION = "11.0.242"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
Fixes #790.

## Root cause

This is a regression introduced in **v11.0.236** by the DuckDB 1.5.3 / upstream `duckdb-go/v2` migration. As part of that bump, the HEP write path started passing the `data_extra` cell to the DuckDB Appender as a plain Go string. The upstream Appender runs `json.Marshal()` on values destined for JSON columns, so the JSON object text got re-encoded into a **JSON string scalar**:

```
expected: {"x_call_id":"aleg-call-id"}
stored:   "{\"x_call_id\":\"aleg-call-id\"}"
```

The correlation script looks up peer legs with `json_extract_string(data_extra, '$.x_call_id')`, which returns `NULL` for a string scalar, so the query succeeds but matches nothing. That's why the reporter saw no errors and no timeouts: the engine ran fine, correlated 0 rows, and `correlation: reloaded scripts count=1` was the only relevant log line. Increasing `HOMER_COORDINATOR_CORRELATION_*` had no effect for the same reason.

## Fix

- `data_extra` is now handed to the Appender as `json.RawMessage`, which is stored verbatim as a JSON object (pooled SIP buffers and the cached simple/version-only cells).
- `BuildInsertMultiValues` (Line Protocol ingest, PCAP import) accepts `json.RawMessage` and pooled `*[]byte` data_extra cells.
- Bundled `sip_call.lua` now extracts `x_call_id` from inside the `data_extra` JSON (and falls back to the `cid` column when it differs from `session_id`), so opening the **B-leg also pulls in the A-leg**; previously only A to B worked.
- Unmodified copies of the bundled script in the settings DB are upgraded automatically on startup via SHA256 fingerprint, preserving `status`; operator-edited scripts are never touched.

## Tests

- New regression test `TestAppenderJSONColumnNotDoubleEncoded`: writes through a real DuckDB Appender into a JSON column and asserts `json_type(data_extra) = 'OBJECT'` plus `x_call_id` extraction (fails on the old code).
- New `TestSeedDefaultCorrelationScript_UpgradesLegacyTemplate` for the in-place seed upgrade.
- Full `go test` over `storage/...`, `coordinator/...`, `scripting/...`, `lineprotoreceiver`, `decoder`, `writer` is green; `go vet` clean.
- Verified end-to-end: all-in-one instance, two HEP legs ingested with `X-CID`, transaction view returns both `session_id`s in both directions.

## Caveat for existing data

Rows ingested on 11.0.236-11.0.241 remain double-encoded on disk; the fix applies to new writes. They can age out with retention or be repaired once with:

```sql
UPDATE homer_lake.hep_proto_1_call
SET data_extra = json_extract(data_extra, '$')::JSON
WHERE json_type(data_extra) = 'VARCHAR';
```

Bumps `VERSION_APPLICATION` to 11.0.242.
