### PR TITLE
fix(node): split lake/mem execution for >1h searches

### DIFF
--- a/src/node/node.go
+++ b/src/node/node.go
@@ -704,8 +704,8 @@ func (n *Node) handleQuery(w http.ResponseWriter, r *http.Request) {
 
 	// Rewrite query for tiered storage (UNION ALL across volumes).
 	rewrittenSQL := n.rewriteQueryForVolumes(req.SQL)
-	logger.Info("Node: handleQuery", "sql_chars", len(req.SQL), "sql", req.SQL)
-	logger.Debug("Node: handleQuery", "original", req.SQL, "rewritten", rewrittenSQL)
+	logger.Info("Node: handleQuery", "sql_chars", len(req.SQL))
+	logger.Debug("Node: handleQuery SQL", "sql", req.SQL, "rewritten", rewrittenSQL)
 
 	db := n.queryDB()
 
@@ -731,8 +731,8 @@ func (n *Node) handleQuery(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sharedResults, sharedCols, sharedPlan, err := n.runSharedSelectWithMemoryPolicy(r.Context(), db, rewrittenSQL)
-	logger.Info("Node: handleQuery execution plan",
-		"mode", sharedPlan.mode,
+	logger.Info("Node: handleQuery execution plan", "mode", sharedPlan.mode)
+	logger.Debug("Node: handleQuery execution plan SQL",
 		"lake_sql", sharedPlan.lakeSQL,
 		"mem_sql", sharedPlan.memSQL,
 		"combined_sql", sharedPlan.combinedSQL,

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -488,6 +488,13 @@ type memoryUnionQueries struct {
 	ok          bool
 }
 
+type sharedQueryPlanLog struct {
+	mode        string
+	lakeSQL     string
+	memSQL      string
+	combinedSQL string
+}
+
 func normalizeSQLWhitespace(s string) string {
 	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(s))), " ")
 }
@@ -602,28 +609,41 @@ func shouldSplitLakeAndMem(sql, baseSQL, orderByClause, limitClause string) bool
 	return ok && rangeMs > memorySplitThresholdMs
 }
 
