### PR TITLE
feat(compaction): native engine safe alongside the live DuckDB writer (11.0.260)

### DIFF
--- a/docs/OOM.md
+++ b/docs/OOM.md
@@ -119,24 +119,28 @@ Why this helps:
 3. Reduce query range temporarily (narrower time window).
 4. Re-enable compaction only after search is stable.
 
-## 6) Native Go Compaction Engine (EXPERIMENTAL / UNSAFE)
+## 6) Native Go Compaction Engine
 
-> ⚠️ **Do not enable `engine: native` on a live writer.** It corrupts the
-> DuckLake catalog. The DuckLake writer keeps its snapshot/id counters cached in
-> DuckDB process memory and allocates new snapshot ids by incrementing that
-> cache — it does **not** re-read the SQLite catalog before each commit. The
-> native engine allocates snapshot ids out-of-band as `MAX(snapshot_id)+1` in
-> SQLite, so the next flush reuses the same id and writes a **duplicate**
-> `ducklake_snapshot` row. The search node then fails with:
+> ℹ️ **The native engine is safe to run alongside the live DuckDB writer as of
+> 11.0.260.** Earlier builds corrupted the catalog because the native engine
+> allocates snapshot ids out-of-band as `MAX(snapshot_id)+1` in SQLite, while the
+> DuckLake writer kept its snapshot/id counter cached in DuckDB memory and reused
+> the same id on its next flush — producing a **duplicate** `ducklake_snapshot`
+> row and:
 >
 > ```
 > Invalid Input Error: Corrupt DuckLake - multiple snapshots returned from database
 > ```
 >
