### PR TITLE
feat(node): configurable lake top-N strategy (chunked|stream|full)

### DIFF
--- a/docs/OOM.md
+++ b/docs/OOM.md
@@ -119,6 +119,38 @@ Why this helps:
 3. Reduce query range temporarily (narrower time window).
 4. Re-enable compaction only after search is stable.
 
+## 5b) Read-Path OOM: Long-Range `ORDER BY timestamp DESC LIMIT N`
+
+A `SELECT * ... WHERE timestamp >= A AND timestamp < B ORDER BY timestamp DESC
+LIMIT N` over a wide range (e.g. 24h) can OOM even with `split_lake_and_mem`
+active: the lake sub-query still has to feed DuckDB's Top-N operator from a
+full-range scan, and for payload-heavy SIP rows the operator buffers more than a
+small `memory_limit` allows.
+
+`storage.ducklake.search.lake_topn_strategy` controls how that lake sub-query is
+executed (it only applies to timestamp-DESC top-N queries over a range wider than
+one hour):
+
+| Strategy  | Memory | Ordering | Notes |
+|-----------|--------|----------|-------|
+| `chunked` (default) | bounded to one window | newest-first, exact | Scans descending time windows (`lake_chunk_sec` wide), newest first, stops once N rows are collected. Recommended. |
+| `stream`  | minimal | scan order, **not** guaranteed newest-N | Drops `ORDER BY` and uses a plain streaming `LIMIT`; fastest and lowest memory, but may not return the strictly newest rows. |
+| `full`    | unbounded | newest-first, exact | Original single ORDER BY scan over the whole range — can OOM on wide data. |
+
+```jsonc
+"storage": {
+  "ducklake": {
+    "search": {
+      "lake_topn_strategy": "chunked", // chunked | stream | full
+      "lake_chunk_sec": 3600            // window width for "chunked"
+    }
+  }
+}
+```
+
+The chosen strategy is reflected in the execution-plan log line
+(`mode=split_lake_and_mem:chunked|stream|full`, plus `lake_chunks` for chunked).
+
 ## 6) Native Go Compaction Engine
 
 > ℹ️ **The native engine is safe to run alongside the live DuckDB writer as of

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -646,6 +646,29 @@ type DuckLakeConfig struct {
 	Compaction           CompactionConfig    `json:"compaction" mapstructure:"compaction"`
 	StoragePolicy        StoragePolicyConfig `json:"storage_policy" mapstructure:"storage_policy"`
 	Volumes              []VolumeConfig      `json:"volumes" mapstructure:"volumes"` // Direct volumes config (alternative to storage_policy for read-only nodes)
+	Search               SearchConfig        `json:"search" mapstructure:"search"`
+}
+
+// SearchConfig tunes how the read/query path executes long-range searches.
+type SearchConfig struct {
+	// LakeTopNStrategy selects how a long-range `ORDER BY timestamp DESC LIMIT N`
+	// lake query is executed (it only applies when the split planner already
+	// decided the query is a timestamp-DESC top-N over a range wider than one
+	// hour):
+	//   "chunked" (default) — scan descending time windows (LakeChunkSec wide),
+	//        newest first, stopping once N rows are gathered. Preserves
+	//        newest-first ordering while bounding peak memory to one window.
+	//        Avoids the OOM the whole-range scan hits on wide SIP rows.
+	//   "stream"  — drop the ORDER BY and use a plain streaming LIMIT. DuckDB
+	//        stops after N rows so memory stays tiny and it is the fastest, but
+	//        the rows are in scan order, NOT guaranteed to be the newest N.
+	//   "full"    — original single ORDER BY scan over the whole range (can OOM
+	//        on wide data under a small memory_limit).
+	LakeTopNStrategy string `json:"lake_topn_strategy" mapstructure:"lake_topn_strategy" default:"chunked"`
+	// LakeChunkSec is the time-window width (seconds) for the "chunked" strategy.
+	// Smaller windows bound memory tighter at the cost of more sub-queries when
+	// data is sparse. Default 3600 (1 hour).
+	LakeChunkSec int `json:"lake_chunk_sec" mapstructure:"lake_chunk_sec" default:"3600"`
 }
 
 // StoragePolicyConfig configures tiered storage with hot and cold volumes

