### PR TITLE
fix(compaction): default to duckdb engine + add catalog rebuild command

### DIFF
--- a/docs/OOM.md
+++ b/docs/OOM.md
@@ -119,14 +119,33 @@ Why this helps:
 3. Reduce query range temporarily (narrower time window).
 4. Re-enable compaction only after search is stable.
 
-## 6) Native Go Compaction Engine (OOM-free merge)
+## 6) Native Go Compaction Engine (EXPERIMENTAL / UNSAFE)
+
+> ⚠️ **Do not enable `engine: native` on a live writer.** It corrupts the
+> DuckLake catalog. The DuckLake writer keeps its snapshot/id counters cached in
+> DuckDB process memory and allocates new snapshot ids by incrementing that
+> cache — it does **not** re-read the SQLite catalog before each commit. The
+> native engine allocates snapshot ids out-of-band as `MAX(snapshot_id)+1` in
+> SQLite, so the next flush reuses the same id and writes a **duplicate**
+> `ducklake_snapshot` row. The search node then fails with:
+>
+> ```
+> Invalid Input Error: Corrupt DuckLake - multiple snapshots returned from database
+> ```
+>
+> The `CatalogLock` does not prevent this: it serializes the *writes*, but
+> DuckLake's id counter lives in memory and is oblivious to out-of-band SQLite
+> writes. As of 11.0.257 the engine is **opt-in** and the default is `duckdb`.
+> See "Recovering a corrupted catalog" below if you already hit this.
 
 The default DuckDB merge (`ducklake_merge_adjacent_files`) loads a whole
 partition into memory to sort/rewrite it. On wide SIP data (large `payload`
 columns) this can exceed `memory_limit` and OOM even for a handful of ~77MB
-files, because the parquet write buffers are not spillable.
+files, because the parquet write buffers are not spillable. Use the batching
+knobs (`max_compacted_files`, `max_file_size_bytes`, lower `memory_limit`
+headroom) from the sections above to keep it within budget.
 
-The `native` engine (the **default**) avoids this entirely. It does **not** use
+The `native` engine avoids the DuckDB merge entirely. It does **not** use
 DuckDB for compaction. Instead it:
 
 - groups a partition's parquet files into batches up to `target_file_size_bytes`
@@ -143,7 +162,8 @@ DuckDB for compaction. Instead it:
 
 ### Configuration
 
-It is on by default. To pin it (or tune the output size) explicitly:
+The default is `duckdb`. The native engine is **opt-in** and unsafe with a live
+writer (see the warning above); only enable it if the writer is fully quiescent:
 
 ```json
 {
@@ -161,10 +181,68 @@ It is on by default. To pin it (or tune the output size) explicitly:
 }
 ```
 