-> The `CatalogLock` does not prevent this: it serializes the *writes*, but
-> DuckLake's id counter lives in memory and is oblivious to out-of-band SQLite
-> writes. As of 11.0.257 the engine is **opt-in** and the default is `duckdb`.
-> See "Recovering a corrupted catalog" below if you already hit this.
+> This is now prevented by a two-part protocol: (1) every native commit/reap runs
+> under the `CatalogLock`, so it never overlaps a flush's catalog `INSERT`; and
+> (2) right after each commit, **while still holding the lock**, the compactor
+> refreshes the writer's DuckLake metadata cache (`DETACH`/`ATTACH`), so the
+> writer's next flush re-reads the latest snapshot from SQLite and never reuses an
+> id the compactor allocated. The engine remains **opt-in** (default `duckdb`).
+> Note: this protects against the *compactor*; running **two writer processes**
+> on the same catalog still corrupts it — homer takes an exclusive writer lock
+> (`<catalog>.lock`) to prevent that. See "Recovering a corrupted catalog" below.
 
 The default DuckDB merge (`ducklake_merge_adjacent_files`) loads a whole
 partition into memory to sort/rewrite it. On wide SIP data (large `payload`
@@ -162,8 +166,9 @@ DuckDB for compaction. Instead it:
 
 ### Configuration
 
-The default is `duckdb`. The native engine is **opt-in** and unsafe with a live
-writer (see the warning above); only enable it if the writer is fully quiescent:
+The default is `duckdb`. The native engine is **opt-in** and safe to enable on a
+live writer (see the note above); it is the recommended choice when the DuckDB
+merge OOMs on wide SIP data:
 
 ```json
 {
@@ -241,8 +246,9 @@ of the catalog from before the native run, restoring it is the safest recovery.
 
 Requirements and behavior:
 
-- **Live-writer hazard** — see the warning at the top of this section. Only run
-  native compaction when no flush can land concurrently.
+- **Safe with a live writer** — each commit/reap holds the `CatalogLock` and then
+  refreshes the writer's DuckLake cache, so the writer never reuses a snapshot id
+  the compactor allocated (see the note at the top of this section).
 - **Local storage + SQLite catalog** — for remote (`s3://`) `data_path` or a
   missing `catalog_path`, the writer **automatically falls back to the `duckdb`
   engine**, so compaction always runs.

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -703,16 +703,18 @@ type CompactionConfig struct {
 	// working set within memory_limit on memory-capped writers.
 	MaxCompactedFiles int `json:"max_compacted_files" mapstructure:"max_compacted_files" default:"0"`
 	// Engine selects the compaction implementation:
-	//   "duckdb" — DuckLake's ducklake_merge_adjacent_files (default, safe).
-	//   "native" — EXPERIMENTAL / UNSAFE. DuckDB-free Go compactor that writes
-	//              the SQLite catalog directly. It bounds peak memory to a
-	//              single parquet row group, but it allocates snapshot ids
-	//              out-of-band (MAX(snapshot_id)+1) while the DuckLake writer
-	//              keeps its own snapshot/id counters cached in memory. A
-	//              concurrent flush then reuses the same snapshot id, producing
-	//              duplicate rows in ducklake_snapshot and corrupting the
-	//              catalog ("Corrupt DuckLake - multiple snapshots returned").
-	//              Do NOT enable unless the writer is fully quiescent.
+	//   "duckdb" — DuckLake's ducklake_merge_adjacent_files (default). Loads a
+	//              whole partition into memory, which can OOM on wide SIP data.
+	//   "native" — DuckDB-free Go compactor that concatenates a partition's
+	//              parquet row groups (peak memory ≈ one row group) and writes
+	//              the SQLite catalog directly. Safe to run alongside the live
+	//              DuckDB writer: every commit/reap runs under the catalog lock
+	//              and, while still holding it, the compactor refreshes the
+	//              writer's DuckLake metadata cache (DETACH/ATTACH) so the
+	//              writer re-reads the latest snapshot and never reuses a
+	//              snapshot id the compactor allocated. Requires a local
+	//              data_path and a SQLite catalog; otherwise it falls back to
+	//              the DuckDB merge automatically.
 	Engine string `json:"engine" mapstructure:"engine" default:"duckdb"`
 	// TargetFileSizeBytes caps each merged output file for the native engine.
 	// 0 = engine default (512MB).

--- a/src/storage/ducklake/compactor/compactor.go
+++ b/src/storage/ducklake/compactor/compactor.go
@@ -29,6 +29,12 @@ type Options struct {
 	// Both may be nil (e.g. in tests) for no locking.
 	Lock   func()
 	Unlock func()
+	// Invalidate drops the DuckLake writer's in-memory snapshot/stats cache so
+	// its next flush re-reads the catalog. It is called right after each
+	// out-of-band commit while the catalog lock is still held, so the DuckDB
+	// writer never reuses a snapshot id this compactor just allocated. May be
+	// nil (tests / no live writer).
+	Invalidate func()
 }
 
 func (o Options) lock() {
@@ -40,6 +46,12 @@ func (o Options) lock() {
 func (o Options) unlock() {
 	if o.Unlock != nil {
 		o.Unlock()
+	}
+}
+
+func (o Options) invalidate() {
+	if o.Invalidate != nil {
+		o.Invalidate()
 	}
 }
 
@@ -286,6 +298,12 @@ func compactPartition(
 				"partition", partVal, "files_deleted", reaped, "snapshots_pruned", pruned)
 		}
 	}
+
+	// Drop the DuckLake writer's cached snapshot/file-id counters while still
+	// holding the catalog lock, so the next flush re-reads this just-committed
+	// snapshot instead of reusing its id (which would corrupt the catalog).
+	opts.invalidate()
+
 	return pr, nil
 }
 

--- a/src/storage/ducklake/compactor/compactor_test.go
+++ b/src/storage/ducklake/compactor/compactor_test.go
@@ -360,3 +360,16 @@ func TestReapRemovesSupersededFiles(t *testing.T) {
 }
 
 func strptr(s string) *string { return &s }
+
+func TestOptionsInvalidate(t *testing.T) {
+	// nil Invalidate is a no-op (must not panic).
+	(Options{}).invalidate()
+
+	calls := 0
+	opts := Options{Invalidate: func() { calls++ }}
+	opts.invalidate()
+	opts.invalidate()
+	if calls != 2 {
+		t.Fatalf("invalidate() called callback %d times, want 2", calls)
+	}
+}

--- a/src/storage/ducklake/ducklake.go
+++ b/src/storage/ducklake/ducklake.go
@@ -430,10 +430,7 @@ func (mtw *MultiTableWriter) connect() error {
 	}
 
 	// Build attach statement (SQLite catalog only)
-	attachSQL := fmt.Sprintf(
-		"ATTACH 'ducklake:sqlite:%s' AS %s (DATA_PATH '%s', AUTOMATIC_MIGRATION TRUE);",
-		mtw.config.CatalogPath, mtw.config.LakeName, mtw.config.DataPath,
-	)
+	attachSQL := mtw.buildAttachSQL()
 
 	if _, err := db.Exec(attachSQL); err != nil {
 		return fmt.Errorf("failed to attach ducklake: %w", err)
@@ -456,6 +453,44 @@ func (mtw *MultiTableWriter) connect() error {
 		}
 	}
 
+	return nil
+}
+
+// buildAttachSQL returns the ATTACH statement for this writer's DuckLake catalog.
+func (mtw *MultiTableWriter) buildAttachSQL() string {
+	return fmt.Sprintf(
+		"ATTACH 'ducklake:sqlite:%s' AS %s (DATA_PATH '%s', AUTOMATIC_MIGRATION TRUE);",
+		mtw.config.CatalogPath, mtw.config.LakeName, mtw.config.DataPath,
+	)
+}
+
+// refreshCatalogCache drops DuckLake's in-memory snapshot/stats cache by
+// detaching and re-attaching the catalog, so the next flush re-reads the latest
+// snapshot_id / next_file_id from the SQLite catalog.
+//
+// This is required after the native compactor commits a snapshot out-of-band
+// (through a separate SQLite connection): without it, the DuckDB writer keeps
+// allocating ids from its stale cached counter and collides with the
+// compactor's snapshot ("Corrupt DuckLake - multiple snapshots returned").
+//
+// The caller MUST hold the catalog lock (CatalogLock) so no flush runs during
+// the DETACH/ATTACH. Best-effort: on failure the catalog is left as-is and the
+// error is returned so the caller can log it.
+func (mtw *MultiTableWriter) refreshCatalogCache() error {
+	if mtw.db == nil {
+		return nil
+	}
+	if _, err := mtw.db.Exec(fmt.Sprintf("DETACH %s;", mtw.config.LakeName)); err != nil {
+		return fmt.Errorf("detach %s: %w", mtw.config.LakeName, err)
+	}
+	if _, err := mtw.db.Exec(mtw.buildAttachSQL()); err != nil {
+		return fmt.Errorf("re-attach %s: %w", mtw.config.LakeName, err)
+	}
+	if mtw.config.DataInliningRowLimit >= 0 {
+		_, _ = mtw.db.Exec(fmt.Sprintf(
+			"CALL %s.set_option('DATA_INLINING_ROW_LIMIT', %d);",
+			mtw.config.LakeName, mtw.config.DataInliningRowLimit))
+	}
 	return nil
 }
 