--- a/src/node/lake_topn_test.go
+++ b/src/node/lake_topn_test.go
@@ -1,0 +1,70 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/sipcapture/homer-core/src/config"
+)
+
+func TestStripOrderByForStream(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "order by desc with limit",
+			in:   "SELECT * FROM t WHERE timestamp >= 1 AND timestamp < 2 ORDER BY timestamp DESC LIMIT 500",
+			want: "SELECT * FROM t WHERE timestamp >= 1 AND timestamp < 2 LIMIT 500",
+		},
+		{
+			name: "no order by is unchanged",
+			in:   "SELECT * FROM t WHERE timestamp >= 1 LIMIT 10",
+			want: "SELECT * FROM t WHERE timestamp >= 1 LIMIT 10",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stripOrderByForStream(tc.in); got != tc.want {
+				t.Fatalf("stripOrderByForStream()\n got=%q\nwant=%q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLakeTopNStrategy(t *testing.T) {
+	cases := map[string]string{
+		"":        lakeTopNChunked,
+		"chunked": lakeTopNChunked,
+		"stream":  lakeTopNStream,
+		"full":    lakeTopNFull,
+		"bogus":   lakeTopNChunked,
+	}
+	for in, want := range cases {
+		n := &Node{config: &config.NodeConfig{
+			DuckLake: config.DuckLakeConfig{Search: config.SearchConfig{LakeTopNStrategy: in}},
+		}}
+		if got := n.lakeTopNStrategy(); got != want {
+			t.Errorf("lakeTopNStrategy(%q)=%q want %q", in, got, want)
+		}
+	}
+	if got := (&Node{}).lakeTopNStrategy(); got != lakeTopNChunked {
+		t.Errorf("nil config: got %q want %q", got, lakeTopNChunked)
+	}
+}
+
+func TestLakeChunkMs(t *testing.T) {
+	if got := (&Node{}).lakeChunkMs(); got != defaultLakeTimeChunkMs {
+		t.Errorf("nil config: got %d want %d", got, defaultLakeTimeChunkMs)
+	}
+	n := &Node{config: &config.NodeConfig{
+		DuckLake: config.DuckLakeConfig{Search: config.SearchConfig{LakeChunkSec: 0}},
+	}}
+	if got := n.lakeChunkMs(); got != defaultLakeTimeChunkMs {
+		t.Errorf("zero: got %d want %d", got, defaultLakeTimeChunkMs)
+	}
+	n.config.DuckLake.Search.LakeChunkSec = 300
+	if got := n.lakeChunkMs(); got != 300_000 {
+		t.Errorf("300s: got %d want 300000", got)
+	}
+}

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -549,6 +549,7 @@ type sharedQueryPlanLog struct {
 	lakeSQL     string
 	memSQL      string
 	combinedSQL string
+	lakeChunks  int // number of time chunks the lake sub-query was split into
 }
 
 func normalizeSQLWhitespace(s string) string {
@@ -556,20 +557,139 @@ func normalizeSQLWhitespace(s string) string {
 }
 
 func memorySplitRangeMs(sql string) (int64, bool) {
-	fromM := sqlTimestampFromRegexp.FindStringSubmatch(sql)
-	toM := sqlTimestampToRegexp.FindStringSubmatch(sql)
-	if len(fromM) < 2 || len(toM) < 2 {
-		return 0, false
-	}
-	fromMs, err := strconv.ParseInt(fromM[1], 10, 64)
-	if err != nil {
-		return 0, false
-	}
-	toMs, err := strconv.ParseInt(toM[1], 10, 64)
-	if err != nil || toMs <= fromMs {
+	fromMs, toMs, ok := memorySplitBoundsMs(sql)
+	if !ok {
 		return 0, false
 	}
 	return toMs - fromMs, true
+}
+
+// memorySplitBoundsMs extracts the [from, to) epoch-millisecond bounds of the
+// `timestamp >= ... AND timestamp < ...` predicate the UI builds for a search.
+func memorySplitBoundsMs(sql string) (int64, int64, bool) {
+	fromM := sqlTimestampFromRegexp.FindStringSubmatch(sql)
+	toM := sqlTimestampToRegexp.FindStringSubmatch(sql)
+	if len(fromM) < 2 || len(toM) < 2 {
+		return 0, 0, false
+	}
+	fromMs, err := strconv.ParseInt(fromM[1], 10, 64)
+	if err != nil {
+		return 0, 0, false
+	}
+	toMs, err := strconv.ParseInt(toM[1], 10, 64)
+	if err != nil || toMs <= fromMs {
+		return 0, 0, false
+	}
+	return fromMs, toMs, true
+}
+
+// Lake top-N execution strategies (storage.ducklake.search.lake_topn_strategy).
+const (
+	lakeTopNChunked = "chunked" // descending time windows, newest first, early stop
+	lakeTopNStream  = "stream"  // drop ORDER BY, plain streaming LIMIT (scan order)
+	lakeTopNFull    = "full"    // original single ORDER BY scan over the whole range
+)
+
+// defaultLakeTimeChunkMs is the fallback chunk width when search.lake_chunk_sec
+// is unset. One hour keeps the per-chunk scan (wide SELECT * over payload-heavy
+// SIP rows) well within a small memory_limit, where scanning the whole range at
+// once OOMs.
+const defaultLakeTimeChunkMs = int64(time.Hour / time.Millisecond)
+
+// lakeTopNStrategy returns the configured lake top-N execution strategy,
+// defaulting to "chunked".
+func (n *Node) lakeTopNStrategy() string {
+	if n.config == nil {
+		return lakeTopNChunked
+	}
+	switch n.config.DuckLake.Search.LakeTopNStrategy {
+	case lakeTopNStream:
+		return lakeTopNStream
+	case lakeTopNFull:
+		return lakeTopNFull
+	default:
+		return lakeTopNChunked
+	}
+}
+
+// lakeChunkMs returns the configured chunk width (ms) for the "chunked"
+// strategy, defaulting to one hour.
+func (n *Node) lakeChunkMs() int64 {
+	if n.config == nil || n.config.DuckLake.Search.LakeChunkSec <= 0 {
+		return defaultLakeTimeChunkMs
+	}
+	return int64(n.config.DuckLake.Search.LakeChunkSec) * 1000
+}
+
+// stripOrderByForStream rewrites a `... ORDER BY timestamp DESC LIMIT N` query
+// into `... LIMIT N` (no ORDER BY). DuckDB then stops scanning after N rows, so
+// memory stays tiny — at the cost of returning rows in scan order rather than
+// strictly newest-first.
+func stripOrderByForStream(sql string) string {
+	orderByClause, limitClause, base := extractOrderLimit(sql)
+	if orderByClause == "" {
+		return sql
+	}
+	out := strings.TrimSpace(base)
+	if limitClause != "" {
+		out += " " + limitClause
+	}
+	return out
+}
+
+// rewriteTimestampBoundsMs replaces the timestamp range predicate in a search
+// SQL with new [from, to) epoch-millisecond bounds, preserving the exact shape
+// DuckDB/DuckLake expect.
+func rewriteTimestampBoundsMs(sql string, fromMs, toMs int64) string {
+	sql = sqlTimestampFromRegexp.ReplaceAllString(sql,
+		fmt.Sprintf("timestamp >= (to_timestamp(%d / 1000.0) AT TIME ZONE 'UTC')", fromMs))
+	sql = sqlTimestampToRegexp.ReplaceAllString(sql,
+		fmt.Sprintf("timestamp < (to_timestamp(%d / 1000.0) AT TIME ZONE 'UTC')", toMs))
+	return sql
+}
+
+// runLakeSplitByTime executes a timestamp-DESC top-N lake query in descending
+// time chunks (newest first), stopping as soon as it has gathered `limit` rows.
+// Because the chunks are disjoint and processed newest→oldest, once `limit` rows
+// are collected no older chunk can contribute to the top-N, so the scan stops
+// early. Each chunk scans at most lakeTimeChunkMs of data, bounding peak memory
+// regardless of the overall range (the whole-range scan OOMs on wide SIP rows).
+func (n *Node) runLakeSplitByTime(
+	ctx context.Context, db *sql.DB, lakeSQL string, fromMs, toMs, chunkMs int64, limit int,
+) ([]map[string]interface{}, []string, int, error) {
+	if chunkMs <= 0 {
+		chunkMs = defaultLakeTimeChunkMs
+	}
+	var all []map[string]interface{}
+	var cols []string
+	chunks := 0
+	for hi := toMs; hi > fromMs; hi -= chunkMs {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, chunks, err
+		}
+		lo := hi - chunkMs
+		if lo < fromMs {
+			lo = fromMs
+		}
+		chunkSQL := rewriteTimestampBoundsMs(lakeSQL, lo, hi)
+		data, c, err := runSelectQuery(ctx, db, chunkSQL)
+		if err != nil {
+			return nil, nil, chunks, err
+		}
+		chunks++
+		if len(c) > 0 {
+			cols = c
+		}
+		all = append(all, data...)
+		if limit > 0 && len(all) >= limit {
+			break
+		}
+	}
+	// Chunks arrive newest-first and each is already DESC, but normalise the
+	// concatenation (sort DESC, dedup, apply limit) so the contract matches a
+	// single ORDER BY timestamp DESC LIMIT query.
+	merged, mcols := mergeSelectResults(all, nil, cols, nil, limit)
+	return merged, mcols, chunks, nil
 }
 
 func sqlSplitSafeForTimestampTopN(sql, baseSQL, orderByClause, limitClause string) bool {
@@ -682,7 +802,31 @@ func (n *Node) runSharedSelectWithMemoryPolicy(ctx context.Context, db *sql.DB, 
 		plan.lakeSQL = mq.lakeSQL
 		plan.memSQL = mq.memSQL
 		plan.combinedSQL = ""
-		lakeData, lakeCols, err := runSelectQuery(ctx, db, mq.lakeSQL)
+		limitN := extractSQLLimit(sql)
+		// The lake sub-query (SELECT * ORDER BY timestamp DESC LIMIT N over a long
+		// range) is what OOMs on payload-heavy SIP rows under a small memory_limit.
+		// search.lake_topn_strategy picks how to run it.
+		var lakeData []map[string]interface{}
+		var lakeCols []string
+		var err error
+		switch n.lakeTopNStrategy() {
+		case lakeTopNFull:
+			plan.mode = "split_lake_and_mem:full"
+			lakeData, lakeCols, err = runSelectQuery(ctx, db, mq.lakeSQL)
+		case lakeTopNStream:
+			plan.mode = "split_lake_and_mem:stream"
+			streamSQL := stripOrderByForStream(mq.lakeSQL)
+			plan.lakeSQL = streamSQL
+			lakeData, lakeCols, err = runSelectQuery(ctx, db, streamSQL)
+		default: // lakeTopNChunked
+			plan.mode = "split_lake_and_mem:chunked"
+			if fromMs, toMs, ok := memorySplitBoundsMs(mq.lakeSQL); ok {
+				lakeData, lakeCols, plan.lakeChunks, err = n.runLakeSplitByTime(
+					ctx, db, mq.lakeSQL, fromMs, toMs, n.lakeChunkMs(), limitN)
+			} else {
+				lakeData, lakeCols, err = runSelectQuery(ctx, db, mq.lakeSQL)
+			}
+		}
 		if err != nil {
 			return nil, nil, plan, fmt.Errorf("lake query: %w", err)
 		}
@@ -690,8 +834,7 @@ func (n *Node) runSharedSelectWithMemoryPolicy(ctx context.Context, db *sql.DB, 
 		if err != nil {
 			return nil, nil, plan, fmt.Errorf("memory query: %w", err)
 		}
-		limit := extractSQLLimit(sql)
-		merged, cols := mergeSelectResults(lakeData, memData, lakeCols, memCols, limit)
+		merged, cols := mergeSelectResults(lakeData, memData, lakeCols, memCols, limitN)
 		return merged, cols, plan, nil
 	}
 	plan.mode = "single_union"
@@ -787,7 +930,7 @@ func (n *Node) handleQuery(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sharedResults, sharedCols, sharedPlan, err := n.runSharedSelectWithMemoryPolicy(r.Context(), db, rewrittenSQL)
-	logger.Info("Node: handleQuery execution plan", "mode", sharedPlan.mode)
+	logger.Info("Node: handleQuery execution plan", "mode", sharedPlan.mode, "lake_chunks", sharedPlan.lakeChunks)
 	logger.Debug("Node: handleQuery execution plan",
 		"mode", sharedPlan.mode,
 		"lake_sql", sharedPlan.lakeSQL,

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.260"
+	VERSION_APPLICATION = "11.0.261"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Adds `storage.ducklake.search.lake_topn_strategy` to control how long-range `ORDER BY timestamp DESC LIMIT N` lake queries run, fixing read-path OOM on payload-heavy SIP rows.
- **chunked** (default): scan descending time windows (`lake_chunk_sec`, default 3600s) newest-first, stop once N rows are gathered. Bounded memory, exact newest-first order.
- **stream**: drop `ORDER BY`, plain streaming `LIMIT`. Minimal memory, fastest, but rows are in scan order (not guaranteed newest-N).
- **full**: original single ORDER BY scan over the whole range (can OOM).
- Strategy surfaced in the execution-plan log (`mode=split_lake_and_mem:<strategy>`, `lake_chunks`).
- Bumps version to 11.0.261, documents in `docs/OOM.md`.

## Notes
Stacked on top of `feat/native-compactor-live-coexist-11.0.260`. Merge that first (or retarget to `homer11` after it lands).

## Test plan
- [x] `go build ./...`, `go vet ./node/... ./config/...`
- [x] New unit tests: `TestStripOrderByForStream`, `TestLakeTopNStrategy`, `TestLakeChunkMs`
- [ ] Verify search over 24h with low `memory_limit` no longer OOMs (chunked) and respects `stream`/`full`