### PR TITLE
fix(ducklake): enable disk spilling so long-range searches don't OOM (11.0.250)

### DIFF
--- a/src/node/node.go
+++ b/src/node/node.go
@@ -1107,13 +1107,21 @@ func configureDuckLake(db *sql.DB, cfg *config.NodeConfig) ([]VolumeInfo, error)
 	if strings.TrimSpace(nodeMemLimit) == "" {
 		nodeMemLimit = "2GB"
 	}
+	// Same rationale as the writer: the node DB is in-memory, and in-memory
+	// DuckDB cannot spill to disk without an explicit temp_directory —
+	// long-range searches then die with Out of Memory at memory_limit.
+	nodeTempDir := cfg.DuckLake.Tuning.TempDirectory
+	if strings.TrimSpace(nodeTempDir) == "" {
+		nodeTempDir = ducklake.DefaultSpillDirectory(cfg.DuckLake.CatalogPath)
+	}
 	ducklake.ApplyDuckDBTuning(
 		db,
 		nodeThreads,
 		nodeMemLimit,
-		cfg.DuckLake.Tuning.TempDirectory,
+		nodeTempDir,
 		"node",
 	)
+	ducklake.ApplyDuckDBMemorySafety(db, "node")
 
 	// Install and load DuckLake extension
 	_, err := db.Exec("INSTALL ducklake; LOAD ducklake;")

--- a/src/storage/ducklake/ducklake.go
+++ b/src/storage/ducklake/ducklake.go
@@ -354,7 +354,20 @@ func (mtw *MultiTableWriter) connect() error {
 		logger.Info("DuckDB writer: auto-limiting memory (operator did not set tuning.memory_limit)",
 			"memory_limit", memLimit)
 	}
-	ApplyDuckDBTuning(db, threads, memLimit, mtw.config.TuningTempDirectory, "writer")
+	// In-memory DuckDB has disk spilling DISABLED unless temp_directory is
+	// set. With the writer pool, search + flush + compaction run concurrently
+	// against the same memory_limit, so without a spill path long-range
+	// searches abort with Out of Memory instead of spilling to disk.
+	tempDir := mtw.config.TuningTempDirectory
+	if strings.TrimSpace(tempDir) == "" {
+		tempDir = DefaultSpillDirectory(mtw.config.CatalogPath)
+		if tempDir != "" {
+			logger.Info("DuckDB writer: defaulting spill directory (operator did not set tuning.temp_directory)",
+				"temp_directory", tempDir)
+		}
+	}
+	ApplyDuckDBTuning(db, threads, memLimit, tempDir, "writer")
+	ApplyDuckDBMemorySafety(db, "writer")
 
 	// Load DuckLake extension (must be pre-installed via --install-extensions)
 	if _, err := db.Exec("LOAD ducklake;"); err != nil {

--- a/src/storage/ducklake/tuning.go
+++ b/src/storage/ducklake/tuning.go
@@ -10,6 +10,8 @@ package ducklake
 import (
 	"database/sql"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	logger "github.com/sipcapture/homer-core/src/utils/logging"
@@ -181,5 +183,53 @@ func ApplyDuckDBTuning(db *sql.DB, threads int, memoryLimit, tempDirectory, who 
 		} else {
 			logger.Info("DuckDB tuning: temp_directory set", "where", who, "temp_directory", s)
 		}
+	}
+}
+
+// DefaultSpillDirectory returns the spill path to use when the operator did
+// not set tuning.temp_directory: "<dir of catalogPath>/.duckdb_spill".
+//
+// This matters because the writer (and the node when it shares the writer DB)
+// runs DuckDB as an IN-MEMORY instance, and in-memory DuckDB disables disk
+// spilling entirely unless temp_directory is set explicitly. Without it any
+// query whose working set exceeds memory_limit fails with Out of Memory
+// instead of spilling — e.g. long-range LIKE searches over wide SIP tables.
+// The catalog directory is used (not os.TempDir) because /tmp is commonly a
+// RAM-backed tmpfs in containers, which would defeat the purpose.
+//
+// The directory is created eagerly; on failure an empty string is returned
+// and the caller should leave temp_directory untouched.
+func DefaultSpillDirectory(catalogPath string) string {
+	dir := strings.TrimSpace(filepath.Dir(strings.TrimSpace(catalogPath)))
+	if dir == "" || dir == "." {
+		return ""
+	}
+	spill := filepath.Join(dir, ".duckdb_spill")
+	if err := os.MkdirAll(spill, 0o755); err != nil {
+		logger.Warn("DuckDB tuning: cannot create default spill directory, disk spilling stays disabled",
+			"path", spill, "error", err)
+		return ""
+	}
+	return spill
+}
+
+// ApplyDuckDBMemorySafety applies instance-global settings that keep
+// memory-heavy queries from taking down the shared writer DuckDB:
+//
+//   - preserve_insertion_order = false: lets DuckDB stream large scans and
+//     UNION ALL results instead of buffering them to keep row order. Safe
+//     here because search queries always ORDER BY explicitly and HEP ingest
+//     order within a flush batch is irrelevant (timestamp column rules).
+//
+// Call once per DuckDB instance after ApplyDuckDBTuning. Errors are logged
+// and swallowed, same contract as ApplyDuckDBTuning.
+func ApplyDuckDBMemorySafety(db *sql.DB, who string) {
+	if db == nil {
+		return
+	}
+	if _, err := db.Exec("SET preserve_insertion_order = false"); err != nil {
+		logger.Warn(fmt.Sprintf("DuckDB tuning (%s): SET preserve_insertion_order = false failed: %v", who, err))
+	} else {
+		logger.Info("DuckDB tuning: preserve_insertion_order disabled", "where", who)
 	}
 }