--- a/src/storage/ducklake/manager.go
+++ b/src/storage/ducklake/manager.go
@@ -242,6 +242,12 @@ func (m *Manager) CatalogUnlock() {
 	m.sharded.CatalogUnlock()
 }
 
+// RefreshCatalogCache drops the DuckLake metadata cache on every shard so the
+// next flush re-reads the catalog. Must be called while holding CatalogLock.
+func (m *Manager) RefreshCatalogCache() error {
+	return m.sharded.RefreshCatalogCache()
+}
+
 // GetDB returns the primary shard's DuckDB connection (for compaction/maintenance)
 func (m *Manager) GetDB() *sql.DB {
 	return m.sharded.Primary().GetDB()

--- a/src/storage/ducklake/sharded_writer.go
+++ b/src/storage/ducklake/sharded_writer.go
@@ -141,3 +141,18 @@ func (sw *ShardedWriter) CatalogUnlock() {
 		sw.shards[i].CatalogUnlock()
 	}
 }
+
+// RefreshCatalogCache drops the DuckLake metadata cache on every shard so the
+// next flush re-reads the catalog. It must be called while holding CatalogLock
+// (the native compactor invokes it right after committing a snapshot, so the
+// DuckDB writer never reuses a snapshot id the compactor allocated). Returns
+// the first shard error, if any.
+func (sw *ShardedWriter) RefreshCatalogCache() error {
+	var firstErr error
+	for _, s := range sw.shards {
+		if err := s.refreshCatalogCache(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.259"
+	VERSION_APPLICATION = "11.0.260"
 
 	// BuildDate is the build date
 	BuildDate = ""

--- a/src/writer/compaction.go
+++ b/src/writer/compaction.go
@@ -140,6 +140,15 @@ type CatalogLocker interface {
 	CatalogUnlock()
 }
 
+// CatalogRefresher drops the DuckLake writer's in-memory snapshot/stats cache so
+// its next flush re-reads the catalog. The native compactor calls it right after
+// each out-of-band commit (while holding the catalog lock) so the live DuckDB
+// writer never reuses a snapshot id the compactor allocated. Implemented by the
+// DuckLake Manager.
+type CatalogRefresher interface {
+	RefreshCatalogCache() error
+}
+
 // CompactionS3Client holds DuckDB httpfs S3 settings for maintenance calls that
 // read s3:// objects (ducklake_cleanup_old_files / ducklake_delete_orphaned_files).
 // Some DuckLake versions appear to evaluate read_blob without inheriting prior
@@ -623,24 +632,35 @@ func (c *CompactionService) runMerge(tables []string) error {
 }
 
 // useNativeEngine reports whether the native compactor should run. The native
-// engine is OPT-IN and UNSAFE: the default (empty engine) and "duckdb" both use
-// the DuckLake merge. Native writes the SQLite catalog out-of-band, which
-// corrupts the catalog when the DuckLake writer is concurrently flushing (it
-// reuses snapshot ids cached in DuckDB memory → duplicate ducklake_snapshot
-// rows). It also requires local storage and a SQLite catalog.
+// engine is OPT-IN (the default empty engine and "duckdb" both use the DuckLake
+// merge). It writes the SQLite catalog out-of-band, but it is safe to run
+// alongside the live DuckDB writer because: (1) each commit/reap runs under the
+// CatalogLock, so it never overlaps a flush's catalog INSERT, and (2) right
+// after every commit it refreshes the writer's DuckLake metadata cache (see
+// CatalogRefresher), so the writer re-reads the latest snapshot and never reuses
+// a snapshot id the compactor allocated. It requires local storage and a SQLite
+// catalog; otherwise the caller falls back to the DuckDB merge.
 func (c *CompactionService) useNativeEngine() bool {
 	if c.config.Engine != EngineNativeGo {
-		// empty/default and "duckdb" → DuckLake merge (safe).
+		// empty/default and "duckdb" → DuckLake merge.
 		return false
 	}
-	logger.Warn("CompactionService: native compaction engine is EXPERIMENTAL and can corrupt "+
-		"the DuckLake catalog when the writer flushes concurrently (duplicate snapshot ids); "+
-		"prefer engine=duckdb unless the writer is quiescent",
-		"lake", c.lakeName)
 	if ducklake.IsRemoteLakeDataPath(c.dataPath) {
 		return false
 	}
-	return strings.TrimSpace(c.catalogPath) != ""
+	if strings.TrimSpace(c.catalogPath) == "" {
+		return false
+	}
+	if _, ok := c.catalogLocker.(CatalogRefresher); !ok {
+		// Without a way to refresh the writer's cache after a commit, the native
+		// engine could race the live writer's snapshot-id allocation. Fall back
+		// to the DuckDB merge rather than risk catalog corruption.
+		logger.Warn("CompactionService: native engine selected but the catalog locker cannot "+
+			"refresh the writer cache; falling back to the DuckDB merge",
+			"lake", c.lakeName)
+		return false
+	}
+	return true
 }
 
 // runNativeMerge compacts every table with the DuckDB-free Go compactor. Each
@@ -669,6 +689,22 @@ func (c *CompactionService) runNativeMerge(tables []string) error {
 		unlockFn = c.catalogLocker.CatalogUnlock
 	}
 
+	// invalidateFn lets the native compactor drop the live DuckDB writer's
+	// DuckLake metadata cache right after each commit (still under the catalog
+	// lock), so the writer's next flush re-reads the catalog and never reuses a
+	// snapshot id the compactor just allocated. This is what makes the native
+	// engine safe to run alongside the live DuckDB writer.
+	var invalidateFn func()
+	if r, ok := c.catalogLocker.(CatalogRefresher); ok {
+		invalidateFn = func() {
+			if err := r.RefreshCatalogCache(); err != nil {
+				logger.Warn("CompactionService: catalog cache refresh after native commit failed; "+
+					"next flush may briefly retry on a snapshot conflict",
+					"lake", c.lakeName, "error", err)
+			}
+		}
+	}
+
 	retention := time.Duration(c.config.SnapshotExpireIntervalSec) * time.Second
 	for _, table := range tables {
 		tableName := tableNameFromFQN(table)
@@ -684,6 +720,7 @@ func (c *CompactionService) runNativeMerge(tables []string) error {
 			SnapshotRetention:   retention,
 			Lock:                lockFn,
 			Unlock:              unlockFn,
+			Invalidate:          invalidateFn,
 		}, tableName)
 		if err != nil {
 			logger.Warn("CompactionService: native merge failed", "table", tableName, "error", err)


### PR DESCRIPTION
## Summary
Makes the native (DuckDB-free) compaction engine **safe to run alongside the live DuckDB writer**, so you get its bounded-memory merge without the catalog corruption (`Corrupt DuckLake - multiple snapshots returned`).

Stacked on #810 (writer lock). Base will switch to `homer11` once #810 merges.

**Root cause:** native writes the SQLite catalog out-of-band (`MAX(snapshot_id)+1`), while DuckLake caches its snapshot/file-id counter in DuckDB memory and reused the id on its next flush → duplicate `ducklake_snapshot`.

**Fix — two-part coordination:**
1. Every native commit/reap already runs under the `CatalogLock`; each flush is a single `db.Exec` held under `catalogMu`, so no DuckDB transaction spans the lock boundary (no overlap).
2. Right after each commit, **still holding the lock**, the compactor refreshes the writer's DuckLake metadata cache via `DETACH`/`ATTACH` (`MultiTableWriter.refreshCatalogCache` → `ShardedWriter`/`Manager.RefreshCatalogCache`, wired through a `CatalogRefresher` passed as `compactor.Options.Invalidate`). The writer's next flush re-reads the latest snapshot and never reuses an id.

`useNativeEngine` now falls back to the DuckDB merge if the locker can't refresh the cache, so native can never silently race the writer. Default stays `duckdb`; native is opt-in and documented safe with a live writer.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./storage/ducklake/... ./writer/...` (incl. compactor commit/reap + new invalidate hook test)
- [ ] Enable `engine: native` on a live writer under ingest load; confirm compaction runs, no `Corrupt DuckLake` errors, snapshot ids strictly increasing