-func (n *Node) runSharedSelectWithMemoryPolicy(ctx context.Context, db *sql.DB, sql string) ([]map[string]interface{}, []string, string, error) {
+func (n *Node) runSharedSelectWithMemoryPolicy(ctx context.Context, db *sql.DB, sql string) ([]map[string]interface{}, []string, sharedQueryPlanLog, error) {
+	plan := sharedQueryPlanLog{
+		mode:        "no_mem_union",
+		lakeSQL:     sql,
+		combinedSQL: sql,
+	}
 	mq := n.buildMemoryUnionQueries(sql)
 	if !mq.ok {
 		data, cols, err := runSelectQuery(ctx, db, sql)
-		return data, cols, sql, err
+		return data, cols, plan, err
 	}
 	orderByClause, limitClause, baseSQL := extractOrderLimit(sql)
 	if shouldSplitLakeAndMem(sql, baseSQL, orderByClause, limitClause) {
+		plan.mode = "split_lake_and_mem"
+		plan.lakeSQL = mq.lakeSQL
+		plan.memSQL = mq.memSQL
+		plan.combinedSQL = ""
 		lakeData, lakeCols, err := runSelectQuery(ctx, db, mq.lakeSQL)
 		if err != nil {
-			return nil, nil, "", fmt.Errorf("lake query: %w", err)
+			return nil, nil, plan, fmt.Errorf("lake query: %w", err)
 		}
 		memData, memCols, err := runSelectQuery(ctx, db, mq.memSQL)
 		if err != nil {
-			return nil, nil, "", fmt.Errorf("memory query: %w", err)
+			return nil, nil, plan, fmt.Errorf("memory query: %w", err)
 		}
 		limit := extractSQLLimit(sql)
 		merged, cols := mergeSelectResults(lakeData, memData, lakeCols, memCols, limit)
-		return merged, cols, "split(lake+mem)", nil
+		return merged, cols, plan, nil
 	}
+	plan.mode = "single_union"
+	plan.lakeSQL = mq.lakeSQL
+	plan.memSQL = mq.memSQL
+	plan.combinedSQL = mq.combinedSQL
 	data, cols, err := runSelectQuery(ctx, db, mq.combinedSQL)
-	return data, cols, mq.combinedSQL, err
+	return data, cols, plan, err
 }
 
 func (n *Node) querySelectMerged(ctx context.Context, sharedSQL string, sharedDB *sql.DB, tieredSQL string, tieredDB *sql.DB, originalSQL string) ([]map[string]interface{}, []string, error) {
@@ -684,7 +704,7 @@ func (n *Node) handleQuery(w http.ResponseWriter, r *http.Request) {
 
 	// Rewrite query for tiered storage (UNION ALL across volumes).
 	rewrittenSQL := n.rewriteQueryForVolumes(req.SQL)
-	logger.Info("Node: handleQuery", "sql_chars", len(req.SQL))
+	logger.Info("Node: handleQuery", "sql_chars", len(req.SQL), "sql", req.SQL)
 	logger.Debug("Node: handleQuery", "original", req.SQL, "rewritten", rewrittenSQL)
 
 	db := n.queryDB()
@@ -710,9 +730,21 @@ func (n *Node) handleQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sharedResults, sharedCols, sharedSQLInfo, err := n.runSharedSelectWithMemoryPolicy(r.Context(), db, rewrittenSQL)
+	sharedResults, sharedCols, sharedPlan, err := n.runSharedSelectWithMemoryPolicy(r.Context(), db, rewrittenSQL)
+	logger.Info("Node: handleQuery execution plan",
+		"mode", sharedPlan.mode,
+		"lake_sql", sharedPlan.lakeSQL,
+		"mem_sql", sharedPlan.memSQL,
+		"combined_sql", sharedPlan.combinedSQL,
+	)
 	if err != nil {
-		logger.Error("Node: Query failed", "sql", req.SQL, "rewritten", sharedSQLInfo, "error", err)
+		logger.Error("Node: Query failed",
+			"sql", req.SQL,
+			"mode", sharedPlan.mode,
+			"lake_sql", sharedPlan.lakeSQL,
+			"mem_sql", sharedPlan.memSQL,
+			"combined_sql", sharedPlan.combinedSQL,
+			"error", err)
 		writeJSON(w, http.StatusOK, QueryResponse{
 			Success: false,
 			Error:   err.Error(),

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -340,6 +340,15 @@ func addStorageColumnsToQuery(sql, lakeName, volumeName string) string {
 }
 
 var sqlLimitRegexp = regexp.MustCompile(`(?is)\s+LIMIT\s+(\d+)\s*$`)
+var (
+	sqlTimestampFromRegexp = regexp.MustCompile(`(?is)\btimestamp\s*>=\s*\(to_timestamp\((\d+)\s*/\s*1000(?:\.0)?\)\s*AT\s+TIME\s+ZONE\s+'UTC'\)`)
+	sqlTimestampToRegexp   = regexp.MustCompile(`(?is)\btimestamp\s*(?:<=|<)\s*\(to_timestamp\((\d+)\s*/\s*1000(?:\.0)?\)\s*AT\s+TIME\s+ZONE\s+'UTC'\)`)
+	sqlGroupByRegexp       = regexp.MustCompile(`(?is)\bGROUP\s+BY\b`)
+	sqlDistinctRegexp      = regexp.MustCompile(`(?is)\bSELECT\s+DISTINCT\b`)
+	sqlAggregateRegexp     = regexp.MustCompile(`(?is)\b(COUNT|SUM|AVG|MIN|MAX)\s*\(`)
+)
+
+const memorySplitThresholdMs = int64(time.Hour / time.Millisecond)
 
 func extractSQLLimit(sql string) int {
 	m := sqlLimitRegexp.FindStringSubmatch(sql)
@@ -463,6 +472,160 @@ func mergeSelectResults(a, b []map[string]interface{}, colsA, colsB []string, li
 	return merged, cols
 }
 
+func runSelectQuery(ctx context.Context, db *sql.DB, query string) ([]map[string]interface{}, []string, error) {
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer rows.Close()
+	return scanAllSQLRows(rows)
+}
+
+type memoryUnionQueries struct {
+	lakeSQL     string
+	memSQL      string
+	combinedSQL string
+	ok          bool
+}
+
+func normalizeSQLWhitespace(s string) string {
+	return strings.Join(strings.Fields(strings.ToLower(strings.TrimSpace(s))), " ")
+}
+
+func memorySplitRangeMs(sql string) (int64, bool) {
+	fromM := sqlTimestampFromRegexp.FindStringSubmatch(sql)
+	toM := sqlTimestampToRegexp.FindStringSubmatch(sql)
+	if len(fromM) < 2 || len(toM) < 2 {
+		return 0, false
+	}
+	fromMs, err := strconv.ParseInt(fromM[1], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	toMs, err := strconv.ParseInt(toM[1], 10, 64)
+	if err != nil || toMs <= fromMs {
+		return 0, false
+	}
+	return toMs - fromMs, true
+}
+
+func sqlSplitSafeForTimestampTopN(sql, baseSQL, orderByClause, limitClause string) bool {
+	if strings.TrimSpace(limitClause) == "" {
+		return false
+	}
+	if normalizeSQLWhitespace(orderByClause) != "order by timestamp desc" {
+		return false
+	}
+	upper := strings.ToUpper(baseSQL)
+	if sqlGroupByRegexp.MatchString(upper) || sqlDistinctRegexp.MatchString(upper) || sqlAggregateRegexp.MatchString(upper) {
+		return false
+	}
+	selectIdx := strings.Index(upper, "SELECT")
+	fromIdx := strings.Index(upper, "FROM")
+	if selectIdx == -1 || fromIdx == -1 || fromIdx <= selectIdx+len("SELECT") {
+		return false
+	}
+	selectList := strings.TrimSpace(baseSQL[selectIdx+len("SELECT") : fromIdx])
+	return strings.HasPrefix(selectList, "*")
+}
+
+func (n *Node) buildMemoryUnionQueries(sql string) memoryUnionQueries {
+	out := memoryUnionQueries{lakeSQL: sql}
+	if n.sharedDB == nil {
+		return out
+	}
+	upper := strings.ToUpper(sql)
+	if !strings.HasPrefix(strings.TrimSpace(upper), "SELECT") {
+		return out
+	}
+
+	marker := ".main.hep_proto_"
+	markerIdx := strings.Index(sql, marker)
+	if markerIdx == -1 {
+		return out
+	}
+
+	lakeStart := markerIdx
+	for lakeStart > 0 {
+		ch := sql[lakeStart-1]
+		if ch == ' ' || ch == '\t' || ch == '\n' || ch == '(' || ch == ',' {
+			break
+		}
+		lakeStart--
+	}
+	lakeName := sql[lakeStart:markerIdx]
+	suffixStart := markerIdx + len(marker)
+	suffixEnd := suffixStart
+	for suffixEnd < len(sql) {
+		ch := sql[suffixEnd]
+		if ch == ' ' || ch == '\t' || ch == '\n' || ch == ',' || ch == ')' || ch == ';' {
+			break
+		}
+		suffixEnd++
+	}
+	tableSuffix := sql[suffixStart:suffixEnd]
+	memTableA := "mem_hep_proto_" + tableSuffix + "_a"
+	memTableB := "mem_hep_proto_" + tableSuffix + "_b"
+	lakeTableFQN := sql[lakeStart:suffixEnd]
+
+	orderByClause, limitClause, baseSQL := extractOrderLimit(sql)
+	memSQLA := strings.Replace(baseSQL, lakeTableFQN, memTableA, 1)
+	memSQLB := strings.Replace(baseSQL, lakeTableFQN, memTableB, 1)
+	for _, memSQL := range []*string{&memSQLA, &memSQLB} {
+		*memSQL = strings.Replace(*memSQL, "'"+lakeName+"' AS storage_lake", "'memory' AS storage_lake", 1)
+		for _, vol := range n.volumes {
+			*memSQL = strings.Replace(*memSQL, "'"+vol.Name+"' AS storage_volume", "'buffer' AS storage_volume", 1)
+		}
+	}
+
+	memUnion := "SELECT * FROM (" + memSQLA + " UNION ALL " + memSQLB + ") _m"
+	combined := "SELECT * FROM (" + baseSQL + " UNION ALL " + memSQLA + " UNION ALL " + memSQLB + ") _u"
+	if orderByClause != "" {
+		memUnion += " " + orderByClause
+		combined += " " + orderByClause
+	}
+	if limitClause != "" {
+		memUnion += " " + limitClause
+		combined += " " + limitClause
+	}
+	out.memSQL = memUnion
+	out.combinedSQL = combined
+	out.ok = true
+	return out
+}
+
+func shouldSplitLakeAndMem(sql, baseSQL, orderByClause, limitClause string) bool {
+	if !sqlSplitSafeForTimestampTopN(sql, baseSQL, orderByClause, limitClause) {
+		return false
+	}
+	rangeMs, ok := memorySplitRangeMs(sql)
+	return ok && rangeMs > memorySplitThresholdMs
+}
+
+func (n *Node) runSharedSelectWithMemoryPolicy(ctx context.Context, db *sql.DB, sql string) ([]map[string]interface{}, []string, string, error) {
+	mq := n.buildMemoryUnionQueries(sql)
+	if !mq.ok {
+		data, cols, err := runSelectQuery(ctx, db, sql)
+		return data, cols, sql, err
+	}
+	orderByClause, limitClause, baseSQL := extractOrderLimit(sql)
+	if shouldSplitLakeAndMem(sql, baseSQL, orderByClause, limitClause) {
+		lakeData, lakeCols, err := runSelectQuery(ctx, db, mq.lakeSQL)
+		if err != nil {
+			return nil, nil, "", fmt.Errorf("lake query: %w", err)
+		}
+		memData, memCols, err := runSelectQuery(ctx, db, mq.memSQL)
+		if err != nil {
+			return nil, nil, "", fmt.Errorf("memory query: %w", err)
+		}
+		limit := extractSQLLimit(sql)
+		merged, cols := mergeSelectResults(lakeData, memData, lakeCols, memCols, limit)
+		return merged, cols, "split(lake+mem)", nil
+	}
+	data, cols, err := runSelectQuery(ctx, db, mq.combinedSQL)
+	return data, cols, mq.combinedSQL, err
+}
+
 func (n *Node) querySelectMerged(ctx context.Context, sharedSQL string, sharedDB *sql.DB, tieredSQL string, tieredDB *sql.DB, originalSQL string) ([]map[string]interface{}, []string, error) {
 	rows1, err := sharedDB.QueryContext(ctx, sharedSQL)
 	if err != nil {
@@ -519,10 +682,8 @@ func (n *Node) handleQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Rewrite query for tiered storage (UNION ALL across volumes)
+	// Rewrite query for tiered storage (UNION ALL across volumes).
 	rewrittenSQL := n.rewriteQueryForVolumes(req.SQL)
-	// Include unflushed in-memory buffer for real-time results
-	rewrittenSQL = n.addMemoryUnion(rewrittenSQL)
 	logger.Info("Node: handleQuery", "sql_chars", len(req.SQL))
 	logger.Debug("Node: handleQuery", "original", req.SQL, "rewritten", rewrittenSQL)
 
@@ -549,66 +710,34 @@ func (n *Node) handleQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	sharedResults, sharedCols, sharedSQLInfo, err := n.runSharedSelectWithMemoryPolicy(r.Context(), db, rewrittenSQL)
+	if err != nil {
+		logger.Error("Node: Query failed", "sql", req.SQL, "rewritten", sharedSQLInfo, "error", err)
+		writeJSON(w, http.StatusOK, QueryResponse{
+			Success: false,
+			Error:   err.Error(),
+		})
+		return
+	}
+
+	results := sharedResults
+	columns := sharedCols
 	tieredUnion, tieredOk := n.tryBuildVolumeUnionSQL(req.SQL)
 	tieredDB := n.tieredQueryDBForRead()
 	if tieredOk && tieredDB != nil && n.sharedDB != nil {
-		merged, columns, err := n.querySelectMerged(r.Context(), rewrittenSQL, db, tieredUnion, tieredDB, req.SQL)
-		if err == nil {
-			logger.Info("Node: handleQuery: returning merged results", "rows", len(merged), "columns", fmt.Sprintf("%v", columns))
+		tieredResults, tieredCols, terr := runSelectQuery(r.Context(), tieredDB, tieredUnion)
+		if terr == nil {
+			limit := extractSQLLimit(req.SQL)
+			results, columns = mergeSelectResults(results, tieredResults, columns, tieredCols, limit)
+			logger.Info("Node: handleQuery: returning merged results", "rows", len(results), "columns", fmt.Sprintf("%v", columns))
 			writeJSON(w, http.StatusOK, QueryResponse{
 				Success: true,
-				Data:    merged,
-				Count:   len(merged),
+				Data:    results,
+				Count:   len(results),
 			})
 			return
 		}
-		logger.Warn("Node: merged writer+tiered query failed, falling back to writer-only", "error", err)
-	}
-
-	rows, err := db.QueryContext(r.Context(), rewrittenSQL)
-	if err != nil {
-		logger.Error("Node: Query failed", "sql", req.SQL, "rewritten", rewrittenSQL, "error", err)
-		writeJSON(w, http.StatusOK, QueryResponse{
-			Success: false,
-			Error:   err.Error(),
-		})
-		return
-	}
-	defer rows.Close()
-
-	columns, err := rows.Columns()
-	if err != nil {
-		writeJSON(w, http.StatusOK, QueryResponse{
-			Success: false,
-			Error:   err.Error(),
-		})
-		return
-	}
-
-	var results []map[string]interface{}
-	for rows.Next() {
-		values := make([]interface{}, len(columns))
-		valuePtrs := make([]interface{}, len(columns))
-		for i := range values {
-			valuePtrs[i] = &values[i]
-		}
-
-		if err := rows.Scan(valuePtrs...); err != nil {
-			continue
-		}
-
-		row := make(map[string]interface{})
-		for i, col := range columns {
-			row[col] = values[i]
-		}
-		results = append(results, row)
-	}
-	if err := rows.Err(); err != nil {
-		writeJSON(w, http.StatusOK, QueryResponse{
-			Success: false,
-			Error:   err.Error(),
-		})
-		return
+		logger.Warn("Node: merged writer+tiered query failed, falling back to writer-only", "error", terr)
 	}
 
 	logger.Info("Node: handleQuery: returning results", "rows", len(results), "columns", fmt.Sprintf("%v", columns))
@@ -623,7 +752,17 @@ func (n *Node) handleQuery(w http.ResponseWriter, r *http.Request) {
 // prepareFlightSQLDataSQL applies node query rewrites (tiered volumes + memory union) after Grafana/sqlrewrite.
 func (n *Node) prepareFlightSQLDataSQL(q string) string {
 	q = n.rewriteQueryForVolumes(q)
-	return n.addMemoryUnion(q)
+	mq := n.buildMemoryUnionQueries(q)
+	if !mq.ok {
+		return q
+	}
+	orderByClause, limitClause, baseSQL := extractOrderLimit(q)
+	if shouldSplitLakeAndMem(q, baseSQL, orderByClause, limitClause) {
+		// FlightSQL prepares a single SQL statement; for wide ranges avoid
+		// the huge lake+mem UNION and keep a lake-only query.
+		return q
+	}
+	return mq.combinedSQL
 }
 
 // duckLakeCatalogForQuery returns the DuckLake catalog name used in rewritten SQL FROM clauses.
@@ -789,73 +928,11 @@ func (n *Node) tryBuildVolumeUnionSQL(sql string) (string, bool) {
 //
 // ) _u ORDER BY ts DESC LIMIT 50
 func (n *Node) addMemoryUnion(sql string) string {
-	if n.sharedDB == nil {
+	mq := n.buildMemoryUnionQueries(sql)
+	if !mq.ok {
 		return sql
 	}
-
-	upper := strings.ToUpper(sql)
-	if !strings.HasPrefix(strings.TrimSpace(upper), "SELECT") {
-		return sql
-	}
-
-	// Find any DuckLake table reference: *.main.hep_proto_*
-	// This works regardless of which lake name was set by rewriteQueryForVolumes
-	marker := ".main.hep_proto_"
-	markerIdx := strings.Index(sql, marker)
-	if markerIdx == -1 {
-		return sql
-	}
-
-	// Walk backwards to find the start of the lake name (e.g. "homer_lake" or "homer_lake_hot")
-	lakeStart := markerIdx
-	for lakeStart > 0 {
-		ch := sql[lakeStart-1]
-		if ch == ' ' || ch == '\t' || ch == '\n' || ch == '(' || ch == ',' {
-			break
-		}
-		lakeStart--
-	}
-	lakeName := sql[lakeStart:markerIdx] // e.g. "homer_lake" or "homer_lake_hot"
-
-	// Extract table suffix (e.g. "1_call")
-	suffixStart := markerIdx + len(marker)
-	suffixEnd := suffixStart
-	for suffixEnd < len(sql) {
-		ch := sql[suffixEnd]
-		if ch == ' ' || ch == '\t' || ch == '\n' || ch == ',' || ch == ')' || ch == ';' {
-			break
-		}
-		suffixEnd++
-	}
-	tableSuffix := sql[suffixStart:suffixEnd]
-	// DuckLake uses double-buffer: mem_hep_proto_{suffix}_a and mem_hep_proto_{suffix}_b
-	memTableA := "mem_hep_proto_" + tableSuffix + "_a"
-	memTableB := "mem_hep_proto_" + tableSuffix + "_b"
-	lakeTableFQN := sql[lakeStart:suffixEnd] // e.g. "homer_lake.main.hep_proto_1_call"
-
-	// Extract ORDER BY and LIMIT clauses from the end of the query
-	orderByClause, limitClause, baseSQL := extractOrderLimit(sql)
-
-	// Build memory-table queries for both buffers
-	memSQLA := strings.Replace(baseSQL, lakeTableFQN, memTableA, 1)
-	memSQLB := strings.Replace(baseSQL, lakeTableFQN, memTableB, 1)
-	for _, memSQL := range []*string{&memSQLA, &memSQLB} {
-		*memSQL = strings.Replace(*memSQL, "'"+lakeName+"' AS storage_lake", "'memory' AS storage_lake", 1)
-		for _, vol := range n.volumes {
-			*memSQL = strings.Replace(*memSQL, "'"+vol.Name+"' AS storage_volume", "'buffer' AS storage_volume", 1)
-		}
-	}
-
-	// Combine: SELECT * FROM (lake UNION ALL mem_a UNION ALL mem_b) _u ORDER BY ... LIMIT ...
-	combined := "SELECT * FROM (" + baseSQL + " UNION ALL " + memSQLA + " UNION ALL " + memSQLB + ") _u"
-	if orderByClause != "" {
-		combined += " " + orderByClause
-	}
-	if limitClause != "" {
-		combined += " " + limitClause
-	}
-
-	return combined
+	return mq.combinedSQL
 }
 
 // extractOrderLimit splits a SQL query into the base query, ORDER BY clause,

--- a/src/node/rewrite_query_test.go
+++ b/src/node/rewrite_query_test.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"database/sql"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -113,5 +114,75 @@ func TestExtractSQLLimit(t *testing.T) {
 	}
 	if g := extractSQLLimit("SELECT 1"); g != 0 {
 		t.Fatalf("got %d", g)
+	}
+}
+
+func defaultMemoryUnionNode() *Node {
+	return &Node{
+		config: &config.NodeConfig{
+			DuckLake: config.DuckLakeConfig{LakeName: "homer_lake"},
+		},
+		sharedDB: new(sql.DB),
+		volumes: []VolumeInfo{
+			{Name: "default", LakeName: "homer_lake"},
+		},
+	}
+}
+
+func searchSQLWithRange(fromMs, toMs int64) string {
+	return fmt.Sprintf(
+		"SELECT *, 'homer_lake' AS storage_lake, 'default' AS storage_volume FROM homer_lake.main.hep_proto_1_call WHERE timestamp >= (to_timestamp(%d / 1000.0) AT TIME ZONE 'UTC') AND timestamp <= (to_timestamp(%d / 1000.0) AT TIME ZONE 'UTC') ORDER BY timestamp DESC LIMIT 50",
+		fromMs, toMs,
+	)
+}
+
+func TestBuildMemoryUnionQueries(t *testing.T) {
+	n := defaultMemoryUnionNode()
+	sqlIn := searchSQLWithRange(1_700_000_000_000, 1_700_000_300_000)
+	q := n.buildMemoryUnionQueries(sqlIn)
+	if !q.ok {
+		t.Fatal("expected memory union query plan")
+	}
+	if !strings.Contains(q.combinedSQL, "mem_hep_proto_1_call_a") || !strings.Contains(q.combinedSQL, "mem_hep_proto_1_call_b") {
+		t.Fatalf("expected combined SQL to include both memory buffers, got: %s", q.combinedSQL)
+	}
+	if !strings.Contains(q.memSQL, "UNION ALL") {
+		t.Fatalf("expected mem SQL to union both buffers, got: %s", q.memSQL)
+	}
+}
+
+func TestShouldSplitLakeAndMemThresholdAndFallback(t *testing.T) {
+	smallRangeSQL := searchSQLWithRange(1_700_000_000_000, 1_700_003_000_000) // 50 min
+	orderBy, limit, base := extractOrderLimit(smallRangeSQL)
+	if shouldSplitLakeAndMem(smallRangeSQL, base, orderBy, limit) {
+		t.Fatal("did not expect split for <= 1h range")
+	}
+
+	largeRangeSQL := searchSQLWithRange(1_700_000_000_000, 1_700_007_500_000) // > 2h
+	orderBy, limit, base = extractOrderLimit(largeRangeSQL)
+	if !shouldSplitLakeAndMem(largeRangeSQL, base, orderBy, limit) {
+		t.Fatal("expected split for > 1h range")
+	}
+
+	customOrderSQL := strings.Replace(largeRangeSQL, "ORDER BY timestamp DESC", "ORDER BY date DESC", 1)
+	orderBy, limit, base = extractOrderLimit(customOrderSQL)
+	if shouldSplitLakeAndMem(customOrderSQL, base, orderBy, limit) {
+		t.Fatal("expected fallback to legacy single-UNION path for custom ORDER BY")
+	}
+}
+
+func TestPrepareFlightSQLDataSQLUsesThresholdDecision(t *testing.T) {
+	n := defaultMemoryUnionNode()
+
+	smallRangeSQL := searchSQLWithRange(1_700_000_000_000, 1_700_003_000_000)
+	gotSmall := n.prepareFlightSQLDataSQL(smallRangeSQL)
+	if !strings.Contains(gotSmall, "mem_hep_proto_1_call_a") {
+		t.Fatalf("expected mem union for <=1h in FlightSQL rewrite, got: %s", gotSmall)
+	}
+
+	largeRangeSQL := searchSQLWithRange(1_700_000_000_000, 1_700_007_500_000)
+	gotLarge := n.prepareFlightSQLDataSQL(largeRangeSQL)
+	if strings.Contains(gotLarge, "mem_hep_proto_1_call_a") || strings.Contains(gotLarge, "mem_hep_proto_1_call_b") {
+		t.Fatalf("expected no mem union SQL for >1h in FlightSQL rewrite, got: %s", gotLarge)
 	}
 }

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.251"
+	VERSION_APPLICATION = "11.0.252"
 
 	// BuildDate is the build date
 	BuildDate = ""

--- a/src/writer/compaction.go
+++ b/src/writer/compaction.go
@@ -22,6 +22,7 @@ import (
 //	Input Error: Invalid footer length provided for file '/path/to/file.parquet'
 var reBrokenParquet = regexp.MustCompile(
 	`Cannot open file "([^"]+\.parquet)"|Invalid footer.*for file '([^']+\.parquet)'`)
+var reNonIdent = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 
 // catalogPathToAbs converts a DuckLake catalog-relative path to an absolute filesystem path.
 //
@@ -560,6 +561,10 @@ func (c *CompactionService) runMerge(tables []string) error {
 				logger.Warn("CompactionService: merge_adjacent_files failed", "table", tableName, "error", err)
 				if isOutOfMemoryError(err) {
 					c.logMemoryBreakdown()
+					if rerr := c.compactSingleDatePartition(tableName); rerr != nil {
+						logger.Warn("CompactionService: date-partition compaction fallback failed",
+							"table", tableName, "error", rerr)
+					}
 				}
 			} else if result != nil {
 				rowsAffected, _ := result.RowsAffected()
@@ -753,6 +758,93 @@ func (c *CompactionService) oomRetryLimits(initial int) []int {
 
 func isOutOfMemoryError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "Out of Memory")
+}
+
+func (c *CompactionService) compactSingleDatePartition(tableName string) error {
+	datePart, filesInPart, err := c.selectDatePartitionForCompaction(tableName)
+	if err != nil {
+		return err
+	}
+	if datePart == "" {
+		logger.Info("CompactionService: no eligible date partition for fallback compaction", "table", tableName)
+		return nil
+	}
+	logger.Warn("CompactionService: fallback to date-partition compaction",
+		"table", tableName,
+		"date", datePart,
+		"files_in_partition", filesInPart)
+	return c.rewriteDatePartition(tableName, datePart)
+}
+
+func (c *CompactionService) selectDatePartitionForCompaction(tableName string) (string, int64, error) {
+	metadataSchema := fmt.Sprintf("__ducklake_metadata_%s", c.lakeName)
+	query := fmt.Sprintf(`
+		SELECT
+			regexp_extract(f.path, 'date=([0-9]{4}-[0-9]{2}-[0-9]{2})', 1) AS part_date,
+			COUNT(*) AS file_count
+		FROM %s.ducklake_data_file f
+		JOIN %s.ducklake_table t ON t.table_id = f.table_id
+		WHERE t.table_name = ?
+		  AND f.end_snapshot IS NULL
+		  AND regexp_extract(f.path, 'date=([0-9]{4}-[0-9]{2}-[0-9]{2})', 1) <> ''
+		GROUP BY 1
+		HAVING COUNT(*) > 1
+		ORDER BY file_count DESC, part_date ASC
+		LIMIT 1
+	`, metadataSchema, metadataSchema)
+
+	rows, err := c.queryWithRetry(query, tableName)
+	if err != nil {
+		return "", 0, err
+	}
+	defer rows.Close()
+	var partDate string
+	var fileCount int64
+	if rows.Next() {
+		if err := rows.Scan(&partDate, &fileCount); err != nil {
+			return "", 0, err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return "", 0, err
+	}
+	return partDate, fileCount, nil
+}
+
+func compactTempTableName(tableName string) string {
+	safe := reNonIdent.ReplaceAllString(tableName, "_")
+	if safe == "" {
+		safe = "table"
+	}
+	return fmt.Sprintf("__compact_%s_%d", safe, time.Now().UnixNano())
+}
+
+func (c *CompactionService) rewriteDatePartition(tableName, partDate string) error {
+	tx, err := c.db.BeginTx(c.ctx, nil)
+	if err != nil {
+		return err
+	}
+	fqn := fmt.Sprintf("%s.main.%s", c.lakeName, tableName)
+	tmp := compactTempTableName(tableName)
+	statements := []string{
+		fmt.Sprintf("CREATE TEMP TABLE %s AS SELECT * FROM %s WHERE date = DATE '%s'", tmp, fqn, partDate),
+		fmt.Sprintf("DELETE FROM %s WHERE date = DATE '%s'", fqn, partDate),
+		fmt.Sprintf("INSERT INTO %s SELECT * FROM %s ORDER BY timestamp", fqn, tmp),
+		fmt.Sprintf("DROP TABLE %s", tmp),
+	}
+	for _, q := range statements {
+		if _, err := tx.ExecContext(c.ctx, q); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	logger.Info("CompactionService: date-partition compaction completed",
+		"table", tableName, "date", partDate)
+	return nil
 }
 
 // logMemoryBreakdown dumps DuckDB's buffer-manager accounting after an

--- a/src/writer/compaction.go
+++ b/src/writer/compaction.go
@@ -26,6 +26,11 @@ var reBrokenParquet = regexp.MustCompile(
 	`Cannot open file "([^"]+\.parquet)"|Invalid footer.*for file '([^']+\.parquet)'`)
 var reNonIdent = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 
+const (
+	partitionFallbackStepTimeout  = 60 * time.Second
+	maxPartitionFallbacksPerCycle = 1
+)
+
 // catalogPathToAbs converts a DuckLake catalog-relative path to an absolute filesystem path.
 //
 // DuckLake stores file paths in ducklake_data_file.path relative to the per-table
@@ -515,6 +520,8 @@ func (c *CompactionService) runMerge(tables []string) error {
 			"max_file_size_bytes", effectiveMaxFileSize)
 	}
 
+	partitionFallbacksUsed := 0
+
 	// 1. Merge adjacent small files FIRST — lock per table
 	for _, table := range tables {
 		tableName := tableNameFromFQN(table)
@@ -569,9 +576,17 @@ func (c *CompactionService) runMerge(tables []string) error {
 				logger.Warn("CompactionService: merge_adjacent_files failed", "table", tableName, "error", err)
 				if isOutOfMemoryError(err) {
 					c.logMemoryBreakdown()
-					if rerr := c.compactSingleDatePartition(tableName); rerr != nil {
-						logger.Warn("CompactionService: date-partition compaction fallback failed",
-							"table", tableName, "error", rerr)
+					if partitionFallbacksUsed >= maxPartitionFallbacksPerCycle {
+						logger.Warn("CompactionService: date-partition compaction fallback skipped (cycle limit reached)",
+							"table", tableName,
+							"max_fallbacks_per_cycle", maxPartitionFallbacksPerCycle)
+					} else {
+						if rerr := c.compactSingleDatePartition(tableName); rerr != nil {
+							logger.Warn("CompactionService: date-partition compaction fallback failed",
+								"table", tableName, "error", rerr)
+						} else {
+							partitionFallbacksUsed++
+						}
 					}
 				}
 			} else if result != nil {
@@ -863,6 +878,7 @@ func (c *CompactionService) compactSingleDatePartition(tableName string) error {
 }
 
 func (c *CompactionService) selectDatePartitionForCompaction(tableName string) (string, int64, error) {
+	cutoffDate := time.Now().UTC().Format("2006-01-02")
 	metadataSchema := fmt.Sprintf("__ducklake_metadata_%s", c.lakeName)
 	query := fmt.Sprintf(`
 		SELECT
@@ -873,13 +889,14 @@ func (c *CompactionService) selectDatePartitionForCompaction(tableName string) (
 		WHERE t.table_name = ?
 		  AND f.end_snapshot IS NULL
 		  AND regexp_extract(f.path, 'date=([0-9]{4}-[0-9]{2}-[0-9]{2})', 1) <> ''
+		  AND regexp_extract(f.path, 'date=([0-9]{4}-[0-9]{2}-[0-9]{2})', 1) < ?
 		GROUP BY 1
 		HAVING COUNT(*) > 1
 		ORDER BY file_count DESC, part_date ASC
 		LIMIT 1
 	`, metadataSchema, metadataSchema)
 
-	rows, err := c.queryWithRetry(query, tableName)
+	rows, err := c.queryWithRetry(query, tableName, cutoffDate)
 	if err != nil {
 		return "", 0, err
 	}
@@ -932,7 +949,15 @@ func (c *CompactionService) rewriteDatePartition(tableName, partDate string) err
 		stepStart := time.Now()
 		logger.Info("CompactionService: date-partition compaction step start",
 			"table", tableName, "date", partDate, "step", step.name)
-		if _, err := tx.ExecContext(c.ctx, step.sql); err != nil {
+		stepCtx, cancel := context.WithTimeout(c.ctx, partitionFallbackStepTimeout)
+		_, err := tx.ExecContext(stepCtx, step.sql)
+		cancel()
+		if err != nil {
+			if isContextTimeout(err) {
+				logger.Warn("CompactionService: date-partition compaction step timeout",
+					"table", tableName, "date", partDate, "step", step.name,
+					"timeout_sec", int(partitionFallbackStepTimeout/time.Second))
+			}
 			logger.Warn("CompactionService: date-partition compaction step failed",
 				"table", tableName, "date", partDate, "step", step.name, "error", err)
 			_ = tx.Rollback()
@@ -951,6 +976,10 @@ func (c *CompactionService) rewriteDatePartition(tableName, partDate string) err
 	logger.Info("CompactionService: date-partition compaction completed",
 		"table", tableName, "date", partDate, "duration_ms", time.Since(start).Milliseconds())
 	return nil
+}
+
+func isContextTimeout(err error) bool {
+	return err != nil && (strings.Contains(strings.ToLower(err.Error()), "context deadline exceeded") || strings.Contains(strings.ToLower(err.Error()), "deadline exceeded"))
 }
 
 // logMemoryBreakdown dumps DuckDB's buffer-manager accounting after an

--- a/src/writer/compaction.go
+++ b/src/writer/compaction.go
@@ -136,14 +136,14 @@ type CatalogLocker interface {
 // Nil or empty AccessKeyID means skip (ApplyDuckDBS3ClientSettings is a no-op).
 type CompactionS3Client struct {
 	Region, AccessKeyID, SecretAccessKey, Endpoint string
-	UseSSL                                           bool
+	UseSSL                                         bool
 }
 
 // CompactionService handles periodic compaction and retention
 type CompactionService struct {
 	db            *sql.DB
 	lakeName      string
-	dataPath      string       // root dir for parquet files; catalog paths are relative to this
+	dataPath      string // root dir for parquet files; catalog paths are relative to this
 	config        CompactionConfig
 	tables        []string
 	catalogLocker CatalogLocker // serializes catalog access with writer flush
@@ -158,6 +158,7 @@ type CompactionService struct {
 	lastCompactionTime time.Time
 	totalCompactions   int64
 	totalRowsDeleted   int64
+	startupCompaction  bool
 }
 
 // NewCompactionService creates a new compaction service.
@@ -237,7 +238,13 @@ func (c *CompactionService) Start() error {
 		time.Sleep(5 * time.Second) // Wait for system to stabilize
 		logger.Info("CompactionService: Running initial compaction on startup")
 		c.withCatalogLock(c.recoverGhostFiles)
+		c.mu.Lock()
+		c.startupCompaction = true
+		c.mu.Unlock()
 		c.runCompaction()
+		c.mu.Lock()
+		c.startupCompaction = false
+		c.mu.Unlock()
 	}()
 
 	// Start periodic compaction
@@ -513,7 +520,10 @@ func (c *CompactionService) runMerge(tables []string) error {
 				logger.Info("CompactionService: Files before merge", "table", tableName, "count", fileCount)
 			}
 
-			mergeSQL := c.buildMergeSQL(tableName)
+			mergeSQL, maxFiles := c.buildMergeSQL(tableName, fileCount)
+			if maxFiles > 0 {
+				logger.Info("CompactionService: Merge batch limit", "table", tableName, "max_compacted_files", maxFiles)
+			}
 			logger.Info("CompactionService: Merge adjacent files", "lake", c.lakeName, "table", tableName)
 			result, err := c.execWithRetry(mergeSQL)
 			if err != nil {
@@ -646,7 +656,37 @@ func (c *CompactionService) GetStats() map[string]interface{} {
 }
 
 // buildMergeSQL constructs the merge SQL with optional parameters
-func (c *CompactionService) buildMergeSQL(tableName string) string {
+func (c *CompactionService) effectiveMaxCompactedFiles(fileCount int64) int {
+	limit := c.config.MaxCompactedFiles
+	if limit <= 0 {
+		return 0
+	}
+	c.mu.RLock()
+	startup := c.startupCompaction
+	c.mu.RUnlock()
+	if !startup {
+		return limit
+	}
+	// Startup compaction often faces large backlogs; reduce merge fan-in aggressively
+	// to keep the working set inside constrained memory_limit values.
+	switch {
+	case fileCount >= 1000:
+		if limit > 10 {
+			return 10
+		}
+	case fileCount >= 300:
+		if limit > 15 {
+			return 15
+		}
+	case fileCount >= 100:
+		if limit > 20 {
+			return 20
+		}
+	}
+	return limit
+}
+
+func (c *CompactionService) buildMergeSQL(tableName string, fileCount int64) (string, int) {
 	// Build optional parameters
 	var params []string
 	params = append(params, "schema => 'main'")
@@ -657,8 +697,9 @@ func (c *CompactionService) buildMergeSQL(tableName string) string {
 	if c.config.MaxFileSizeBytes > 0 {
 		params = append(params, fmt.Sprintf("max_file_size => %d", c.config.MaxFileSizeBytes))
 	}
-	if c.config.MaxCompactedFiles > 0 {
-		params = append(params, fmt.Sprintf("max_compacted_files => %d", c.config.MaxCompactedFiles))
+	maxFiles := c.effectiveMaxCompactedFiles(fileCount)
+	if maxFiles > 0 {
+		params = append(params, fmt.Sprintf("max_compacted_files => %d", maxFiles))
 	}
 
 	return fmt.Sprintf(
@@ -666,7 +707,7 @@ func (c *CompactionService) buildMergeSQL(tableName string) string {
 		c.lakeName,
 		tableName,
 		strings.Join(params, ", "),
-	)
+	), maxFiles
 }
 
 // logMemoryBreakdown dumps DuckDB's buffer-manager accounting after an

--- a/src/writer/compaction.go
+++ b/src/writer/compaction.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -507,6 +509,12 @@ func (c *CompactionService) runMerge(tables []string) error {
 	// flushInlinedData for why this matters even when inlining is disabled.
 	c.flushInlinedData()
 
+	effectiveMaxFileSize := c.effectiveMergeMaxFileSizeBytes()
+	if effectiveMaxFileSize > 0 {
+		logger.Info("CompactionService: Merge max file size derived",
+			"max_file_size_bytes", effectiveMaxFileSize)
+	}
+
 	// 1. Merge adjacent small files FIRST — lock per table
 	for _, table := range tables {
 		tableName := tableNameFromFQN(table)
@@ -521,7 +529,7 @@ func (c *CompactionService) runMerge(tables []string) error {
 				logger.Info("CompactionService: Files before merge", "table", tableName, "count", fileCount)
 			}
 
-			mergeSQL, maxFiles := c.buildMergeSQL(tableName, fileCount)
+			mergeSQL, maxFiles := c.buildMergeSQL(tableName, fileCount, effectiveMaxFileSize)
 			if maxFiles > 0 {
 				logger.Info("CompactionService: Merge batch limit", "table", tableName, "max_compacted_files", maxFiles)
 			}
@@ -543,7 +551,7 @@ func (c *CompactionService) runMerge(tables []string) error {
 					logger.Warn("CompactionService: merge OOM retry with smaller batch",
 						"table", tableName,
 						"retry_max_compacted_files", retryLimit)
-					retrySQL := c.buildMergeSQLWithLimit(tableName, retryLimit)
+					retrySQL := c.buildMergeSQLWithLimit(tableName, retryLimit, effectiveMaxFileSize)
 					result, err = c.execWithRetry(retrySQL)
 					if err == nil {
 						maxFiles = retryLimit
@@ -711,12 +719,12 @@ func (c *CompactionService) effectiveMaxCompactedFiles(fileCount int64) int {
 	return limit
 }
 
-func (c *CompactionService) buildMergeSQL(tableName string, fileCount int64) (string, int) {
+func (c *CompactionService) buildMergeSQL(tableName string, fileCount int64, maxFileSizeBytes int64) (string, int) {
 	maxFiles := c.effectiveMaxCompactedFiles(fileCount)
-	return c.buildMergeSQLWithLimit(tableName, maxFiles), maxFiles
+	return c.buildMergeSQLWithLimit(tableName, maxFiles, maxFileSizeBytes), maxFiles
 }
 
-func (c *CompactionService) buildMergeSQLWithLimit(tableName string, maxFiles int) string {
+func (c *CompactionService) buildMergeSQLWithLimit(tableName string, maxFiles int, maxFileSizeBytes int64) string {
 	// Build optional parameters
 	var params []string
 	params = append(params, "schema => 'main'")
@@ -724,8 +732,8 @@ func (c *CompactionService) buildMergeSQLWithLimit(tableName string, maxFiles in
 	if c.config.MinFileSizeBytes > 0 {
 		params = append(params, fmt.Sprintf("min_file_size => %d", c.config.MinFileSizeBytes))
 	}
-	if c.config.MaxFileSizeBytes > 0 {
-		params = append(params, fmt.Sprintf("max_file_size => %d", c.config.MaxFileSizeBytes))
+	if maxFileSizeBytes > 0 {
+		params = append(params, fmt.Sprintf("max_file_size => %d", maxFileSizeBytes))
 	}
 	if maxFiles > 0 {
 		params = append(params, fmt.Sprintf("max_compacted_files => %d", maxFiles))
@@ -758,6 +766,84 @@ func (c *CompactionService) oomRetryLimits(initial int) []int {
 
 func isOutOfMemoryError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "Out of Memory")
+}
+
+func (c *CompactionService) effectiveMergeMaxFileSizeBytes() int64 {
+	if c.config.MaxFileSizeBytes > 0 {
+		return c.config.MaxFileSizeBytes
+	}
+	memLimit, err := c.currentDuckDBMemoryLimitBytes()
+	if err != nil || memLimit <= 0 {
+		return 0
+	}
+	return memLimit
+}
+
+func (c *CompactionService) currentDuckDBMemoryLimitBytes() (int64, error) {
+	rows, err := c.queryWithRetry("SELECT current_setting('memory_limit')")
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+	var setting string
+	if rows.Next() {
+		if err := rows.Scan(&setting); err != nil {
+			return 0, err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	return parseDuckDBByteSize(setting)
+}
+
+func parseDuckDBByteSize(s string) (int64, error) {
+	raw := strings.TrimSpace(strings.ToUpper(s))
+	raw = strings.ReplaceAll(raw, " ", "")
+	if raw == "" || raw == "-1" {
+		return 0, fmt.Errorf("invalid memory_limit: %q", s)
+	}
+	re := regexp.MustCompile(`^([0-9]+(?:\.[0-9]+)?)([A-Z]+)?$`)
+	m := re.FindStringSubmatch(raw)
+	if len(m) < 2 {
+		return 0, fmt.Errorf("unparsable byte size: %q", s)
+	}
+	v, err := strconv.ParseFloat(m[1], 64)
+	if err != nil {
+		return 0, err
+	}
+	unit := "B"
+	if len(m) >= 3 && m[2] != "" {
+		unit = m[2]
+	}
+	mul := float64(1)
+	switch unit {
+	case "B":
+		mul = 1
+	case "KB":
+		mul = 1e3
+	case "MB":
+		mul = 1e6
+	case "GB":
+		mul = 1e9
+	case "TB":
+		mul = 1e12
+	case "KIB":
+		mul = 1 << 10
+	case "MIB":
+		mul = 1 << 20
+	case "GIB":
+		mul = 1 << 30
+	case "TIB":
+		mul = 1 << 40
+	default:
+		return 0, fmt.Errorf("unknown byte size unit: %q", unit)
+	}
+	bytes := v * mul
+	if bytes <= 0 || bytes > float64(math.MaxInt64) {
+		return 0, fmt.Errorf("invalid byte size value: %q", s)
+	}
+	return int64(bytes), nil
 }
 
 func (c *CompactionService) compactSingleDatePartition(tableName string) error {

--- a/src/writer/compaction.go
+++ b/src/writer/compaction.go
@@ -536,9 +536,29 @@ func (c *CompactionService) runMerge(tables []string) error {
 					}
 				}
 			}
+			if err != nil && isOutOfMemoryError(err) {
+				c.logMemoryBreakdown()
+				for _, retryLimit := range c.oomRetryLimits(maxFiles) {
+					logger.Warn("CompactionService: merge OOM retry with smaller batch",
+						"table", tableName,
+						"retry_max_compacted_files", retryLimit)
+					retrySQL := c.buildMergeSQLWithLimit(tableName, retryLimit)
+					result, err = c.execWithRetry(retrySQL)
+					if err == nil {
+						maxFiles = retryLimit
+						logger.Info("CompactionService: merge OOM retry succeeded",
+							"table", tableName,
+							"max_compacted_files", retryLimit)
+						break
+					}
+					if !isOutOfMemoryError(err) {
+						break
+					}
+				}
+			}
 			if err != nil {
 				logger.Warn("CompactionService: merge_adjacent_files failed", "table", tableName, "error", err)
-				if strings.Contains(err.Error(), "Out of Memory") {
+				if isOutOfMemoryError(err) {
 					c.logMemoryBreakdown()
 				}
 			} else if result != nil {
@@ -687,6 +707,11 @@ func (c *CompactionService) effectiveMaxCompactedFiles(fileCount int64) int {
 }
 
 func (c *CompactionService) buildMergeSQL(tableName string, fileCount int64) (string, int) {
+	maxFiles := c.effectiveMaxCompactedFiles(fileCount)
+	return c.buildMergeSQLWithLimit(tableName, maxFiles), maxFiles
+}
+
+func (c *CompactionService) buildMergeSQLWithLimit(tableName string, maxFiles int) string {
 	// Build optional parameters
 	var params []string
 	params = append(params, "schema => 'main'")
@@ -697,7 +722,6 @@ func (c *CompactionService) buildMergeSQL(tableName string, fileCount int64) (st
 	if c.config.MaxFileSizeBytes > 0 {
 		params = append(params, fmt.Sprintf("max_file_size => %d", c.config.MaxFileSizeBytes))
 	}
-	maxFiles := c.effectiveMaxCompactedFiles(fileCount)
 	if maxFiles > 0 {
 		params = append(params, fmt.Sprintf("max_compacted_files => %d", maxFiles))
 	}
@@ -707,7 +731,28 @@ func (c *CompactionService) buildMergeSQL(tableName string, fileCount int64) (st
 		c.lakeName,
 		tableName,
 		strings.Join(params, ", "),
-	), maxFiles
+	)
+}
+
+func (c *CompactionService) oomRetryLimits(initial int) []int {
+	if initial <= 1 {
+		return nil
+	}
+	candidates := []int{10, 5, 2, 1}
+	out := make([]int, 0, len(candidates))
+	seen := make(map[int]bool, len(candidates))
+	for _, n := range candidates {
+		if n >= initial || seen[n] {
+			continue
+		}
+		seen[n] = true
+		out = append(out, n)
+	}
+	return out
+}
+
+func isOutOfMemoryError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "Out of Memory")
 }
 
 // logMemoryBreakdown dumps DuckDB's buffer-manager accounting after an

--- a/src/writer/compaction.go
+++ b/src/writer/compaction.go
@@ -906,30 +906,50 @@ func compactTempTableName(tableName string) string {
 }
 
 func (c *CompactionService) rewriteDatePartition(tableName, partDate string) error {
+	start := time.Now()
+	logger.Info("CompactionService: date-partition compaction start",
+		"table", tableName, "date", partDate)
+
 	tx, err := c.db.BeginTx(c.ctx, nil)
 	if err != nil {
+		logger.Warn("CompactionService: date-partition compaction begin failed",
+			"table", tableName, "date", partDate, "error", err)
 		return err
 	}
 	fqn := fmt.Sprintf("%s.main.%s", c.lakeName, tableName)
 	tmp := compactTempTableName(tableName)
-	statements := []string{
-		fmt.Sprintf("CREATE TEMP TABLE %s AS SELECT * FROM %s WHERE date = DATE '%s'", tmp, fqn, partDate),
-		fmt.Sprintf("DELETE FROM %s WHERE date = DATE '%s'", fqn, partDate),
-		fmt.Sprintf("INSERT INTO %s SELECT * FROM %s ORDER BY timestamp", fqn, tmp),
-		fmt.Sprintf("DROP TABLE %s", tmp),
+	type stepSQL struct {
+		name string
+		sql  string
 	}
-	for _, q := range statements {
-		if _, err := tx.ExecContext(c.ctx, q); err != nil {
+	statements := []stepSQL{
+		{name: "create_temp_partition_copy", sql: fmt.Sprintf("CREATE TEMP TABLE %s AS SELECT * FROM %s WHERE date = DATE '%s'", tmp, fqn, partDate)},
+		{name: "delete_partition_rows", sql: fmt.Sprintf("DELETE FROM %s WHERE date = DATE '%s'", fqn, partDate)},
+		{name: "insert_repacked_partition_rows", sql: fmt.Sprintf("INSERT INTO %s SELECT * FROM %s ORDER BY timestamp", fqn, tmp)},
+		{name: "drop_temp_partition_copy", sql: fmt.Sprintf("DROP TABLE %s", tmp)},
+	}
+	for _, step := range statements {
+		stepStart := time.Now()
+		logger.Info("CompactionService: date-partition compaction step start",
+			"table", tableName, "date", partDate, "step", step.name)
+		if _, err := tx.ExecContext(c.ctx, step.sql); err != nil {
+			logger.Warn("CompactionService: date-partition compaction step failed",
+				"table", tableName, "date", partDate, "step", step.name, "error", err)
 			_ = tx.Rollback()
 			return err
 		}
+		logger.Info("CompactionService: date-partition compaction step done",
+			"table", tableName, "date", partDate, "step", step.name,
+			"duration_ms", time.Since(stepStart).Milliseconds())
 	}
 	if err := tx.Commit(); err != nil {
+		logger.Warn("CompactionService: date-partition compaction commit failed",
+			"table", tableName, "date", partDate, "error", err)
 		_ = tx.Rollback()
 		return err
 	}
 	logger.Info("CompactionService: date-partition compaction completed",
-		"table", tableName, "date", partDate)
+		"table", tableName, "date", partDate, "duration_ms", time.Since(start).Milliseconds())
 	return nil
 }
 

--- a/src/writer/compaction_oom_test.go
+++ b/src/writer/compaction_oom_test.go
@@ -47,3 +47,10 @@ func TestBuildMergeSQLWithLimit(t *testing.T) {
 		t.Fatalf("did not expect max_compacted_files in SQL when limit=0, got: %s", sqlNoLimit)
 	}
 }
+
+func TestCompactTempTableNameSanitizes(t *testing.T) {
+	name := compactTempTableName("hep.proto-1/call")
+	if !strings.HasPrefix(name, "__compact_hep_proto_1_call_") {
+		t.Fatalf("unexpected compact temp table name: %s", name)
+	}
+}

--- a/src/writer/compaction_oom_test.go
+++ b/src/writer/compaction_oom_test.go
@@ -34,15 +34,17 @@ func TestBuildMergeSQLWithLimit(t *testing.T) {
 		lakeName: "homer_lake",
 		config: CompactionConfig{
 			MinFileSizeBytes:  1024,
-			MaxFileSizeBytes:  8192,
 			MaxCompactedFiles: 25,
 		},
 	}
-	sqlWithLimit := c.buildMergeSQLWithLimit("hep_proto_1_call", 5)
+	sqlWithLimit := c.buildMergeSQLWithLimit("hep_proto_1_call", 5, 8192)
 	if !strings.Contains(sqlWithLimit, "max_compacted_files => 5") {
 		t.Fatalf("expected explicit max_compacted_files in SQL, got: %s", sqlWithLimit)
 	}
-	sqlNoLimit := c.buildMergeSQLWithLimit("hep_proto_1_call", 0)
+	if !strings.Contains(sqlWithLimit, "max_file_size => 8192") {
+		t.Fatalf("expected explicit max_file_size in SQL, got: %s", sqlWithLimit)
+	}
+	sqlNoLimit := c.buildMergeSQLWithLimit("hep_proto_1_call", 0, 0)
 	if strings.Contains(sqlNoLimit, "max_compacted_files") {
 		t.Fatalf("did not expect max_compacted_files in SQL when limit=0, got: %s", sqlNoLimit)
 	}
@@ -52,5 +54,25 @@ func TestCompactTempTableNameSanitizes(t *testing.T) {
 	name := compactTempTableName("hep.proto-1/call")
 	if !strings.HasPrefix(name, "__compact_hep_proto_1_call_") {
 		t.Fatalf("unexpected compact temp table name: %s", name)
+	}
+}
+
+func TestParseDuckDBByteSize(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int64
+	}{
+		{in: "4GB", want: 4_000_000_000},
+		{in: "3.7 GiB", want: 3972844748},
+		{in: "1500MB", want: 1_500_000_000},
+	}
+	for _, tc := range cases {
+		got, err := parseDuckDBByteSize(tc.in)
+		if err != nil {
+			t.Fatalf("parse %q: %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Fatalf("parse %q got=%d want=%d", tc.in, got, tc.want)
+		}
 	}
 }

--- a/src/writer/compaction_oom_test.go
+++ b/src/writer/compaction_oom_test.go
@@ -1,0 +1,49 @@
+package writer
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOOMRetryLimits(t *testing.T) {
+	c := &CompactionService{}
+	cases := []struct {
+		initial int
+		want    []int
+	}{
+		{initial: 10, want: []int{5, 2, 1}},
+		{initial: 25, want: []int{10, 5, 2, 1}},
+		{initial: 2, want: []int{1}},
+		{initial: 1, want: nil},
+	}
+	for _, tc := range cases {
+		got := c.oomRetryLimits(tc.initial)
+		if len(got) != len(tc.want) {
+			t.Fatalf("initial=%d got=%v want=%v", tc.initial, got, tc.want)
+		}
+		for i := range tc.want {
+			if got[i] != tc.want[i] {
+				t.Fatalf("initial=%d got=%v want=%v", tc.initial, got, tc.want)
+			}
+		}
+	}
+}
+
+func TestBuildMergeSQLWithLimit(t *testing.T) {
+	c := &CompactionService{
+		lakeName: "homer_lake",
+		config: CompactionConfig{
+			MinFileSizeBytes:  1024,
+			MaxFileSizeBytes:  8192,
+			MaxCompactedFiles: 25,
+		},
+	}
+	sqlWithLimit := c.buildMergeSQLWithLimit("hep_proto_1_call", 5)
+	if !strings.Contains(sqlWithLimit, "max_compacted_files => 5") {
+		t.Fatalf("expected explicit max_compacted_files in SQL, got: %s", sqlWithLimit)
+	}
+	sqlNoLimit := c.buildMergeSQLWithLimit("hep_proto_1_call", 0)
+	if strings.Contains(sqlNoLimit, "max_compacted_files") {
+		t.Fatalf("did not expect max_compacted_files in SQL when limit=0, got: %s", sqlNoLimit)
+	}
+}

--- a/src/writer/writer.go
+++ b/src/writer/writer.go
@@ -347,7 +347,7 @@ func (w *Writer) Start() error {
 			// memory_limit and abort with Out of Memory while search/flush
 			// run on the same instance. Capping keeps each cycle's peak
 			// bounded — leftovers are picked up by the next cycle.
-			compactionCfg.MaxCompactedFiles = 100
+			compactionCfg.MaxCompactedFiles = 25
 		}
 		var compactionS3 *CompactionS3Client
 		if ducklake.IsRemoteLakeDataPath(w.storageConfig.DuckLake.DataPath) {


### PR DESCRIPTION
## Summary
- keep current single UNION behavior for short ranges (`<= 1h`) and split wide ranges into two queries: lake-only and mem-only (`mem_*_a UNION ALL mem_*_b`)
- merge split results in Go using existing dedupe/ordering helpers, then apply final `LIMIT` to preserve top-N semantics
- apply the same threshold logic to FlightSQL SQL preparation fallback path and bump `VERSION_APPLICATION` to `11.0.252`

## Test plan
- [x] `go test ./node` from `src/`
- [x] Added/updated unit tests for threshold and fallback behavior in `src/node/rewrite_query_test.go`