-To force the old DuckDB merge instead, set `"engine": "duckdb"`.
+Leaving `engine` unset (or `"duckdb"`) uses the DuckLake merge, which is the
+recommended, catalog-safe path.
+
+### Recovering a corrupted catalog
+
+If you already see `Corrupt DuckLake - multiple snapshots returned from
+database`, the SQLite catalog has duplicate `snapshot_id` rows.
+
+**Preferred: rebuild the catalog from disk.** Stop the Homer writer, then run:
+
+```bash
+homer system --config-path /etc/homer/config.json --rebuild-catalog
+```
+
+This backs up the existing catalog to `*.corrupt.<timestamp>`, attaches a fresh
+empty catalog, and re-ingests every on-disk parquet table through DuckLake (so
+all snapshot/file ids are allocated by DuckLake and the result is consistent).
+After verifying queries work, reclaim the old files with either:
+
+```bash
+homer system --config-path /etc/homer/config.json --rebuild-catalog --rebuild-cleanup-orphans
+# or, later:
+homer system --config-path /etc/homer/config.json --compaction-force
+```
+
+Notes:
+- Run with the writer **stopped** (it discards the live catalog).
+- Local `data_path` + SQLite catalog only; single-catalog (non-sharded) layouts.
+- Rows that were only ever inlined in the old catalog (never written to parquet)
+  cannot be recovered this way.
+
+**Manual alternative (dedup in place).** If you prefer to repair the existing
+catalog, **back up the catalog file first**, then dedup:
+
+```sql
+-- 1) Back up first:  cp homer_catalog.sqlite homer_catalog.sqlite.bak
+-- 2) Inspect the damage:
+SELECT snapshot_id, COUNT(*) c FROM ducklake_snapshot GROUP BY snapshot_id HAVING c > 1;
+
+-- 3) Keep one row per snapshot_id (the most-advanced next_file_id / next_catalog_id):
+DELETE FROM ducklake_snapshot
+WHERE rowid NOT IN (
+  SELECT rowid FROM ducklake_snapshot s
+  WHERE s.next_file_id = (SELECT MAX(next_file_id) FROM ducklake_snapshot x WHERE x.snapshot_id = s.snapshot_id)
+  GROUP BY s.snapshot_id
+);
+
+-- 4) Re-base the latest snapshot's counters above every registered id so the
+--    writer cannot reuse one:
+UPDATE ducklake_snapshot
+SET next_file_id    = (SELECT COALESCE(MAX(data_file_id),0)+1 FROM ducklake_data_file),
+    next_catalog_id = (SELECT MAX(next_catalog_id) FROM ducklake_snapshot)
+WHERE snapshot_id = (SELECT MAX(snapshot_id) FROM ducklake_snapshot);
+```
+
+Then set `engine` to `duckdb` (or remove it) and restart. If you keep a backup
+of the catalog from before the native run, restoring it is the safest recovery.
 
 Requirements and behavior:
 
+- **Live-writer hazard** — see the warning at the top of this section. Only run
+  native compaction when no flush can land concurrently.
 - **Local storage + SQLite catalog** — for remote (`s3://`) `data_path` or a
   missing `catalog_path`, the writer **automatically falls back to the `duckdb`
   engine**, so compaction always runs.

