### PR TITLE
feat(ducklake): startup autofix for Corrupt DuckLake (multiple snapshots)

### DIFF
--- a/docs/OOM.md
+++ b/docs/OOM.md
@@ -226,7 +226,21 @@ recommended, catalog-safe path.
 If you already see `Corrupt DuckLake - multiple snapshots returned from
 database`, the SQLite catalog has duplicate `snapshot_id` rows.
 
-**Preferred: rebuild the catalog from disk.** Stop the Homer writer, then run:
+**Automatic (default).** On startup the writer runs a lossless autofix
+(`storage.ducklake.auto_repair_catalog`, default enabled) that collapses
+duplicate `ducklake_snapshot` / `ducklake_table` rows — keeping the most
+recently written row, which still references the same Parquet files. It runs
+before the catalog is attached, while the writer holds the exclusive lock, so it
+fixes the corruption on the next restart with no data loss and no manual step.
+The repair logs a warning listing how many duplicate rows it removed. Disable
+with:
+
+```jsonc
+"storage": { "ducklake": { "auto_repair_catalog": false } }
+```
+
+**If the autofix cannot recover it** (e.g. corruption beyond duplicate metadata
+rows), rebuild the catalog from disk. Stop the Homer writer, then run:
 
 ```bash
 homer system --config-path /etc/homer/config.json --rebuild-catalog

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -626,6 +626,11 @@ type DuckLakeConfig struct {
 	SearchBuffer  bool   `json:"search_buffer" mapstructure:"search_buffer" default:"false"`
 	ShardCount    int    `json:"shard_count" mapstructure:"shard_count" default:"1"`
 	FlushQueue    *bool  `json:"flush_queue" mapstructure:"flush_queue"` // nil = auto (true for SQLite), explicit true/false overrides
+	// AutoRepairCatalog runs a startup catalog autofix that removes duplicate
+	// snapshot/table metadata rows causing "Corrupt DuckLake - multiple
+	// snapshots returned from database". Lossless for data. nil = enabled
+	// (default); set false to disable.
+	AutoRepairCatalog *bool `json:"auto_repair_catalog" mapstructure:"auto_repair_catalog"`
 	// DataInliningRowLimit controls the DuckLake data inlining threshold (DuckLake v1.0).
 	// Writes of ≤N rows are stored directly in the catalog database instead of creating
 	// small Parquet files.

--- a/src/storage/ducklake/ducklake.go
+++ b/src/storage/ducklake/ducklake.go
@@ -101,6 +101,12 @@ type Config struct {
 	// "Corrupt DuckLake - multiple snapshots returned"). Set only on writer
 	// paths; readers and CLI maintenance leave it false.
 	ExclusiveLock bool
+
+	// AutoRepairCatalog, when true, runs RepairCatalogSnapshots on startup
+	// (before ATTACH) to remove duplicate snapshot/table metadata rows that
+	// cause "Corrupt DuckLake - multiple snapshots returned from database".
+	// Lossless for data; only conflicting duplicate metadata rows are dropped.
+	AutoRepairCatalog bool
 }
 
 // isS3Path checks if path is an S3 URL
@@ -414,6 +420,23 @@ func (mtw *MultiTableWriter) connect() error {
 		logger.Warn("DuckLake inline GC failed (non-fatal)", "err", err)
 	} else if n > 0 {
 		logger.Info("DuckLake inline GC: dropped empty ducklake_inlined_data_* tables (upstream #1065)", "dropped", n)
+	}
+
+	// Autofix the "Corrupt DuckLake - multiple snapshots returned" corruption
+	// before ATTACH, while we still have exclusive access to the sqlite file.
+	// Lossless: only duplicate snapshot/table metadata rows are collapsed.
+	if mtw.config.AutoRepairCatalog &&
+		(mtw.config.CatalogType == CatalogSQLite || mtw.config.CatalogType == "") {
+		if res, err := RepairCatalogSnapshots(mtw.config.CatalogPath); err != nil {
+			logger.Warn("DuckLake catalog auto-repair failed (non-fatal); "+
+				"run `homer system --rebuild-catalog` if queries still error", "err", err)
+		} else if res.Changed() {
+			logger.Warn("DuckLake catalog auto-repair: removed duplicate metadata rows "+
+				"(fixed 'Corrupt DuckLake - multiple snapshots returned')",
+				"duplicate_snapshots", res.DuplicateSnapshots,
+				"duplicate_tables", res.DuplicateTables,
+				"catalog", mtw.config.CatalogPath)
+		}
 	}
 
 	// SET s3_* is applied per pooled connection by the connector init above.

--- a/src/storage/ducklake/manager.go
+++ b/src/storage/ducklake/manager.go
@@ -98,8 +98,10 @@ func NewManagerFromConfig() (*Manager, error) {
 	if config.FlushInterval <= 0 {
 		config.FlushInterval = 30 * time.Second
 	}
-	// Legacy writer/ingest path: guard against a second writer on the catalog.
+	// Legacy writer/ingest path: guard against a second writer on the catalog
+	// and autofix duplicate-snapshot corruption on startup.
 	config.ExclusiveLock = true
+	config.AutoRepairCatalog = true
 
 	return NewManager(config)
 }

--- a/src/storage/ducklake/repair.go
+++ b/src/storage/ducklake/repair.go
@@ -1,0 +1,120 @@
+package ducklake
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+
+	_ "modernc.org/sqlite" // pure-Go SQLite driver for out-of-band catalog repair
+)
+
+// RepairResult summarizes what a startup catalog repair changed.
+type RepairResult struct {
+	DuplicateSnapshots int // ducklake_snapshot rows removed
+	DuplicateTables    int // ducklake_table rows removed
+}
+
+// Changed reports whether the repair removed anything.
+func (r RepairResult) Changed() bool {
+	return r.DuplicateSnapshots > 0 || r.DuplicateTables > 0
+}
+
+// RepairCatalogSnapshots removes duplicate metadata rows from a DuckLake SQLite
+// catalog that produce the fatal "Corrupt DuckLake - multiple snapshots
+// returned from database" error.
+//
+// Root cause: when two writers (or a writer + an out-of-band native compactor)
+// committed against the same SQLite catalog without coordination, they could
+// insert two rows sharing the same snapshot_id (or table_id). DuckLake's
+// get-by-id reads then return >1 row and abort the whole query path.
+//
+// The fix is surgical and lossless for data: for each duplicated key we keep
+// the most recently written row (highest rowid) and delete the rest. The kept
+// row still references the same Parquet data files, so no data is lost — only
+// the conflicting duplicate metadata rows are dropped.
+//
+// MUST be called while no other process has the catalog open (the same
+// pre-ATTACH window GCOrphanInlineTables uses). Best-effort: a missing file or
+// missing tables is a no-op; any operation error is returned so the caller can
+// log it and continue (the worst case is the original corruption error, which
+// the operator can still fix with `homer system --rebuild-catalog`).
+func RepairCatalogSnapshots(catalogPath string) (RepairResult, error) {
+	var res RepairResult
+	if catalogPath == "" {
+		return res, nil
+	}
+	if _, err := os.Stat(catalogPath); os.IsNotExist(err) {
+		return res, nil // fresh catalog, nothing to repair
+	}
+
+	dsn := fmt.Sprintf("file:%s?_pragma=busy_timeout(30000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(0)", catalogPath)
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return res, fmt.Errorf("open catalog for repair: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	defer db.Close()
+	if err := db.Ping(); err != nil {
+		return res, fmt.Errorf("ping catalog for repair: %w", err)
+	}
+
+	// ducklake_snapshot: collapse duplicate snapshot_id rows, keeping the last.
+	if exists, _ := sqliteTableExists(db, "ducklake_snapshot"); exists {
+		n, err := dedupeByKey(db, "ducklake_snapshot", "snapshot_id")
+		if err != nil {
+			return res, err
+		}
+		res.DuplicateSnapshots = n
+	}
+
+	// ducklake_table: duplicate table_id rows are the secondary corruption two
+	// concurrent writers create (duplicate table registration). Same fix.
+	if exists, _ := sqliteTableExists(db, "ducklake_table"); exists {
+		n, err := dedupeByKey(db, "ducklake_table", "table_id")
+		if err != nil {
+			return res, err
+		}
+		res.DuplicateTables = n
+	}
+
+	return res, nil
+}
+
+// sqliteTableExists reports whether a table is present in the SQLite schema.
+func sqliteTableExists(db *sql.DB, name string) (bool, error) {
+	var x int
+	err := db.QueryRow(
+		"SELECT 1 FROM sqlite_master WHERE type='table' AND name=? LIMIT 1", name).Scan(&x)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+// dedupeByKey deletes rows of table sharing the same keyCol value, keeping the
+// one with the highest rowid (the most recently written). Returns the number of
+// rows removed. The DELETE runs in a single implicit transaction.
+func dedupeByKey(db *sql.DB, table, keyCol string) (int, error) {
+	// Count duplicates first so we can skip the (locking) DELETE on a healthy
+	// catalog — the common case on every startup.
+	var dupRows int
+	countSQL := fmt.Sprintf(
+		`SELECT COALESCE(SUM(c-1),0) FROM (SELECT COUNT(*) c FROM "%s" GROUP BY "%s" HAVING c>1)`,
+		table, keyCol)
+	if err := db.QueryRow(countSQL).Scan(&dupRows); err != nil {
+		return 0, fmt.Errorf("count duplicate %s: %w", keyCol, err)
+	}
+	if dupRows == 0 {
+		return 0, nil
+	}
+
+	delSQL := fmt.Sprintf(
+		`DELETE FROM "%s" WHERE rowid NOT IN (SELECT MAX(rowid) FROM "%s" GROUP BY "%s")`,
+		table, table, keyCol)
+	resExec, err := db.Exec(delSQL)
+	if err != nil {
+		return 0, fmt.Errorf("dedupe %s by %s: %w", table, keyCol, err)
+	}
+	n, _ := resExec.RowsAffected()
+	return int(n), nil
+}

--- a/src/storage/ducklake/repair_test.go
+++ b/src/storage/ducklake/repair_test.go
@@ -1,0 +1,104 @@
+package ducklake
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func openTestCatalog(t *testing.T, path string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func TestRepairCatalogSnapshots(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "catalog.sqlite")
+	db := openTestCatalog(t, path)
+
+	stmts := []string{
+		`CREATE TABLE ducklake_snapshot (snapshot_id BIGINT, next_file_id BIGINT)`,
+		`CREATE TABLE ducklake_table (table_id BIGINT, table_name TEXT)`,
+		// snapshot 3 is duplicated (the corruption); 1 and 2 are healthy.
+		`INSERT INTO ducklake_snapshot VALUES (1,10),(2,20),(3,30),(3,31)`,
+		// table 7 duplicated.
+		`INSERT INTO ducklake_table VALUES (5,'a'),(7,'b'),(7,'b')`,
+	}
+	for _, s := range stmts {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("setup %q: %v", s, err)
+		}
+	}
+	db.Close()
+
+	res, err := RepairCatalogSnapshots(path)
+	if err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+	if res.DuplicateSnapshots != 1 {
+		t.Errorf("DuplicateSnapshots=%d want 1", res.DuplicateSnapshots)
+	}
+	if res.DuplicateTables != 1 {
+		t.Errorf("DuplicateTables=%d want 1", res.DuplicateTables)
+	}
+	if !res.Changed() {
+		t.Errorf("Changed()=false want true")
+	}
+
+	// Verify the kept snapshot row is the last-written one (next_file_id=31).
+	db2 := openTestCatalog(t, path)
+	var cnt, keptFileID int
+	if err := db2.QueryRow(`SELECT COUNT(*) FROM ducklake_snapshot`).Scan(&cnt); err != nil {
+		t.Fatal(err)
+	}
+	if cnt != 3 {
+		t.Errorf("snapshot rows=%d want 3", cnt)
+	}
+	if err := db2.QueryRow(`SELECT next_file_id FROM ducklake_snapshot WHERE snapshot_id=3`).Scan(&keptFileID); err != nil {
+		t.Fatal(err)
+	}
+	if keptFileID != 31 {
+		t.Errorf("kept next_file_id=%d want 31 (latest)", keptFileID)
+	}
+}
+
+func TestRepairCatalogSnapshotsHealthy(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "catalog.sqlite")
+	db := openTestCatalog(t, path)
+	for _, s := range []string{
+		`CREATE TABLE ducklake_snapshot (snapshot_id BIGINT, next_file_id BIGINT)`,
+		`INSERT INTO ducklake_snapshot VALUES (1,10),(2,20)`,
+	} {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+	}
+	db.Close()
+
+	res, err := RepairCatalogSnapshots(path)
+	if err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+	if res.Changed() {
+		t.Errorf("healthy catalog reported changes: %+v", res)
+	}
+}
+
+func TestRepairCatalogSnapshotsMissingFile(t *testing.T) {
+	res, err := RepairCatalogSnapshots(filepath.Join(t.TempDir(), "does-not-exist.sqlite"))
+	if err != nil {
+		t.Fatalf("missing file should be no-op, got err: %v", err)
+	}
+	if res.Changed() {
+		t.Errorf("missing file reported changes: %+v", res)
+	}
+	_ = fmt.Sprint(res) // keep fmt import if test trimmed
+}

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.261"
+	VERSION_APPLICATION = "11.0.262"
 
 	// BuildDate is the build date
 	BuildDate = ""

--- a/src/writer/writer.go
+++ b/src/writer/writer.go
@@ -262,6 +262,9 @@ func New(ingestCfg *config.IngestConfig, storageCfg *config.StorageConfig, promC
 		// (e.g. a duplicate container) refuses to start instead of corrupting
 		// the SQLite catalog.
 		ExclusiveLock: true,
+		// Autofix duplicate snapshot/table rows on startup (default on).
+		AutoRepairCatalog: storageCfg.DuckLake.AutoRepairCatalog == nil ||
+			*storageCfg.DuckLake.AutoRepairCatalog,
 	}
 
 	// S3 config


### PR DESCRIPTION
## Summary
Another operator hit `Corrupt DuckLake - multiple snapshots returned from database`. This adds an automatic, **lossless** startup repair so the writer self-heals on the next restart instead of requiring a manual `--rebuild-catalog`.

- New `RepairCatalogSnapshots()` collapses duplicate `ducklake_snapshot` (by `snapshot_id`) and `ducklake_table` (by `table_id`) rows, keeping the most recently written row (highest rowid). The kept row still references the same Parquet files → no data loss.
- Runs in `connect()` **before ATTACH**, in the same exclusive pre-attach window as the inline-table GC, while the writer holds the exclusive catalog lock (so no concurrent writer is touching it).
- Controlled by `storage.ducklake.auto_repair_catalog` (default **enabled**; set `false` to opt out).
- Best-effort: any error is logged non-fatally; operators can still use `homer system --rebuild-catalog`.
- Logs a warning listing how many duplicate rows were removed when it fires.

## Notes
Stacked on `feat/lake-topn-strategy-11.0.261` (shares `config.go`/`version.go`). Merge bases bottom-up, or retarget to `homer11`.

## Test plan
- [x] `go build ./...`, `go vet ./storage/ducklake/... ./writer/... ./config/...`
- [x] New unit tests: `TestRepairCatalogSnapshots` (dedupes + keeps latest), `...Healthy` (no-op), `...MissingFile` (no-op)
- [ ] Reproduce a corrupted catalog, restart writer, confirm warning logged and queries succeed