### PR TITLE
fix(compaction): bound merge batch and log memory breakdown on OOM (11.0.251)

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -698,7 +698,9 @@ type CompactionConfig struct {
 	MinFileSizeBytes int64 `json:"min_file_size_bytes" mapstructure:"min_file_size_bytes" default:"0"`
 	// MaxFileSizeBytes: maximum size of merged file. 0 = no limit (DuckLake default).
 	MaxFileSizeBytes int64 `json:"max_file_size_bytes" mapstructure:"max_file_size_bytes" default:"0"`
-	// MaxCompactedFiles: maximum number of files to merge per table per cycle. 0 = no limit.
+	// MaxCompactedFiles: maximum number of files to merge per table per cycle.
+	// 0 = writer default (100). Bounding the merge batch keeps the compaction
+	// working set within memory_limit on memory-capped writers.
 	MaxCompactedFiles int `json:"max_compacted_files" mapstructure:"max_compacted_files" default:"0"`
 }
 

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.250"
+	VERSION_APPLICATION = "11.0.251"
 
 	// BuildDate is the build date
 	BuildDate = ""

--- a/src/writer/compaction.go
+++ b/src/writer/compaction.go
@@ -528,6 +528,9 @@ func (c *CompactionService) runMerge(tables []string) error {
 			}
 			if err != nil {
 				logger.Warn("CompactionService: merge_adjacent_files failed", "table", tableName, "error", err)
+				if strings.Contains(err.Error(), "Out of Memory") {
+					c.logMemoryBreakdown()
+				}
 			} else if result != nil {
 				rowsAffected, _ := result.RowsAffected()
 				logger.Info("CompactionService: merge_adjacent_files completed", "table", tableName, "files_merged", rowsAffected)
@@ -664,6 +667,43 @@ func (c *CompactionService) buildMergeSQL(tableName string) string {
 		tableName,
 		strings.Join(params, ", "),
 	)
+}
+
+// logMemoryBreakdown dumps DuckDB's buffer-manager accounting after an
+// Out of Memory failure so operators can see WHO holds the memory_limit
+// budget (in-memory buffer tables, hash joins, parquet readers, ...) and
+// whether temp spilling is actually engaged (temporary_storage_bytes > 0
+// proves temp_directory is set and used; all-zero means spilling is off,
+// i.e. the instance runs without a temp_directory).
+func (c *CompactionService) logMemoryBreakdown() {
+	rows, err := c.db.Query(`
+		SELECT tag,
+		       memory_usage_bytes,
+		       temporary_storage_bytes
+		FROM duckdb_memory()
+		ORDER BY memory_usage_bytes DESC`)
+	if err != nil {
+		logger.Warn("CompactionService: duckdb_memory() failed", "error", err)
+		return
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var tag string
+		var memBytes, tempBytes int64
+		if err := rows.Scan(&tag, &memBytes, &tempBytes); err != nil {
+			continue
+		}
+		if memBytes == 0 && tempBytes == 0 {
+			continue
+		}
+		logger.Warn("CompactionService: duckdb memory breakdown",
+			"tag", tag,
+			"memory_mb", memBytes/(1<<20),
+			"spilled_to_disk_mb", tempBytes/(1<<20))
+	}
+	if err := rows.Err(); err != nil {
+		logger.Warn("CompactionService: duckdb_memory() iteration failed", "error", err)
+	}
 }
 
 func (c *CompactionService) execWithRetry(query string, args ...any) (sql.Result, error) {

--- a/src/writer/writer.go
+++ b/src/writer/writer.go
@@ -341,6 +341,14 @@ func (w *Writer) Start() error {
 		if compactionCfg.MinAgeSec <= 0 {
 			compactionCfg.MinAgeSec = 3600 // default 1 hour
 		}
+		if compactionCfg.MaxCompactedFiles <= 0 {
+			// Unbounded merge rewrites every small parquet of a table in one
+			// CALL; on a memory-capped writer that working set alone can hit
+			// memory_limit and abort with Out of Memory while search/flush
+			// run on the same instance. Capping keeps each cycle's peak
+			// bounded — leftovers are picked up by the next cycle.
+			compactionCfg.MaxCompactedFiles = 100
+		}
 		var compactionS3 *CompactionS3Client
 		if ducklake.IsRemoteLakeDataPath(w.storageConfig.DuckLake.DataPath) {
 			s := w.storageConfig.DuckLake.S3


### PR DESCRIPTION
## Summary

Follow-up to #798: `CompactionService: merge_adjacent_files` still OOMs on a 2GB-capped writer (`could not allocate block of size 256.0 KiB (1.8 GiB/1.8 GiB used)`).

Unbounded `ducklake_merge_adjacent_files` rewrites **every** small parquet of a table in one CALL; that working set alone can exhaust `memory_limit` while search and flush share the same DuckDB instance.

## Changes

- **Default `max_compacted_files = 100`** when `compaction.max_compacted_files` is 0/unset — bounds each merge cycle's peak memory; leftovers are picked up next cycle. Explicit operator values still win.
- **OOM diagnostics:** on Out of Memory during merge, dump `duckdb_memory()` (tag, memory_mb, spilled_to_disk_mb). `spilled_to_disk_mb > 0` proves the #798 spill directory is engaged; all-zero spill on a build with #798 means `temp_directory` didn't apply — please paste this output if the warning persists.
- `VERSION_APPLICATION` → `11.0.251`

## Test plan

- [x] `go build ./...`, `go vet`, `go test ./writer/` — pass
- [ ] Deploy, wait for a compaction cycle: `merge_adjacent_files completed` instead of OOM
- [ ] If OOM persists, the new `duckdb memory breakdown` WRN lines identify the holder