### PR TITLE
fix(ui): pretty-print and syntax-highlight JSON event payloads (#789)

### DIFF
--- a/src/ui/src/App.css
+++ b/src/ui/src/App.css
@@ -146,6 +146,41 @@
   }
 }
 
+/* JSON syntax highlighting (dangerouslySetInnerHTML) — plain CSS so Tailwind
+   content scan does not need to see class names inside TS string literals. */
+.json-hl-key {
+  color: oklch(0.52 0.16 245);
+}
+.json-hl-str {
+  color: oklch(0.48 0.14 155);
+}
+.json-hl-num {
+  color: oklch(0.58 0.16 75);
+}
+.json-hl-bool {
+  color: oklch(0.52 0.17 295);
+}
+.json-hl-null,
+.json-hl-punct {
+  color: oklch(0.48 0.015 255);
+}
+.dark .json-hl-key {
+  color: oklch(0.74 0.14 245);
+}
+.dark .json-hl-str {
+  color: oklch(0.72 0.14 155);
+}
+.dark .json-hl-num {
+  color: oklch(0.80 0.14 75);
+}
+.dark .json-hl-bool {
+  color: oklch(0.76 0.14 295);
+}
+.dark .json-hl-null,
+.dark .json-hl-punct {
+  color: oklch(0.72 0.015 255);
+}
+
 /* uPlot legend: small circular swatches (Grafana-style) instead of 1em squares */
 .uplot .u-legend .u-marker {
   width: 7px;

--- a/src/ui/src/dashboard/MessageModal.tsx
+++ b/src/ui/src/dashboard/MessageModal.tsx
@@ -7,50 +7,18 @@ import { FloatingWindow } from '@/components/ui/floating-window'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { displayDstIp, displaySrcIp } from '@/lib/ipAliasDisplay'
+import {
+  escapeHtml,
+  highlightJSON,
+  isJsonDisplayable,
+  payloadAsString,
+} from '@/lib/jsonDisplay'
 import { useLocale } from '@/components/locale/locale-provider'
-
-function escapeHtml(str) {
-  if (typeof str !== 'string') return str
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-}
-
-function isJSON(str) {
-  if (!str) return false
-  const trimmed = str.trim()
-  return (trimmed.startsWith('{') && trimmed.endsWith('}')) ||
-    (trimmed.startsWith('[') && trimmed.endsWith(']'))
-}
 
 // Tailwind v4 scans source files for class strings — keeping literal classnames
 // here so the compiler picks them up:
 // text-sky-500 text-violet-500 text-amber-500 text-emerald-500
 // text-destructive text-muted-foreground font-semibold font-medium
-
-function highlightJSON(payload) {
-  try {
-    const obj = JSON.parse(payload)
-    const formatted = JSON.stringify(obj, null, 2)
-    let html = escapeHtml(formatted)
-    html = html.replace(/&quot;([^&]+)&quot;(\s*:)/g,
-      '<span class="text-sky-500">&quot;$1&quot;</span><span class="text-muted-foreground">$2</span>')
-    html = html.replace(/: &quot;([^&]*)&quot;/g,
-      ': <span class="text-emerald-500">&quot;$1&quot;</span>')
-    html = html.replace(/: (-?\d+\.?\d*)/g,
-      ': <span class="text-amber-500">$1</span>')
-    html = html.replace(/: (true|false)/g,
-      ': <span class="text-violet-500">$1</span>')
-    html = html.replace(/: (null)/g,
-      ': <span class="text-muted-foreground">$1</span>')
-    html = html.replace(/([{}\[\]])/g, '<span class="text-muted-foreground">$1</span>')
-    return html
-  } catch {
-    return escapeHtml(payload)
-  }
-}
 
 function highlightSIP(payload) {
   if (!payload) return '(no payload)'
@@ -233,9 +201,9 @@ export default function MessageModal({ modal, onClose, timeZone }) {
   if (!modal) return null
 
   const { uuid, loading, data, error, messageContext, modalKey } = modal
-  const payload = data?.payload || ''
-  const payloadIsJson = isJSON(payload)
-  const payloadHtml = payloadIsJson ? highlightJSON(payload) : highlightSIP(payload)
+  const payload = payloadAsString(data?.payload)
+  const payloadIsJson = isJsonDisplayable(data?.payload ?? payload)
+  const payloadHtml = payloadIsJson ? highlightJSON(data?.payload ?? payload) : highlightSIP(payload)
 
   const handleDecode = async () => {
     if (!uuid || decoding) return

--- a/src/ui/src/dashboard/OTLPLogRowModal.tsx
+++ b/src/ui/src/dashboard/OTLPLogRowModal.tsx
@@ -3,45 +3,13 @@ import { useMemo, useState } from 'react'
 import { FloatingWindow } from '@/components/ui/floating-window'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+  highlightJSON,
+  isJsonDisplayable,
+  serializeRowForDisplay,
+} from '@/lib/jsonDisplay'
 import { cn } from '@/lib/utils'
 import { useLocale } from '@/components/locale/locale-provider'
-
-function escapeHtml(str) {
-  if (typeof str !== 'string') return str
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-}
-
-function isJSON(str) {
-  if (!str) return false
-  const trimmed = String(str).trim()
-  return (trimmed.startsWith('{') && trimmed.endsWith('}')) || (trimmed.startsWith('[') && trimmed.endsWith(']'))
-}
-
-function highlightJSON(payload) {
-  try {
-    const obj = JSON.parse(payload)
-    const formatted = JSON.stringify(obj, null, 2)
-    let html = escapeHtml(formatted)
-    html = html.replace(/&quot;([^&]+)&quot;(\s*:)/g,
-      '<span class="text-sky-500">&quot;$1&quot;</span><span class="text-muted-foreground">$2</span>')
-    html = html.replace(/: &quot;([^&]*)&quot;/g,
-      ': <span class="text-emerald-500">&quot;$1&quot;</span>')
-    html = html.replace(/: (-?\d+\.?\d*)/g,
-      ': <span class="text-amber-500">$1</span>')
-    html = html.replace(/: (true|false)/g,
-      ': <span class="text-violet-500">$1</span>')
-    html = html.replace(/: (null)/g,
-      ': <span class="text-muted-foreground">$1</span>')
-    html = html.replace(/([{}\[\]])/g, '<span class="text-muted-foreground">$1</span>')
-    return html
-  } catch {
-    return escapeHtml(payload)
-  }
-}
 
 function severityFromNumber(n) {
   if (n == null || Number.isNaN(n)) return ''
@@ -152,12 +120,7 @@ export default function OTLPLogRowModal({ modal, timeZone, onClose }) {
       else display = '—'
       entries.push({ key: k, display })
     }
-    let text
-    try {
-      text = JSON.stringify(row, null, 2)
-    } catch {
-      text = String(row)
-    }
+    const text = serializeRowForDisplay(row)
     const body = row?.body ?? row?.BODY ?? ''
     return { detailEntries: entries, jsonText: text, bodyText: String(body ?? '') }
   }, [row, timeZone, locale])
@@ -170,7 +133,9 @@ export default function OTLPLogRowModal({ modal, timeZone, onClose }) {
 
   const sev = resolvedSeverityLabel(row)
   const badgeCls = severityBadgeClass(sev)
-  const prettyHtml = isJSON(jsonText) ? highlightJSON(jsonText) : escapeHtml(jsonText)
+  const prettyHtml = highlightJSON(jsonText)
+  const bodyIsJson = isJsonDisplayable(bodyText)
+  const bodyPrettyHtml = bodyIsJson ? highlightJSON(bodyText) : ''
 
   return (
     <FloatingWindow
@@ -208,9 +173,16 @@ export default function OTLPLogRowModal({ modal, timeZone, onClose }) {
             <div>
               <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Body</span>
               <ScrollArea className="mt-1 max-h-[140px] rounded-sm border border-border bg-muted/20">
-                <pre className="whitespace-pre-wrap break-words p-2 font-mono text-[11px] text-foreground">
-                  {bodyText}
-                </pre>
+                {bodyIsJson ? (
+                  <pre
+                    className="whitespace-pre p-2 font-mono text-[11px] leading-relaxed"
+                    dangerouslySetInnerHTML={{ __html: bodyPrettyHtml }}
+                  />
+                ) : (
+                  <pre className="whitespace-pre-wrap break-words p-2 font-mono text-[11px] text-foreground">
+                    {bodyText}
+                  </pre>
+                )}
               </ScrollArea>
             </div>
           ) : null}

--- a/src/ui/src/dashboard/TransactionModal.tsx
+++ b/src/ui/src/dashboard/TransactionModal.tsx
@@ -22,6 +22,13 @@ import {
 } from '@/components/ui/table'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { displayDstIp, displaySrcIp } from '@/lib/ipAliasDisplay'
+import {
+  eventPayloadField,
+  formatJsonField,
+  highlightJSON,
+  isJsonDisplayable,
+  serializeRowForDisplay,
+} from '@/lib/jsonDisplay'
 import { cn } from '@/lib/utils'
 import { newModalKey } from '@/lib/modalKey'
 import { useLocale } from '@/components/locale/locale-provider'
@@ -291,6 +298,11 @@ function formatEventsCell(value, col, timeZone, locale) {
     const s = formatDateTime(value, locale, timeZone)
     return s || '—'
   }
+  const payloadLike = col.keys?.some((k) => k === 'payload' || k === 'message' || k === 'data' || k === 'body')
+  if (payloadLike && isJsonDisplayable(value)) {
+    const pretty = formatJsonField(value).replace(/\s+/g, ' ')
+    return pretty.length > 200 ? `${pretty.slice(0, 197)}…` : pretty
+  }
   if (typeof value === 'object') {
     try {
       const j = JSON.stringify(value)
@@ -303,16 +315,85 @@ function formatEventsCell(value, col, timeZone, locale) {
   return s.length > 200 ? `${s.slice(0, 197)}…` : s
 }
 
-function serializeRowJSONForWindow(row) {
-  try {
-    return JSON.stringify(
-      row,
-      (_k, v) => (typeof v === 'bigint' ? v.toString() : v),
-      2,
-    )
-  } catch (e) {
-    return `Error serializing row: ${e?.message || e}`
-  }
+function EventRecordDetail({ row }) {
+  const [recordTab, setRecordTab] = React.useState('pretty')
+  const [payloadTab, setPayloadTab] = React.useState('pretty')
+  const payloadVal = eventPayloadField(row)
+  const payloadIsJson = isJsonDisplayable(payloadVal)
+  const recordText = serializeRowForDisplay(row)
+  const recordPrettyHtml = highlightJSON(recordText)
+  const payloadPrettyHtml = highlightJSON(payloadVal)
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden">
+      {payloadIsJson ? (
+        <div className="shrink-0 space-y-1">
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Payload
+          </span>
+          <Tabs value={payloadTab} onValueChange={setPayloadTab} className="flex flex-col gap-2">
+            <TabsList variant="line" className="h-8 w-fit justify-start">
+              <TabsTrigger value="pretty" className="text-[11px]">
+                Pretty
+              </TabsTrigger>
+              <TabsTrigger value="raw" className="text-[11px]">
+                Raw
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value="pretty" className="mt-0">
+              <ScrollArea className="max-h-[220px] rounded-md border border-border bg-muted/40">
+                <pre
+                  className="whitespace-pre p-2 font-mono text-[11px] leading-relaxed"
+                  dangerouslySetInnerHTML={{ __html: payloadPrettyHtml || '(no payload)' }}
+                />
+              </ScrollArea>
+            </TabsContent>
+            <TabsContent value="raw" className="mt-0">
+              <ScrollArea className="max-h-[220px] rounded-md border border-border bg-muted/40">
+                <pre className="whitespace-pre-wrap break-all p-2 font-mono text-[11px] leading-relaxed text-foreground">
+                  {formatJsonField(payloadVal)}
+                </pre>
+              </ScrollArea>
+            </TabsContent>
+          </Tabs>
+        </div>
+      ) : null}
+      <div className="flex min-h-0 flex-1 flex-col gap-1 overflow-hidden">
+        <span className="shrink-0 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Full record
+        </span>
+        <Tabs
+          value={recordTab}
+          onValueChange={setRecordTab}
+          className="flex min-h-0 flex-1 flex-col overflow-hidden"
+        >
+          <TabsList variant="line" className="h-8 w-fit shrink-0 justify-start">
+            <TabsTrigger value="pretty" className="text-[11px]">
+              Pretty
+            </TabsTrigger>
+            <TabsTrigger value="raw" className="text-[11px]">
+              Raw
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="pretty" className="mt-0 min-h-0 flex-1 overflow-hidden">
+            <ScrollArea className="min-h-0 flex-1 rounded-md border border-border bg-muted/40">
+              <pre
+                className="whitespace-pre p-2 font-mono text-[11px] leading-relaxed"
+                dangerouslySetInnerHTML={{ __html: recordPrettyHtml || '(empty)' }}
+              />
+            </ScrollArea>
+          </TabsContent>
+          <TabsContent value="raw" className="mt-0 min-h-0 flex-1 overflow-hidden">
+            <ScrollArea className="min-h-0 flex-1 rounded-md border border-border bg-muted/40">
+              <pre className="whitespace-pre-wrap break-words p-2 font-mono text-[11px] leading-relaxed text-foreground">
+                {recordText}
+              </pre>
+            </ScrollArea>
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  )
 }
 
 function EventsTab({ data, isLoading, err, emptyLabel, timeZone, locale }) {
@@ -408,15 +489,8 @@ function EventsTab({ data, isLoading, err, emptyLabel, timeZone, locale }) {
           minHeight={280}
           className="flex min-h-0 flex-col"
         >
-          <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden px-3 pb-3 pt-0">
-            <p className="shrink-0 text-[10px] text-muted-foreground">
-              Full record including data_extra (JSON).
-            </p>
-            <ScrollArea className="min-h-0 flex-1 rounded-md border border-border bg-muted/40">
-              <pre className="whitespace-pre-wrap break-words p-3 font-mono text-[11px] leading-relaxed text-foreground">
-                {serializeRowJSONForWindow(detailRow)}
-              </pre>
-            </ScrollArea>
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 pb-3 pt-0">
+            <EventRecordDetail row={detailRow} />
           </div>
         </FloatingWindow>
       ) : null}
@@ -539,15 +613,8 @@ function OtlpLogsTab({
           minHeight={320}
           className="flex min-h-0 flex-col"
         >
-          <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden px-3 pb-3 pt-0">
-            <p className="shrink-0 text-[10px] text-muted-foreground">
-              Full record (JSON), including fields not shown in the table.
-            </p>
-            <ScrollArea className="min-h-0 flex-1 rounded-md border border-border bg-muted/40">
-              <pre className="whitespace-pre-wrap break-words p-3 font-mono text-[11px] leading-relaxed text-foreground">
-                {serializeRowJSONForWindow(detailRow)}
-              </pre>
-            </ScrollArea>
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-3 pb-3 pt-0">
+            <EventRecordDetail row={detailRow} />
           </div>
         </FloatingWindow>
       ) : null}

--- a/src/ui/src/lib/jsonDisplay.test.ts
+++ b/src/ui/src/lib/jsonDisplay.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatJsonField,
+  highlightJSON,
+  isJsonDisplayable,
+  serializeRowForDisplay,
+} from './jsonDisplay'
+
+describe('jsonDisplay', () => {
+  it('expands JSON payload strings when serializing a row', () => {
+    const row = {
+      uuid: 'abc',
+      payload: '{"level":"INFO","msg":"hello"}',
+      session_id: 'x@host',
+    }
+    const out = serializeRowForDisplay(row)
+    expect(out).toContain('"level": "INFO"')
+    expect(out).not.toContain('\\"level\\"')
+    expect(out).toContain('"payload": {')
+  })
+
+  it('pretty-prints a JSON payload string field', () => {
+    const pretty = formatJsonField('{"a":1,"b":[2,3]}')
+    expect(pretty).toBe(`{
+  "a": 1,
+  "b": [
+    2,
+    3
+  ]
+}`)
+  })
+
+  it('detects JSON objects and strings', () => {
+    expect(isJsonDisplayable('{"x":1}')).toBe(true)
+    expect(isJsonDisplayable({ x: 1 })).toBe(true)
+    expect(isJsonDisplayable('plain text')).toBe(false)
+  })
+
+  it('emits syntax-highlight markup with stable CSS classes', () => {
+    const html = highlightJSON('{"level":"INFO","count":3,"ok":true,"x":null}')
+    expect(html).toContain('json-hl-key')
+    expect(html).toContain('json-hl-str')
+    expect(html).toContain('json-hl-num')
+    expect(html).toContain('json-hl-bool')
+    expect(html).toContain('json-hl-null')
+  })
+})

--- a/src/ui/src/lib/jsonDisplay.ts
+++ b/src/ui/src/lib/jsonDisplay.ts
@@ -1,0 +1,127 @@
+/** Fields that often carry JSON as a VARCHAR string (Kamailio hlog, OTLP, etc.). */
+export const JSON_EMBEDDED_FIELD_NAMES = new Set([
+  'payload',
+  'message',
+  'data',
+  'data_extra',
+  'body',
+  'raw',
+  'attributes',
+  'resource_attrs',
+  'span_attrs',
+  'body_json',
+])
+
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+export function looksLikeJsonString(str: string): boolean {
+  const t = str.trim()
+  return (t.startsWith('{') && t.endsWith('}')) || (t.startsWith('[') && t.endsWith(']'))
+}
+
+/** Parse a JSON string; return the original value when it is not JSON text. */
+export function parseJsonLoose(val: unknown): unknown {
+  if (val == null) return val
+  if (typeof val === 'object') return val
+  if (typeof val !== 'string') return val
+  const t = val.trim()
+  if (!looksLikeJsonString(t)) return val
+  try {
+    return JSON.parse(t)
+  } catch {
+    return val
+  }
+}
+
+export function isJsonDisplayable(val: unknown): boolean {
+  if (val == null || val === '') return false
+  if (typeof val === 'object') return true
+  if (typeof val === 'string') return looksLikeJsonString(val)
+  return false
+}
+
+export function payloadAsString(val: unknown): string {
+  if (val == null || val === '') return ''
+  if (typeof val === 'string') return val
+  if (typeof val === 'object') {
+    try {
+      return JSON.stringify(val)
+    } catch {
+      return String(val)
+    }
+  }
+  return String(val)
+}
+
+/** Pretty-print a single field that may be JSON text or an object. */
+export function formatJsonField(val: unknown): string {
+  if (val == null) return '—'
+  const parsed = parseJsonLoose(val)
+  if (parsed !== val || typeof parsed === 'object') {
+    try {
+      return JSON.stringify(parsed, null, 2)
+    } catch {
+      return String(val)
+    }
+  }
+  return String(val)
+}
+
+export function expandEmbeddedJsonReplacer(key: string, value: unknown): unknown {
+  if (typeof value === 'bigint') return value.toString()
+  if (typeof value === 'string' && JSON_EMBEDDED_FIELD_NAMES.has(key)) {
+    const parsed = parseJsonLoose(value)
+    if (parsed !== value) return parsed
+  }
+  return value
+}
+
+/** Serialize a search/API row for display, expanding nested JSON string fields. */
+export function serializeRowForDisplay(row: Record<string, unknown>): string {
+  try {
+    return JSON.stringify(row, expandEmbeddedJsonReplacer, 2)
+  } catch (e) {
+    const err = e as { message?: string }
+    return `Error serializing row: ${err?.message || e}`
+  }
+}
+
+export function highlightJSON(payload: unknown): string {
+  try {
+    const obj = parseJsonLoose(payload)
+    const formatted = JSON.stringify(obj, null, 2)
+    let html = escapeHtml(formatted)
+    // Value highlighting before keys — the key pass wraps colons and breaks later ": …" patterns.
+    html = html.replace(
+      /: &quot;([^&]*)&quot;/g,
+      ': <span class="json-hl-str">&quot;$1&quot;</span>',
+    )
+    html = html.replace(/: (-?\d+\.?\d*)/g, ': <span class="json-hl-num">$1</span>')
+    html = html.replace(/: (true|false)/g, ': <span class="json-hl-bool">$1</span>')
+    html = html.replace(/: (null)/g, ': <span class="json-hl-null">$1</span>')
+    html = html.replace(
+      /&quot;([^&]+)&quot;(\s*:)/g,
+      '<span class="json-hl-key">&quot;$1&quot;</span><span class="json-hl-punct">$2</span>',
+    )
+    html = html.replace(/([{}\[\],])/g, '<span class="json-hl-punct">$1</span>')
+    return html
+  } catch {
+    return escapeHtml(payloadAsString(payload))
+  }
+}
+
+/** First non-empty payload-like field on a LOG / event row. */
+export function eventPayloadField(row: Record<string, unknown> | null | undefined): unknown {
+  if (!row || typeof row !== 'object') return ''
+  for (const k of ['payload', 'message', 'data', 'body']) {
+    const v = row[k]
+    if (v != null && v !== '') return v
+  }
+  return ''
+}

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.243"
+	VERSION_APPLICATION = "11.0.244"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
LOG/hlog payloads are stored as JSON strings inside VARCHAR columns. The Events detail view now expands nested JSON (payload, data_extra) and shows Pretty/Raw tabs with colored syntax highlighting via stable CSS classes (json-hl-*) that work in dangerouslySetInnerHTML without relying on Tailwind content scan. MessageModal and OTLP log modals share the same jsonDisplay helpers.