### PR TITLE
feat(node): default lake top-N to stream + Go-side sort

### DIFF
--- a/docs/OOM.md
+++ b/docs/OOM.md
@@ -133,16 +133,16 @@ one hour):
 
 | Strategy  | Memory | Ordering | Notes |
 |-----------|--------|----------|-------|
-| `chunked` (default) | bounded to one window | newest-first, exact | Scans descending time windows (`lake_chunk_sec` wide), newest first, stops once N rows are collected. Recommended. |
-| `stream`  | minimal | scan order, **not** guaranteed newest-N | Drops `ORDER BY` and uses a plain streaming `LIMIT`; fastest and lowest memory, but may not return the strictly newest rows. |
+| `stream` (default) | minimal | newest-first (Go-sorted), **sample** | Drops `ORDER BY` so DuckDB stops after N rows (flat memory, fastest), then Homer re-sorts the N rows newest-first in Go before returning. The N rows are an arbitrary scan-order sample of the range, so they are correctly ordered but not guaranteed to be the globally newest N. |
+| `chunked` | bounded to one window | newest-first, **exact** | Scans descending time windows (`lake_chunk_sec` wide), newest first, stops once N rows are collected. Use when exact newest-N is required. |
 | `full`    | unbounded | newest-first, exact | Original single ORDER BY scan over the whole range — can OOM on wide data. |
 
 ```jsonc
 "storage": {
   "ducklake": {
     "search": {
-      "lake_topn_strategy": "chunked", // chunked | stream | full
-      "lake_chunk_sec": 3600            // window width for "chunked"
+      "lake_topn_strategy": "stream", // stream (default) | chunked | full
+      "lake_chunk_sec": 3600           // window width for "chunked"
     }
   }
 }

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -660,16 +660,19 @@ type SearchConfig struct {
 	// lake query is executed (it only applies when the split planner already
 	// decided the query is a timestamp-DESC top-N over a range wider than one
 	// hour):
-	//   "chunked" (default) — scan descending time windows (LakeChunkSec wide),
-	//        newest first, stopping once N rows are gathered. Preserves
-	//        newest-first ordering while bounding peak memory to one window.
-	//        Avoids the OOM the whole-range scan hits on wide SIP rows.
-	//   "stream"  — drop the ORDER BY and use a plain streaming LIMIT. DuckDB
-	//        stops after N rows so memory stays tiny and it is the fastest, but
-	//        the rows are in scan order, NOT guaranteed to be the newest N.
+	//   "stream" (default) — drop the ORDER BY and use a plain streaming LIMIT
+	//        so DuckDB stops after N rows and memory stays flat (the lowest-memory,
+	//        fastest option), then re-sort the N rows newest-first in Go before
+	//        returning. Caveat: the N rows are an arbitrary scan-order sample of
+	//        the range, so they are ordered correctly but not guaranteed to be the
+	//        globally newest N. Use "chunked" when exact newest-N is required.
+	//   "chunked" — scan descending time windows (LakeChunkSec wide), newest
+	//        first, stopping once N rows are gathered. Exact newest-first result
+	//        while bounding peak memory to one window. Avoids the OOM the
+	//        whole-range scan hits on wide SIP rows.
 	//   "full"    — original single ORDER BY scan over the whole range (can OOM
 	//        on wide data under a small memory_limit).
-	LakeTopNStrategy string `json:"lake_topn_strategy" mapstructure:"lake_topn_strategy" default:"chunked"`
+	LakeTopNStrategy string `json:"lake_topn_strategy" mapstructure:"lake_topn_strategy" default:"stream"`
 	// LakeChunkSec is the time-window width (seconds) for the "chunked" strategy.
 	// Smaller windows bound memory tighter at the cost of more sub-queries when
 	// data is sparse. Default 3600 (1 hour).

--- a/src/node/lake_topn_test.go
+++ b/src/node/lake_topn_test.go
@@ -2,9 +2,33 @@ package node
 
 import (
 	"testing"
+	"time"
 
 	"github.com/sipcapture/homer-core/src/config"
 )
+
+func TestSortRowsByTimestampDescLimit(t *testing.T) {
+	base := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
+	rows := []map[string]interface{}{
+		{"timestamp": base.Add(1 * time.Minute), "id": 2},
+		{"timestamp": base.Add(3 * time.Minute), "id": 4},
+		{"timestamp": base.Add(0 * time.Minute), "id": 1},
+		{"timestamp": base.Add(2 * time.Minute), "id": 3},
+	}
+	got := sortRowsByTimestampDescLimit(rows, 2)
+	if len(got) != 2 {
+		t.Fatalf("len=%d want 2", len(got))
+	}
+	if got[0]["id"] != 4 || got[1]["id"] != 3 {
+		t.Errorf("got newest ids %v,%v want 4,3", got[0]["id"], got[1]["id"])
+	}
+
+	// limit 0 = no trim, still sorted desc.
+	all := sortRowsByTimestampDescLimit(rows, 0)
+	if len(all) != 4 || all[0]["id"] != 4 || all[3]["id"] != 1 {
+		t.Errorf("unexpected order/len: %+v", all)
+	}
+}
 
 func TestStripOrderByForStream(t *testing.T) {
 	tests := []struct {
@@ -34,11 +58,11 @@ func TestStripOrderByForStream(t *testing.T) {
 
 func TestLakeTopNStrategy(t *testing.T) {
 	cases := map[string]string{
-		"":        lakeTopNChunked,
+		"":        lakeTopNStream,
 		"chunked": lakeTopNChunked,
 		"stream":  lakeTopNStream,
 		"full":    lakeTopNFull,
-		"bogus":   lakeTopNChunked,
+		"bogus":   lakeTopNStream,
 	}
 	for in, want := range cases {
 		n := &Node{config: &config.NodeConfig{
@@ -48,8 +72,8 @@ func TestLakeTopNStrategy(t *testing.T) {
 			t.Errorf("lakeTopNStrategy(%q)=%q want %q", in, got, want)
 		}
 	}
-	if got := (&Node{}).lakeTopNStrategy(); got != lakeTopNChunked {
-		t.Errorf("nil config: got %q want %q", got, lakeTopNChunked)
+	if got := (&Node{}).lakeTopNStrategy(); got != lakeTopNStream {
+		t.Errorf("nil config: got %q want %q", got, lakeTopNStream)
 	}
 }
 

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -597,19 +597,32 @@ const (
 const defaultLakeTimeChunkMs = int64(time.Hour / time.Millisecond)
 
 // lakeTopNStrategy returns the configured lake top-N execution strategy,
-// defaulting to "chunked".
+// defaulting to "stream" (lowest memory; Go re-sorts the result newest-first).
 func (n *Node) lakeTopNStrategy() string {
 	if n.config == nil {
-		return lakeTopNChunked
+		return lakeTopNStream
 	}
 	switch n.config.DuckLake.Search.LakeTopNStrategy {
-	case lakeTopNStream:
-		return lakeTopNStream
+	case lakeTopNChunked:
+		return lakeTopNChunked
 	case lakeTopNFull:
 		return lakeTopNFull
-	default:
-		return lakeTopNChunked
+	default: // "" and any unknown value
+		return lakeTopNStream
 	}
+}
+
+// sortRowsByTimestampDescLimit orders rows newest-first by their timestamp and
+// trims to limit. Used to restore ordering after the "stream" strategy drops
+// ORDER BY at the database to keep memory flat.
+func sortRowsByTimestampDescLimit(rows []map[string]interface{}, limit int) []map[string]interface{} {
+	sort.Slice(rows, func(i, j int) bool {
+		return rowTimestampSortKey(rows[i]) > rowTimestampSortKey(rows[j])
+	})
+	if limit > 0 && len(rows) > limit {
+		rows = rows[:limit]
+	}
+	return rows
 }
 
 // lakeChunkMs returns the configured chunk width (ms) for the "chunked"
@@ -813,18 +826,24 @@ func (n *Node) runSharedSelectWithMemoryPolicy(ctx context.Context, db *sql.DB, 
 		case lakeTopNFull:
 			plan.mode = "split_lake_and_mem:full"
 			lakeData, lakeCols, err = runSelectQuery(ctx, db, mq.lakeSQL)
-		case lakeTopNStream:
-			plan.mode = "split_lake_and_mem:stream"
-			streamSQL := stripOrderByForStream(mq.lakeSQL)
-			plan.lakeSQL = streamSQL
-			lakeData, lakeCols, err = runSelectQuery(ctx, db, streamSQL)
-		default: // lakeTopNChunked
+		case lakeTopNChunked:
 			plan.mode = "split_lake_and_mem:chunked"
 			if fromMs, toMs, ok := memorySplitBoundsMs(mq.lakeSQL); ok {
 				lakeData, lakeCols, plan.lakeChunks, err = n.runLakeSplitByTime(
 					ctx, db, mq.lakeSQL, fromMs, toMs, n.lakeChunkMs(), limitN)
 			} else {
 				lakeData, lakeCols, err = runSelectQuery(ctx, db, mq.lakeSQL)
+			}
+		default: // lakeTopNStream (default)
+			plan.mode = "split_lake_and_mem:stream"
+			streamSQL := stripOrderByForStream(mq.lakeSQL)
+			plan.lakeSQL = streamSQL
+			lakeData, lakeCols, err = runSelectQuery(ctx, db, streamSQL)
+			if err == nil {
+				// We dropped ORDER BY to keep DuckDB memory flat, so the rows come
+				// back in arbitrary scan order. Re-sort newest-first in Go before
+				// returning so the result ordering still matches the request.
+				lakeData = sortRowsByTimestampDescLimit(lakeData, limitN)
 			}
 		}
 		if err != nil {

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.262"
+	VERSION_APPLICATION = "11.0.263"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
Per request: make `stream` the default `lake_topn_strategy` and sort the result on the Go side before returning.

- **Default is now `stream`**: the lake sub-query drops `ORDER BY` so DuckDB does a true streaming `LIMIT` (stops after N rows → flat memory, fastest, no OOM on wide SIP rows).
- The N rows come back in arbitrary scan order, so Homer re-sorts them newest-first in Go (`sortRowsByTimestampDescLimit`) before merging with the memory buffer and returning — the result ordering still matches the request.
- **Caveat (documented):** the streamed N rows are an arbitrary scan-order *sample* of the range — correctly ordered but not guaranteed to be the globally newest N. Use `chunked` for exact newest-N.
- `chunked` and `full` remain available.

## Notes
Stacked on `feat/catalog-autorepair-11.0.262` (→ `feat/lake-topn-strategy-11.0.261` → `homer11`). Merge bases bottom-up.

## Test plan
- [x] `go build ./...`, `go vet ./node/... ./config/...`
- [x] Unit tests incl. `TestSortRowsByTimestampDescLimit`, updated `TestLakeTopNStrategy` (default → stream)
- [ ] 30-day search under low `memory_limit`: no OOM, rows returned newest-first