### PR TITLE
fix(ducklake): exclusive writer lock to prevent concurrent-writer catalog corruption (11.0.259)

### DIFF
--- a/src/storage/ducklake/ducklake.go
+++ b/src/storage/ducklake/ducklake.go
@@ -93,6 +93,14 @@ type Config struct {
 	TuningThreads       int
 	TuningMemoryLimit   string
 	TuningTempDirectory string
+
+	// ExclusiveLock, when true, makes the writer take an exclusive OS file lock
+	// (flock) on the SQLite catalog before attaching. A second writer process on
+	// the same catalog then refuses to start instead of corrupting it (two
+	// concurrent DuckLake writers on SQLite duplicate snapshot/table ids — see
+	// "Corrupt DuckLake - multiple snapshots returned"). Set only on writer
+	// paths; readers and CLI maintenance leave it false.
+	ExclusiveLock bool
 }
 
 // isS3Path checks if path is an S3 URL
@@ -189,6 +197,11 @@ type MultiTableWriter struct {
 	flushInterval time.Duration
 	lakeName      string
 	searchBuffer  bool // include memory tables in read queries
+
+	// writerLock holds the exclusive flock on the SQLite catalog (when
+	// config.ExclusiveLock is set). Kept open for the writer's lifetime; closing
+	// it (on Stop) releases the lock. The OS also releases it on process exit.
+	writerLock *os.File
 
 	// Centralized single-writer flush queue. When non-nil, all DuckLake INSERT
 	// operations go through a single goroutine, eliminating catalog contention.
@@ -305,6 +318,18 @@ const writerPoolConns = 4
 
 // connect establishes connection to DuckDB and attaches DuckLake
 func (mtw *MultiTableWriter) connect() error {
+	// Guard against a second writer attaching the same SQLite catalog (two
+	// concurrent DuckLake writers corrupt it — duplicate snapshot/table ids).
+	if mtw.config.ExclusiveLock && mtw.config.CatalogPath != "" &&
+		(mtw.config.CatalogType == CatalogSQLite || mtw.config.CatalogType == "") {
+		lock, err := acquireCatalogWriterLock(mtw.config.CatalogPath)
+		if err != nil {
+			return err
+		}
+		mtw.writerLock = lock
+		logger.Info(fmt.Sprintf("DuckLake writer holds exclusive catalog lock: %s.lock", mtw.config.CatalogPath))
+	}
+
 	// SET s3_* is session-scoped: replay it on every new pooled connection.
 	// Without this, the pool can hand out a fresh connection without those
 	// settings → intermittent S3 404 / NoSuchBucket on flush.
@@ -580,6 +605,12 @@ func (mtw *MultiTableWriter) Stop() error {
 
 		if mtw.db != nil {
 			closeErr = mtw.db.Close()
+		}
+
+		// Release the exclusive catalog lock last, after the DB is closed.
+		if mtw.writerLock != nil {
+			releaseCatalogWriterLock(mtw.writerLock)
+			mtw.writerLock = nil
 		}
 	})
 	return closeErr

--- a/src/storage/ducklake/manager.go
+++ b/src/storage/ducklake/manager.go
@@ -98,6 +98,8 @@ func NewManagerFromConfig() (*Manager, error) {
 	if config.FlushInterval <= 0 {
 		config.FlushInterval = 30 * time.Second
 	}
+	// Legacy writer/ingest path: guard against a second writer on the catalog.
+	config.ExclusiveLock = true
 
 	return NewManager(config)
 }

--- a/src/storage/ducklake/writer_lock.go
+++ b/src/storage/ducklake/writer_lock.go
@@ -1,0 +1,43 @@
+package ducklake
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// acquireCatalogWriterLock takes a non-blocking exclusive OS lock (flock) on a
+// lock file derived from the SQLite catalog path. It prevents two writer
+// processes from attaching the same catalog concurrently — concurrent DuckLake
+// writers on a SQLite catalog duplicate snapshot/table ids and corrupt it
+// ("Corrupt DuckLake - multiple snapshots returned from database").
+//
+// The returned *os.File must be kept open for the lifetime of the writer;
+// closing it releases the lock. The kernel also releases the lock automatically
+// when the process exits or crashes, so there are no stale locks to clean up.
+func acquireCatalogWriterLock(catalogPath string) (*os.File, error) {
+	lockPath := catalogPath + ".lock"
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open writer lock %s: %w", lockPath, err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if err == syscall.EWOULDBLOCK {
+			return nil, fmt.Errorf("another homer writer already holds the catalog lock %s "+
+				"(refusing to start: two writers on one SQLite catalog corrupt it); "+
+				"ensure only one homer writer runs per catalog/data_path", lockPath)
+		}
+		return nil, fmt.Errorf("flock %s: %w", lockPath, err)
+	}
+	return f, nil
+}
+
+// releaseCatalogWriterLock releases and removes the writer lock file.
+func releaseCatalogWriterLock(f *os.File) {
+	if f == nil {
+		return
+	}
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	_ = f.Close()
+}

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.258"
+	VERSION_APPLICATION = "11.0.259"
 
 	// BuildDate is the build date
 	BuildDate = ""

--- a/src/writer/writer.go
+++ b/src/writer/writer.go
@@ -258,6 +258,10 @@ func New(ingestCfg *config.IngestConfig, storageCfg *config.StorageConfig, promC
 		TuningThreads:        storageCfg.DuckLake.Tuning.Threads,
 		TuningMemoryLimit:    storageCfg.DuckLake.Tuning.MemoryLimit,
 		TuningTempDirectory:  storageCfg.DuckLake.Tuning.TempDirectory,
+		// Writer path: take an exclusive catalog lock so a second writer process
+		// (e.g. a duplicate container) refuses to start instead of corrupting
+		// the SQLite catalog.
+		ExclusiveLock: true,
 	}
 
 	// S3 config


### PR DESCRIPTION
## Summary
Follow-up to #808. Addresses the second root cause behind issue #809 ("Corrupt DuckLake - multiple snapshots returned from database").

The corruption in #809 came from **two writer processes** attaching the same SQLite catalog at once (the reporter's duplicate container). Each DuckLake writer caches its snapshot/id counters in memory, so two writers allocate duplicate `ducklake_snapshot` / `ducklake_table` ids and corrupt the catalog. The reporter's recovery had to dedup `ducklake_table`/`ducklake_column`/`ducklake_schema_versions`, which only a second concurrent `CREATE TABLE` can produce.

This PR adds a single-writer guard: the writer takes a non-blocking exclusive `flock` on `<catalog_path>.lock` before attaching. A second writer refuses to start instead of corrupting the catalog. The kernel auto-releases the lock on exit/crash, so there are no stale locks.

- New `ExclusiveLock` config flag, set only on writer paths (modular writer + legacy `NewManagerFromConfig`); readers and CLI maintenance are unaffected.
- Lock acquired at the start of `connect()` (per shard catalog), released in `Stop()`.
- Bumps version to 11.0.259.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./storage/ducklake/ ./writer/ ./cli/`
- [ ] Start two writers on the same catalog/data_path -> second exits with a clear "another homer writer already holds the catalog lock" error
- [ ] Normal single-writer startup logs "DuckLake writer holds exclusive catalog lock"