--- a/src/storage/ducklake/tuning_test.go
+++ b/src/storage/ducklake/tuning_test.go
@@ -9,6 +9,7 @@ package ducklake
 
 import (
 	"database/sql"
+	"os"
 	"strings"
 	"testing"
 
@@ -83,6 +84,45 @@ func TestApplyDuckDBTuning_NilDB(t *testing.T) {
 		}
 	}()
 	ApplyDuckDBTuning(nil, 4, "1GB", "/tmp", "test")
+}
+
+// TestDefaultSpillDirectory verifies the spill dir is derived from the
+// catalog location and created on disk, and that degenerate catalog paths
+// yield "" (leave temp_directory untouched).
+func TestDefaultSpillDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	got := DefaultSpillDirectory(tmp + "/homer_catalog.sqlite")
+	want := tmp + "/.duckdb_spill"
+	if got != want {
+		t.Fatalf("DefaultSpillDirectory = %q, want %q", got, want)
+	}
+	if st, err := os.Stat(got); err != nil || !st.IsDir() {
+		t.Fatalf("spill directory not created: %v", err)
+	}
+
+	if got := DefaultSpillDirectory("homer_catalog.sqlite"); got != "" {
+		t.Fatalf("bare filename: got %q, want empty", got)
+	}
+	if got := DefaultSpillDirectory(""); got != "" {
+		t.Fatalf("empty path: got %q, want empty", got)
+	}
+}
+
+// TestApplyDuckDBMemorySafety asserts preserve_insertion_order is switched
+// off on the instance and that a nil DB is a no-op.
+func TestApplyDuckDBMemorySafety(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer db.Close()
+
+	ApplyDuckDBMemorySafety(db, "test")
+	if got := getSetting(t, db, "preserve_insertion_order"); got != "false" {
+		t.Fatalf("preserve_insertion_order = %q, want %q", got, "false")
+	}
+
+	ApplyDuckDBMemorySafety(nil, "test") // must not panic
 }
 
 func TestEnsureWriterS3Secret_MinIOStyle(t *testing.T) {

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.249"
+	VERSION_APPLICATION = "11.0.250"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary

Long-range searches (e.g. call_id over 14 days) fail with DuckDB `Out of Memory Error ... (1.7 GiB/1.8 GiB used)` since the writer connection pool (#785 fix, `4766d08`): search, flush and compaction now run **concurrently** on one in-memory DuckDB instance sharing the 2GB `memory_limit`.

Root cause: **in-memory DuckDB has disk spilling disabled** unless `temp_directory` is set explicitly. When the working set hits `memory_limit`, queries abort instead of spilling.

## Fix

- Default `temp_directory` to `<catalog dir>/.duckdb_spill` when `tuning.temp_directory` is empty (writer **and** node). Catalog dir, not `/tmp`, because `/tmp` is often RAM-backed tmpfs in containers.
- `SET preserve_insertion_order = false` on writer/node instances — one of DuckDB's own OOM remediations; safe because searches always `ORDER BY` explicitly and HEP batch order is irrelevant.
- `VERSION_APPLICATION` → `11.0.250`.

Operators can still override via `tuning.temp_directory` / `tuning.memory_limit`.

## Test plan

- [x] `go test ./storage/ducklake/ -run 'Tuning|Spill|MemorySafety'` — PASS
- [x] `go build ./...`, `go vet` — clean
- [ ] Repro: call_id search over 14 days on a ~2GB-limited container → returns instead of OOM (spills to `.duckdb_spill`)