### PR TITLE
Potential fix for code scanning alert no. 40: Database query built from user-controlled sources

### DIFF
--- a/src/node/node.go
+++ b/src/node/node.go
@@ -480,7 +480,34 @@ func mergeSelectResults(a, b []map[string]interface{}, colsA, colsB []string, li
 // UNIONs and the overall statement shape are built dynamically. As defence in
 // depth we still reject anything that is not a single read-only SELECT before
 // it reaches the driver, so a malformed/stacked statement can never run here.
+var dangerousSQLPattern = regexp.MustCompile(`(?i)\b(attach|detach|copy|pragma|install|load|call|create|alter|drop|truncate|insert|update|delete|merge|replace|grant|revoke|vacuum|analyze|export|import)\b`)
+
+func validateUserSQL(query string) error {
+	trimmed := strings.TrimSpace(query)
+	if trimmed == "" {
+		return fmt.Errorf("empty SQL query")
+	}
+
+	upper := strings.ToUpper(trimmed)
+	if !strings.HasPrefix(upper, "SELECT") && !strings.HasPrefix(upper, "WITH") {
+		return fmt.Errorf("only SELECT/CTE queries are allowed")
+	}
+
+	if strings.Contains(trimmed, ";") || strings.Contains(trimmed, "--") || strings.Contains(trimmed, "/*") || strings.Contains(trimmed, "*/") {
+		return fmt.Errorf("SQL contains forbidden comment or statement separator")
+	}
+
+	if dangerousSQLPattern.MatchString(trimmed) {
+		return fmt.Errorf("SQL contains forbidden keyword")
+	}
+
+	return nil
+}
+
 func runSelectQuery(ctx context.Context, db *sql.DB, query string) ([]map[string]interface{}, []string, error) {
+	if err := validateUserSQL(query); err != nil {
+		return nil, nil, err
+	}
 	if err := ensureReadOnlySingleStatement(query); err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/sipcapture/homer/security/code-scanning/40](https://github.com/sipcapture/homer/security/code-scanning/40)

Best fix: stop executing raw client SQL and enforce a strict allowlist validation before any DB execution. Since this endpoint’s functionality relies on SQL input, the least disruptive safe fix in the shown code is to add a strong validation gate in `runSelectQuery` (the final sink boundary) and reject queries containing dangerous tokens/patterns, while keeping existing behavior for expected read-only SELECTs.

Concretely in `src/node/node.go`:
- Strengthen `runSelectQuery` around lines 483–487 by adding a call to a new validator (for example `validateUserSQL(query)`), before `db.QueryContext`.
- Implement `validateUserSQL` in the same file (near other SQL helpers), using a conservative allowlist:
  - must begin with `SELECT` or `WITH`
  - reject comments (`--`, `/* */`), statement separators (`;`)
  - reject high-risk keywords (`ATTACH`, `DETACH`, `COPY`, `PRAGMA`, `INSTALL`, `LOAD`, `CALL`, `CREATE`, `ALTER`, `DROP`, `INSERT`, `UPDATE`, `DELETE`, etc.)
- Keep `ensureReadOnlySingleStatement(query)` as defense-in-depth.
- Use already imported `regexp`/`strings`/`fmt` (no new dependency required).

This preserves existing flow while adding an explicit sink-side security boundary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