--- a/src/cli/system_cmd.go
+++ b/src/cli/system_cmd.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -86,6 +87,8 @@ type SystemFlags struct {
 	CompactionRetentionDays   int
 	CompactionMergeList       bool
 	CompactionMergeListLimit  int
+	RebuildCatalog            bool
+	RebuildCleanupOrphans     bool
 	InstallExtensions         bool
 	Reload                    bool
 	PidFile                   string
@@ -104,6 +107,8 @@ type systemFlagRefs struct {
 	CompactionRetentionDays   *int
 	CompactionMergeList       *bool
 	CompactionMergeListLimit  *int
+	RebuildCatalog            *bool
+	RebuildCleanupOrphans     *bool
 	InstallExtensions         *bool
 	Reload                    *bool
 	PidFile                   *string
@@ -126,6 +131,8 @@ func RegisterSystemFlags() (*flag.FlagSet, *systemFlagRefs) {
 	refs.CompactionRetentionDays = fs.Int("compaction-retention-days", 0, "delete data older than N days and exit")
 	refs.CompactionMergeList = fs.Bool("compaction-merge-list", false, "list smallest DuckLake files before/after merge")
 	refs.CompactionMergeListLimit = fs.Int("compaction-merge-list-limit", 50, "limit for compaction-merge-list output")
+	refs.RebuildCatalog = fs.Bool("rebuild-catalog", false, "fix a corrupt catalog: back up the existing catalog and fully rebuild it from the parquet files on disk, then exit")
+	refs.RebuildCleanupOrphans = fs.Bool("rebuild-cleanup-orphans", false, "with --rebuild-catalog: after a successful rebuild, delete the now-orphaned original parquet files to reclaim space")
 	refs.InstallExtensions = fs.Bool("install-extensions", false, "install DuckDB extensions (ducklake, sqlite) and exit")
 	refs.Reload = fs.Bool("reload", false, "send SIGHUP to running homer-core process to reload config")
 	refs.PidFile = fs.String("pid-file", "/var/run/homer-core.pid", "path to PID file (used with --reload)")
@@ -148,6 +155,8 @@ func ParseSystemFlags(refs *systemFlagRefs) SystemFlags {
 		CompactionRetentionDays:   *refs.CompactionRetentionDays,
 		CompactionMergeList:       *refs.CompactionMergeList,
 		CompactionMergeListLimit:  *refs.CompactionMergeListLimit,
+		RebuildCatalog:            *refs.RebuildCatalog,
+		RebuildCleanupOrphans:     *refs.RebuildCleanupOrphans,
 		InstallExtensions:         *refs.InstallExtensions,
 		Reload:                    *refs.Reload,
 		PidFile:                   *refs.PidFile,
@@ -178,6 +187,12 @@ func RunSystemCmd(f SystemFlags) error {
 
 	if f.Reload {
 		return handleReloadCommand(f.PidFile)
+	}
+
+	// Catalog rebuild -- needs config, must run with its own fresh ATTACH
+	// (cannot reuse the corrupt catalog the way runCompaction does).
+	if f.RebuildCatalog {
+		return rebuildCatalog(f)
 	}
 
 	// Compaction commands -- need config
@@ -513,6 +528,226 @@ func recoverCatalog(db *sql.DB, lakeName, dataPath string) (int, error) {
 	}
 
 	return recovered, nil
+}
+
+// rebuildCatalog fixes a corrupt DuckLake catalog by discarding it and
+// rebuilding a clean one entirely from the parquet files on disk.
+//
+// Unlike --compaction-recover (which re-ingests into the *existing* catalog and
+// therefore cannot help when the catalog itself is unreadable, e.g. "Corrupt
+// DuckLake - multiple snapshots returned from database"), this:
+//
+//  1. backs up the existing catalog file (+ -wal/-shm) to *.corrupt.<ts>,
+//  2. ATTACHes a brand-new empty catalog at the same path (DuckLake creates the
+//     known HEP tables automatically),
+//  3. re-ingests every on-disk parquet table through DuckLake, so all snapshot
+//     and file ids are allocated by DuckLake itself (never out-of-band) and the
+//     resulting catalog is internally consistent,
+//  4. optionally deletes the now-orphaned original parquet files.
+//
+// Limitations: rows that were only ever stored inline in the old catalog (never
+// written to parquet) cannot be recovered. Run this with the writer stopped.
+func rebuildCatalog(f SystemFlags) error {
+	cfg, err := config.Load(f.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	logger.InitLoggerSimple("info", true, false)
+
+	duckCfg := duckLakeConfigFromModular(cfg)
+	dataPath := duckCfg.DataPath
+	catalogPath := duckCfg.CatalogPath
+
+	if ducklake.IsRemoteLakeDataPath(dataPath) {
+		return fmt.Errorf("rebuild-catalog requires a local data_path; got %q", dataPath)
+	}
+	if strings.TrimSpace(catalogPath) == "" {
+		return fmt.Errorf("rebuild-catalog requires a sqlite catalog_path in the config")
+	}
+	if _, err := os.Stat(filepath.Join(dataPath, "main")); err != nil {
+		return fmt.Errorf("rebuild-catalog: data directory %q not found: %w",
+			filepath.Join(dataPath, "main"), err)
+	}
+
+	logger.Warn("rebuild-catalog: this discards the current catalog and rebuilds it "+
+		"from parquet on disk; make sure the homer writer is STOPPED before continuing",
+		"catalog_path", catalogPath, "data_path", dataPath)
+
+	// 1) Back up the corrupt catalog out of the way so ATTACH creates a fresh one.
+	backup, err := backupCatalogFiles(catalogPath)
+	if err != nil {
+		return fmt.Errorf("rebuild-catalog: failed to back up existing catalog: %w", err)
+	}
+	if backup != "" {
+		logger.Info("rebuild-catalog: backed up existing catalog", "backup", backup)
+	} else {
+		logger.Info("rebuild-catalog: no existing catalog found, building a new one", "catalog_path", catalogPath)
+	}
+
+	// 2) Fresh ATTACH. NewManager creates the known HEP tables automatically.
+	manager, err := ducklake.NewManager(duckCfg)
+	if err != nil {
+		return fmt.Errorf("rebuild-catalog: failed to attach fresh catalog (original preserved at %q): %w", backup, err)
+	}
+	defer manager.Stop()
+
+	db := manager.GetDB()
+	lakeName := manager.GetLakeName()
+
+	// 3) Discover on-disk tables and re-ingest each through DuckLake.
+	tables, err := listOnDiskTables(dataPath)
+	if err != nil {
+		return fmt.Errorf("rebuild-catalog: failed to list data directory: %w", err)
+	}
+	if len(tables) == 0 {
+		logger.Warn("rebuild-catalog: no table directories found under data_path/main", "data_path", dataPath)
+		return nil
+	}
+
+	var rebuilt, skipped int
+	var totalRows int64
+	var failed []string
+	for _, table := range tables {
+		if !tableHasParquet(db, dataPath, table) {
+			logger.Info("rebuild-catalog: no data parquet files, skipping", "table", table)
+			skipped++
+			continue
+		}
+
+		rows, err := reingestTable(db, lakeName, dataPath, table)
+		if err != nil {
+			logger.Error("rebuild-catalog: failed to rebuild table", "table", table, "error", err)
+			failed = append(failed, table)
+			continue
+		}
+		logger.Info("rebuild-catalog: rebuilt table", "table", table, "rows", rows)
+		totalRows += rows
+		rebuilt++
+	}
+
+	logger.Info("rebuild-catalog: rebuild complete",
+		"tables_rebuilt", rebuilt, "tables_skipped", skipped, "tables_failed", len(failed), "total_rows", totalRows)
+
+	if len(failed) > 0 {
+		return fmt.Errorf("rebuild-catalog: %d table(s) failed: %s (original catalog preserved at %q)",
+			len(failed), strings.Join(failed, ", "), backup)
+	}
+
+	// 4) The originals are now orphaned (DuckLake wrote fresh files during
+	//    re-ingest). Only delete them on explicit request and only after a
+	//    fully successful rebuild.
+	if f.RebuildCleanupOrphans {
+		orphanSQL := fmt.Sprintf("CALL ducklake_delete_orphaned_files('%s', cleanup_all => true)", lakeName)
+		if _, err := db.Exec(orphanSQL); err != nil {
+			logger.Warn("rebuild-catalog: orphaned-file cleanup failed (not critical)", "error", err)
+		} else {
+			logger.Info("rebuild-catalog: deleted orphaned original parquet files")
+		}
+	} else {
+		logger.Info("rebuild-catalog: original parquet files are now orphaned; verify queries, then run " +
+			"'homer system --compaction-force' or re-run with --rebuild-cleanup-orphans to reclaim space")
+	}
+
+	logger.Info("rebuild-catalog: done — verify with a query, then restart the homer writer")
+	return nil
+}
+
+// backupCatalogFiles renames the catalog file and its -wal/-shm sidecars to
+// "<path>.corrupt.<timestamp>" so a fresh catalog can be created at the original
+// path. Returns the backup path of the main catalog file ("" if none existed).
+func backupCatalogFiles(catalogPath string) (string, error) {
+	suffix := ".corrupt." + time.Now().Format("20060102-150405")
+	mainBackup := ""
+	for _, ext := range []string{"", "-wal", "-shm"} {
+		src := catalogPath + ext
+		if _, err := os.Stat(src); err != nil {
+			continue // sidecar may not exist
+		}
+		dst := catalogPath + suffix + ext
+		if err := os.Rename(src, dst); err != nil {
+			return mainBackup, fmt.Errorf("rename %s -> %s: %w", src, dst, err)
+		}
+		if ext == "" {
+			mainBackup = dst
+		}
+	}
+	return mainBackup, nil
+}
+
+// listOnDiskTables returns the table directory names under {dataPath}/main.
+func listOnDiskTables(dataPath string) ([]string, error) {
+	entries, err := os.ReadDir(filepath.Join(dataPath, "main"))
+	if err != nil {
+		return nil, err
+	}
+	var tables []string
+	for _, e := range entries {
+		if e.IsDir() {
+			tables = append(tables, e.Name())
+		}
+	}
+	sort.Strings(tables)
+	return tables, nil
+}
+
+// tableHasParquet reports whether the table has at least one hive-partitioned
+// data parquet file (date=…/), ignoring *-delete.parquet tombstones.
+func tableHasParquet(db *sql.DB, dataPath, table string) bool {
+	pattern := parquetDataGlobPattern(dataPath, table)
+	var n int
+	if err := db.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM glob('%s')", pattern)).Scan(&n); err != nil {
+		return false
+	}
+	return n > 0
+}
+
+// duckLakeTableExists reports whether a table already exists in the catalog
+// (the known HEP tables are auto-created by NewManager).
+func duckLakeTableExists(db *sql.DB, lakeName, table string) bool {
+	q := fmt.Sprintf(`SELECT COUNT(*) FROM information_schema.tables
+		WHERE table_catalog = '%s' AND table_schema = 'main' AND table_name = '%s'`,
+		lakeName, table)
+	var n int
+	if err := db.QueryRow(q).Scan(&n); err != nil {
+		return false
+	}
+	return n > 0
+}
+
+// reingestTable reads all of a table's on-disk parquet files and inserts them
+// into the (fresh) DuckLake table, creating the table first if it is not one of
+// the auto-created HEP tables. DuckLake allocates all snapshot/file ids, so the
+// rebuilt catalog is consistent. Returns the number of rows ingested.
+func reingestTable(db *sql.DB, lakeName, dataPath, table string) (int64, error) {
+	pattern := parquetDataGlobPattern(dataPath, table)
+	readExpr := fmt.Sprintf("read_parquet('%s', union_by_name=true, hive_partitioning=true)", pattern)
+	fqn := fmt.Sprintf("%s.main.%s", lakeName, table)
+
+	if !duckLakeTableExists(db, lakeName, table) {
+		// Unknown/custom table (e.g. otlp_*, lp_*): create it from the parquet
+		// schema, partition/sort like the HEP tables (best-effort), then ingest.
+		createSQL := fmt.Sprintf("CREATE TABLE %s AS SELECT * FROM %s WHERE 1=0", fqn, readExpr)
+		if _, err := db.Exec(createSQL); err != nil {
+			return 0, fmt.Errorf("create table: %w", err)
+		}
+		if _, err := db.Exec(fmt.Sprintf("ALTER TABLE %s SET PARTITIONED BY (date)", fqn)); err != nil {
+			logger.Info("rebuild-catalog: table not partitioned by date (ok)", "table", table, "reason", err.Error())
+		}
+		if _, err := db.Exec(fmt.Sprintf("ALTER TABLE %s SET SORTED BY (timestamp ASC)", fqn)); err != nil {
+			logger.Info("rebuild-catalog: table not sorted by timestamp (ok)", "table", table, "reason", err.Error())
+		}
+	}
+
+	// BY NAME so partition/added columns line up with the table definition
+	// regardless of parquet column order.
+	insertSQL := fmt.Sprintf("INSERT INTO %s BY NAME SELECT * FROM %s", fqn, readExpr)
+	result, err := db.Exec(insertSQL)
+	if err != nil {
+		return 0, fmt.Errorf("insert: %w", err)
+	}
+	rows, _ := result.RowsAffected()
+	return rows, nil
 }
 
 func logDuckLakeSmallFiles(db *sql.DB, lakeName string, stage string, limit int) {

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -703,16 +703,17 @@ type CompactionConfig struct {
 	// working set within memory_limit on memory-capped writers.
 	MaxCompactedFiles int `json:"max_compacted_files" mapstructure:"max_compacted_files" default:"0"`
 	// Engine selects the compaction implementation:
-	//   "native" — DuckDB-free Go compactor (default). Concatenates a
-	//              partition's parquet row groups into files up to
-	//              TargetFileSizeBytes and writes the SQLite catalog directly.
-	//              Bounds peak memory to a single row group, avoiding the
-	//              whole-partition OOM the DuckDB merge hits on wide SIP data.
-	//              Used only for local data_path + SQLite catalog on
-	//              append-only tables; otherwise the writer falls back to
-	//              "duckdb" automatically.
-	//   "duckdb" — DuckLake's ducklake_merge_adjacent_files.
-	Engine string `json:"engine" mapstructure:"engine" default:"native"`
+	//   "duckdb" — DuckLake's ducklake_merge_adjacent_files (default, safe).
+	//   "native" — EXPERIMENTAL / UNSAFE. DuckDB-free Go compactor that writes
+	//              the SQLite catalog directly. It bounds peak memory to a
+	//              single parquet row group, but it allocates snapshot ids
+	//              out-of-band (MAX(snapshot_id)+1) while the DuckLake writer
+	//              keeps its own snapshot/id counters cached in memory. A
+	//              concurrent flush then reuses the same snapshot id, producing
+	//              duplicate rows in ducklake_snapshot and corrupting the
+	//              catalog ("Corrupt DuckLake - multiple snapshots returned").
+	//              Do NOT enable unless the writer is fully quiescent.
+	Engine string `json:"engine" mapstructure:"engine" default:"duckdb"`
 	// TargetFileSizeBytes caps each merged output file for the native engine.
 	// 0 = engine default (512MB).
 	TargetFileSizeBytes int64 `json:"target_file_size_bytes" mapstructure:"target_file_size_bytes" default:"0"`

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.256"
+	VERSION_APPLICATION = "11.0.258"
 
 	// BuildDate is the build date
 	BuildDate = ""

--- a/src/writer/compaction.go
+++ b/src/writer/compaction.go
@@ -622,16 +622,21 @@ func (c *CompactionService) runMerge(tables []string) error {
 	return nil
 }
 
-// useNativeEngine reports whether the native compactor should run. Native is
-// the default (empty engine == native), but it requires local storage and a
-// SQLite catalog; otherwise the caller falls back to the DuckDB path.
+// useNativeEngine reports whether the native compactor should run. The native
+// engine is OPT-IN and UNSAFE: the default (empty engine) and "duckdb" both use
+// the DuckLake merge. Native writes the SQLite catalog out-of-band, which
+// corrupts the catalog when the DuckLake writer is concurrently flushing (it
+// reuses snapshot ids cached in DuckDB memory → duplicate ducklake_snapshot
+// rows). It also requires local storage and a SQLite catalog.
 func (c *CompactionService) useNativeEngine() bool {
-	switch c.config.Engine {
-	case EngineNativeGo, "":
-		// native (default)
-	default:
-		return false // explicit "duckdb" or unknown
+	if c.config.Engine != EngineNativeGo {
+		// empty/default and "duckdb" → DuckLake merge (safe).
+		return false
 	}
+	logger.Warn("CompactionService: native compaction engine is EXPERIMENTAL and can corrupt "+
+		"the DuckLake catalog when the writer flushes concurrently (duplicate snapshot ids); "+
+		"prefer engine=duckdb unless the writer is quiescent",
+		"lake", c.lakeName)
 	if ducklake.IsRemoteLakeDataPath(c.dataPath) {
 		return false
 	}


### PR DESCRIPTION
The native compaction engine corrupts the DuckLake catalog: it allocates snapshot ids out-of-band (MAX(snapshot_id)+1 written directly to SQLite), but the live DuckLake writer keeps its snapshot/id counters cached in DuckDB process memory and does not re-read the catalog before each commit. The next flush then reuses the same id, producing duplicate ducklake_snapshot rows and "Corrupt DuckLake - multiple snapshots returned from database". The CatalogLock cannot prevent this since the id counter lives in memory, not the catalog.

- config: default compaction engine duckdb (was native); native is now opt-in
- writer: empty/duckdb use the safe DuckLake merge; native logs a corruption warning when explicitly enabled
- cli: add `homer system --rebuild-catalog` to fix a corrupt catalog by backing it up and rebuilding from on-disk parquet via DuckLake (safe id allocation), with optional --rebuild-cleanup-orphans
- docs: document the hazard and recovery (CLI + manual dedup)
- bump version to 11.0.258