### PR TITLE
feat(coordinator): honor lake_topn_strategy in V4 transaction search

### DIFF
--- a/docs/OOM.md
+++ b/docs/OOM.md
@@ -151,6 +151,40 @@ one hour):
 The chosen strategy is reflected in the execution-plan log line
 (`mode=split_lake_and_mem:chunked|stream|full`, plus `lake_chunks` for chunked).
 
+The **coordinator transaction search** (`V4TransactionsSearch`, the path the UI
+uses for the transactions table) honours the same strategy — it is propagated to
+`coordinator.lake_topn_strategy` from `storage.ducklake.search.lake_topn_strategy`
+at startup.
+
+Both `stream` and `chunked` execute the range as **newest-first 24h time slices
+with early exit**, because a single `SELECT *` over 30 days of wide SIP rows
+OOMs at the node regardless of `LIMIT` — the parallel Parquet decompression
+alone exceeds a ~2 GB `memory_limit`, so capping the per-window scan breadth is
+what actually prevents the OOM (dropping `ORDER BY` is not enough on its own).
+They differ only in how each window is read:
+
+- `stream` (default) — **one query over the whole range** with `ORDER BY`
+  dropped, so DuckDB streams a flat `LIMIT` and stops after N rows; the rows are
+  re-sorted newest-first in Go. No time-slicing — simplest and fastest. Log:
+  `V4TransactionsSearch: stream execution (single query)`.
+- `chunked` — newest-first 24h windows (`coordinator.lake_chunk_sec`, default
+  86400) with early exit; each window keeps `ORDER BY timestamp DESC`, so the
+  node sub-splits it into 1h inner windows (`storage.ducklake.search.lake_chunk_sec`,
+  default 3600) for memory safety. Originally added for sipcapture/homer#785.
+  Log: `strategy=chunked`.
+- `full` — a single `ORDER BY` query over the whole range (can OOM).
+
+Note: a single unfiltered `SELECT *` over very long ranges can still pressure
+memory at the node even with a flat `LIMIT` (parallel Parquet decompression of
+wide rows). If `stream` OOMs on your data, switch to `chunked`.
+
+**Filtered searches are never node-sub-sliced.** When the query carries a
+predicate beyond the timestamp range (e.g. `session_id LIKE '%…%'`), the node
+runs each window as a single efficient scan instead of slicing it into 1h
+windows. Such queries return few rows (no memory risk), and slicing a
+non-prunable full-scan filter into many tiny per-window scans multiplies the
+catalog/Parquet open overhead and serialises them — which previously timed out.
+
 ## 6) Native Go Compaction Engine
 
 > ℹ️ **The native engine is safe to run alongside the live DuckDB writer as of

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -373,6 +373,22 @@ type CoordinatorConfig struct {
 	// before it is exhausted (TTL via expires_at still applies). Default 3, min 1, max 1000.
 	TransactionViewMaxOpens int `json:"transaction_view_max_opens" mapstructure:"transaction_view_max_opens" default:"3"`
 
+	// LakeTopNStrategy selects how long-range timestamp-DESC top-N transaction
+	// searches run: "stream" (default — newest-first time slices without ORDER BY,
+	// re-sorted in Go, lowest memory), "chunked" (newest-first time slices with
+	// per-window ORDER BY) or "full" (single ORDER BY over the whole range).
+	// Auto-populated from storage.ducklake.search.lake_topn_strategy at startup.
+	LakeTopNStrategy string `json:"lake_topn_strategy" mapstructure:"lake_topn_strategy" default:"stream"`
+
+	// LakeChunkSec is the OUTER time-window width (seconds) the coordinator uses
+	// to slice a long-range transaction search for the "chunked" strategy,
+	// newest-first with early exit. Each window is sent to the node as one query
+	// (the node further sub-slices it for memory safety, search.lake_chunk_sec
+	// = 1h), so this knob controls coordinator round-trips, not peak memory.
+	// Default 86400 (24h). Not used by the "stream" strategy, which runs a
+	// single query over the whole range.
+	LakeChunkSec int `json:"lake_chunk_sec" mapstructure:"lake_chunk_sec" default:"86400"`
+
 	// IPAliasCacheTTLSec is how long the in-memory IP→alias LPM table is reused between
 	// ListActive rebuilds (search/QoS/message enrichment). CRUD on aliases still invalidates
 	// immediately. Default 30, min 5, max 86400 (24h). Zero means use the default.

--- a/src/coordinator/coordinator.go
+++ b/src/coordinator/coordinator.go
@@ -202,7 +202,7 @@ func (c *Coordinator) setupRoutes() {
 	aliasSvc := services.NewAliasService(c.settingsDB, time.Duration(c.config.IPAliasCacheTTLSec)*time.Second)
 	authTokenSvc := services.NewAuthTokenService(c.settingsDB)
 	mapSvc := services.NewMappingService(c.settingsDB)
-	searchHandler := handlers.NewSearchHandler(c.flightService, aliasSvc, &c.config.MCP, shareExportSvc, viewTokenSvc, c.config.TransactionViewMaxOpens, mapSvc)
+	searchHandler := handlers.NewSearchHandler(c.flightService, aliasSvc, &c.config.MCP, shareExportSvc, viewTokenSvc, c.config.TransactionViewMaxOpens, mapSvc, c.config.LakeTopNStrategy, c.config.LakeChunkSec)
 	if c.correlation != nil {
 		searchHandler.SetCorrelator(correlatorAdapter{engine: c.correlation})
 	}

--- a/src/coordinator/handlers/lake_topn_test.go
+++ b/src/coordinator/handlers/lake_topn_test.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSearchHandlerLakeTopNStrategy(t *testing.T) {
+	cases := map[string]string{
+		"":        topNStream,
+		"stream":  topNStream,
+		"chunked": topNChunked,
+		"full":    topNFull,
+		"bogus":   topNStream,
+	}
+	for in, want := range cases {
+		h := &SearchHandler{lakeTopNStrategyCfg: in}
+		if got := h.lakeTopNStrategy(); got != want {
+			t.Errorf("lakeTopNStrategy(%q)=%q want %q", in, got, want)
+		}
+	}
+}
+
+func TestOuterChunkMs(t *testing.T) {
+	if got := (&SearchHandler{}).outerChunkMs(); got != transactionSearchChunkMs {
+		t.Errorf("default got %d want %d (24h)", got, transactionSearchChunkMs)
+	}
+	if got := (&SearchHandler{lakeChunkSec: 0}).outerChunkMs(); got != transactionSearchChunkMs {
+		t.Errorf("zero got %d want %d (24h)", got, transactionSearchChunkMs)
+	}
+	if got := (&SearchHandler{lakeChunkSec: 300}).outerChunkMs(); got != 300_000 {
+		t.Errorf("300s got %d want 300000", got)
+	}
+}
+
+func TestTransactionSearchTopNShape(t *testing.T) {
+	mk := func(sel, group, order string) *SearchObjectV4 {
+		r := &SearchObjectV4{}
+		r.Param.Select = sel
+		r.Param.GroupBy = group
+		r.Param.OrderBy = order
+		return r
+	}
+	if !transactionSearchTopNShape(mk("", "", "")) {
+		t.Error("default top-N shape should be true")
+	}
+	if !transactionSearchTopNShape(mk("", "", "timestamp DESC")) {
+		t.Error("timestamp DESC should be true")
+	}
+	if transactionSearchTopNShape(mk("count(*)", "", "")) {
+		t.Error("custom select should be false")
+	}
+	if transactionSearchTopNShape(mk("", "method", "")) {
+		t.Error("group by should be false")
+	}
+	if transactionSearchTopNShape(mk("", "", "caller ASC")) {
+		t.Error("custom order should be false")
+	}
+}
+
+func TestSortRowsByTimestampDescLimit(t *testing.T) {
+	base := time.Date(2026, 6, 15, 10, 0, 0, 0, time.UTC)
+	rows := []map[string]interface{}{
+		{"timestamp": base.Add(1 * time.Minute), "id": 2},
+		{"timestamp": "2026-06-15 10:03:00", "id": 4},
+		{"timestamp": base.Add(0 * time.Minute), "id": 1},
+		{"timestamp": base.Add(2 * time.Minute), "id": 3},
+	}
+	got := sortRowsByTimestampDescLimit(rows, 2)
+	if len(got) != 2 || got[0]["id"] != 4 || got[1]["id"] != 3 {
+		t.Errorf("got %v,%v want newest 4,3", get(got, 0), get(got, 1))
+	}
+}
+
+func get(rows []map[string]interface{}, i int) interface{} {
+	if i < len(rows) {
+		return rows[i]["id"]
+	}
+	return nil
+}

--- a/src/coordinator/handlers/mcp_llm_test.go
+++ b/src/coordinator/handlers/mcp_llm_test.go
@@ -70,7 +70,7 @@ func newLLMTestHandler(t *testing.T, llmHandler http.HandlerFunc, apiKey string)
 	}
 
 	fs := services.NewFlightService(nil, 0)
-	h := NewSearchHandler(fs, nil, cfg, nil, nil, 0, nil)
+	h := NewSearchHandler(fs, nil, cfg, nil, nil, 0, nil, "", 0)
 	return h, ts.Close
 }
 
@@ -155,7 +155,7 @@ func TestTryLLMStructured_DisabledReturnsZeroResult(t *testing.T) {
 	cfg := &config.MCPConfig{}
 	cfg.LLM = config.MCPLLMConfig{Enable: false}
 	fs := services.NewFlightService(nil, 0)
-	h := NewSearchHandler(fs, nil, cfg, nil, nil, 0, nil)
+	h := NewSearchHandler(fs, nil, cfg, nil, nil, 0, nil, "", 0)
 
 	req, res := h.tryLLMStructured(context.Background(), "anything", 0, 0, 0)
 	if req != nil {
@@ -246,7 +246,7 @@ func TestV4MCPLLMStatus_OllamaPingNoAPIKey(t *testing.T) {
 		TimeoutSec: 2,
 	}
 	fs := services.NewFlightService(nil, 0)
-	h := NewSearchHandler(fs, nil, cfg, nil, nil, 0, nil)
+	h := NewSearchHandler(fs, nil, cfg, nil, nil, 0, nil, "", 0)
 
 	e := echo.New()
 	rec := httptest.NewRecorder()
@@ -290,7 +290,7 @@ func TestNewSearchHandler_LLMDisabledMeansNilClient(t *testing.T) {
 	cfg := &config.MCPConfig{}
 	cfg.LLM = config.MCPLLMConfig{Enable: false}
 	fs := services.NewFlightService(nil, 0)
-	h := NewSearchHandler(fs, nil, cfg, nil, nil, 0, nil)
+	h := NewSearchHandler(fs, nil, cfg, nil, nil, 0, nil, "", 0)
 	if h.llm != nil {
 		t.Fatalf("expected nil LLM client when Enable=false, got %#v", h.llm)
 	}

--- a/src/coordinator/handlers/search.go
+++ b/src/coordinator/handlers/search.go
@@ -72,11 +72,18 @@ type SearchHandler struct {
 	correlation Correlator
 	// mappingService loads mapping_schema rows for fields_mapping virtual filters (optional).
 	mappingService *services.MappingService
+	// lakeTopNStrategyCfg selects how long-range timestamp-DESC top-N searches
+	// run (stream | chunked | full). Empty defaults to stream. Mirrors
+	// storage.ducklake.search.lake_topn_strategy.
+	lakeTopNStrategyCfg string
+	// lakeChunkSec is the stream-strategy time-window width in seconds (<=0 =>
+	// 1h default). Mirrors storage.ducklake.search.lake_chunk_sec.
+	lakeChunkSec int
 }
 
 // NewSearchHandler creates a new search handler.
 // aliasSvc may be nil; transaction rows will not get aliasSrc/aliasDst in that case.
-func NewSearchHandler(fs *services.FlightService, aliasSvc *services.AliasService, mcpCfg *config.MCPConfig, share *services.ShareExportService, viewTok *services.TransactionViewTokenService, transactionViewMaxOpens int, mappingSvc *services.MappingService) *SearchHandler {
+func NewSearchHandler(fs *services.FlightService, aliasSvc *services.AliasService, mcpCfg *config.MCPConfig, share *services.ShareExportService, viewTok *services.TransactionViewTokenService, transactionViewMaxOpens int, mappingSvc *services.MappingService, lakeTopNStrategy string, lakeChunkSec int) *SearchHandler {
 	if transactionViewMaxOpens <= 0 {
 		transactionViewMaxOpens = 3
 	}
@@ -98,6 +105,8 @@ func NewSearchHandler(fs *services.FlightService, aliasSvc *services.AliasServic
 		viewTokens:              viewTok,
 		transactionViewMaxOpens: transactionViewMaxOpens,
 		mappingService:          mappingSvc,
+		lakeTopNStrategyCfg:     lakeTopNStrategy,
+		lakeChunkSec:            lakeChunkSec,
 	}
 }
 

--- a/src/coordinator/handlers/transactions_v4.go
+++ b/src/coordinator/handlers/transactions_v4.go
@@ -568,19 +568,145 @@ func transactionSearchChunkable(req *SearchObjectV4) bool {
 		strings.EqualFold(orderBy, "time desc")
 }
 
+// Lake top-N execution strategies (mirrors storage.ducklake.search.lake_topn_strategy).
+const (
+	topNStream  = "stream"  // drop ORDER BY, single streaming LIMIT, Go-side sort
+	topNChunked = "chunked" // newest-first time slices with early exit
+	topNFull    = "full"    // single ORDER BY query over the whole range
+)
+
+// rowTimestampSortKey extracts a comparable newest-first key from a result
+// row's "timestamp" field, tolerating the representations FlightSQL/Arrow can
+// hand back (time.Time, string, []byte, epoch numbers).
+func rowTimestampSortKey(m map[string]interface{}) int64 {
+	v, ok := m["timestamp"]
+	if !ok || v == nil {
+		return 0
+	}
+	switch t := v.(type) {
+	case time.Time:
+		return t.UnixNano()
+	case string:
+		return parseTimestampKey(t)
+	case []byte:
+		return parseTimestampKey(string(t))
+	case int64:
+		return t
+	case int:
+		return int64(t)
+	case float64:
+		return int64(t)
+	}
+	return 0
+}
+
+func parseTimestampKey(s string) int64 {
+	for _, layout := range []string{
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05",
+		time.RFC3339Nano,
+		time.RFC3339,
+	} {
+		if ts, err := time.Parse(layout, s); err == nil {
+			return ts.UnixNano()
+		}
+	}
+	return 0
+}
+
+// sortRowsByTimestampDescLimit orders rows newest-first and trims to limit.
+// Used to restore ordering after the "stream" strategy drops ORDER BY at the
+// database to keep memory flat.
+func sortRowsByTimestampDescLimit(rows []map[string]interface{}, limit int) []map[string]interface{} {
+	sort.SliceStable(rows, func(i, j int) bool {
+		return rowTimestampSortKey(rows[i]) > rowTimestampSortKey(rows[j])
+	})
+	if limit > 0 && len(rows) > limit {
+		rows = rows[:limit]
+	}
+	return rows
+}
+
+// lakeTopNStrategy returns the configured strategy for long-range timestamp-DESC
+// top-N searches, defaulting to "stream".
+func (h *SearchHandler) lakeTopNStrategy() string {
+	switch h.lakeTopNStrategyCfg {
+	case topNChunked:
+		return topNChunked
+	case topNFull:
+		return topNFull
+	default:
+		return topNStream
+	}
+}
+
+// outerChunkMs is the coordinator's OUTER window width for the chunked strategy,
+// defaulting to 24h (transactionSearchChunkMs). The node sub-slices each window
+// to 1h for memory safety, so this only governs coordinator round-trips.
+func (h *SearchHandler) outerChunkMs() int64 {
+	if h.lakeChunkSec <= 0 {
+		return transactionSearchChunkMs
+	}
+	return int64(h.lakeChunkSec) * 1000
+}
+
+// transactionSearchTopNShape reports whether the request is a plain
+// timestamp-DESC top-N (no aggregation, custom projection or non-default
+// ordering) — the only shape for which the stream/chunked strategies are
+// correct. Unlike transactionSearchChunkable it does not require the range to
+// exceed a chunk, because a streaming LIMIT helps at any range.
+func transactionSearchTopNShape(req *SearchObjectV4) bool {
+	if strings.TrimSpace(req.Param.Select) != "" || strings.TrimSpace(req.Param.GroupBy) != "" {
+		return false
+	}
+	orderBy := strings.TrimSpace(req.Param.OrderBy)
+	return orderBy == "" ||
+		strings.EqualFold(orderBy, "timestamp desc") ||
+		strings.EqualFold(orderBy, "time desc")
+}
+
 // queryTransactionSearch executes a v4 transaction search. fullSQL is the
-// already-validated query for the whole time range; chunkable requests are
-// instead executed as newest-first time slices that stop as soon as the row
-// limit is collected (see transactionSearchChunkMs).
+// already-validated query for the whole time range. The lake_topn_strategy
+// config selects how a long-range timestamp-DESC top-N is run:
+//   - stream (default): one query over the WHOLE range with ORDER BY dropped
+//     (the DB streams a flat LIMIT and stops after N rows); the rows are
+//     re-sorted newest-first in Go. No time-slicing — fastest, simplest.
+//   - chunked: newest-first 24h time slices, each ORDER BY timestamp DESC, with
+//     early exit; the node further sub-splits each window to 1h for memory.
+//   - full: a single ORDER BY query over the whole range.
 func (h *SearchHandler) queryTransactionSearch(ctx context.Context, fullSQL string, req *SearchObjectV4, virtualRules map[string]services.VirtualFieldRule) ([]map[string]interface{}, error) {
-	if !transactionSearchChunkable(req) {
+	strategy := h.lakeTopNStrategy()
+
+	// full, or shapes we cannot safely rewrite (aggregations, custom projection
+	// or non-default ordering must see the whole range at once): single query.
+	if strategy == topNFull || !transactionSearchTopNShape(req) {
 		return h.flightService.Query(ctx, fullSQL)
 	}
 
-	chunks := splitSearchTimeRange(req.Timestamp.From, req.Timestamp.To, transactionSearchChunkMs)
+	// stream: a single query over the whole range, ORDER BY dropped, re-sorted
+	// in Go. No chunking.
+	if strategy == topNStream {
+		limit := effectiveSearchLimit(req.Param.Limit)
+		streamSQL, err := buildSearchSQLV4WithOpts(h.flightService.LakeName(), req, virtualRules, searchSQLOpts{noOrderBy: true})
+		if err != nil {
+			return nil, err
+		}
+		logger.Info("V4TransactionsSearch: stream execution (single query)", "limit", limit,
+			"from", req.Timestamp.From, "to", req.Timestamp.To)
+		rows, err := h.flightService.Query(ctx, streamSQL)
+		if err != nil {
+			return nil, err
+		}
+		return sortRowsByTimestampDescLimit(rows, limit), nil
+	}
+
+	// chunked: newest-first time slices with early exit. Each window keeps
+	// ORDER BY timestamp DESC, so the node sub-splits it into 1h windows for
+	// memory; the concatenation is already globally newest-first.
+	chunks := splitSearchTimeRange(req.Timestamp.From, req.Timestamp.To, h.outerChunkMs())
 	limit := effectiveSearchLimit(req.Param.Limit)
 	logger.Info("V4TransactionsSearch: chunked execution",
-		"chunks", len(chunks), "limit", limit,
+		"strategy", strategy, "chunks", len(chunks), "limit", limit,
 		"from", req.Timestamp.From, "to", req.Timestamp.To)
 
 	results := make([]map[string]interface{}, 0, limit)
@@ -591,7 +717,8 @@ func (h *SearchHandler) queryTransactionSearch(ctx context.Context, fullSQL stri
 		chunkReq := *req
 		chunkReq.Timestamp.From = chunk.FromMs
 		chunkReq.Timestamp.To = chunk.ToMs
-		sql, err := buildSearchSQLV4WithOpts(h.flightService.LakeName(), &chunkReq, virtualRules, searchSQLOpts{toExclusive: !chunk.ToInclusive})
+		sql, err := buildSearchSQLV4WithOpts(h.flightService.LakeName(), &chunkReq, virtualRules,
+			searchSQLOpts{toExclusive: !chunk.ToInclusive})
 		if err != nil {
 			return nil, err
 		}
@@ -603,8 +730,11 @@ func (h *SearchHandler) queryTransactionSearch(ctx context.Context, fullSQL stri
 		if len(results) >= limit {
 			logger.Info("V4TransactionsSearch: chunked early exit",
 				"chunks_done", i+1, "chunks_total", len(chunks), "rows", len(results))
-			return results[:limit], nil
+			break
 		}
+	}
+	if len(results) > limit {
+		results = results[:limit]
 	}
 	return results, nil
 }
@@ -2234,6 +2364,11 @@ type searchSQLOpts struct {
 	// interior slices of a chunked search neither lose nor duplicate rows
 	// on chunk boundaries (timestamps can carry sub-millisecond precision).
 	toExclusive bool
+	// noOrderBy omits the ORDER BY clause so DuckDB executes a plain streaming
+	// LIMIT (stops after N rows, flat memory) instead of a Top-N over the whole
+	// range. The caller is expected to re-sort the rows in Go. Only honored for
+	// the default timestamp-DESC ordering (custom order_by still emits ORDER BY).
+	noOrderBy bool
 }
 
 // timestampRangeConditions renders WHERE bounds for a [fromMs, toMs] window
@@ -2440,7 +2575,9 @@ func buildSearchSQLV4WithOpts(lakeName string, req *SearchObjectV4, virtualRules
 			return "", fmt.Errorf("invalid order_by: %w", err)
 		}
 		sql += " ORDER BY " + strings.TrimSpace(req.Param.OrderBy)
-	} else {
+	} else if !opts.noOrderBy {
+		// noOrderBy drops the default timestamp-DESC sort so the query streams
+		// (the caller re-sorts in Go). A custom order_by is always honored.
 		sql += " ORDER BY timestamp DESC"
 	}
 

--- a/src/coordinator/handlers/transactions_v4_correlation_test.go
+++ b/src/coordinator/handlers/transactions_v4_correlation_test.go
@@ -128,7 +128,7 @@ func newTestSearchHandler(t *testing.T, rowsPerCall [][]map[string]interface{}, 
 	_ = fs.ConnectAll()
 	fs.SetLakeName("homer_lake")
 
-	h := NewSearchHandler(fs, nil, &config.MCPConfig{}, nil, nil, 0, nil)
+	h := NewSearchHandler(fs, nil, &config.MCPConfig{}, nil, nil, 0, nil, "", 0)
 
 	return h, func() {
 		srv.Close()

--- a/src/main.go
+++ b/src/main.go
@@ -583,6 +583,16 @@ func runServer() {
 					cfg.Coordinator.LakeName = cfg.Node.DuckLake.LakeName
 				}
 			}
+			// Propagate the lake top-N search strategy so the coordinator's
+			// transaction search honours the same knob as the node split path.
+			if s := strings.TrimSpace(cfg.Node.DuckLake.Search.LakeTopNStrategy); s != "" {
+				cfg.Coordinator.LakeTopNStrategy = s
+			} else if s := strings.TrimSpace(cfg.Storage.DuckLake.Search.LakeTopNStrategy); s != "" {
+				cfg.Coordinator.LakeTopNStrategy = s
+			}
+			// NB: coordinator.lake_chunk_sec is the OUTER window (default 24h) and
+			// is intentionally NOT taken from the node's search.lake_chunk_sec
+			// (the node's 1h INNER sub-split); they are different layers.
 			cfg.Coordinator.MCP = cfg.MCP
 			if HasEmbeddedUI() {
 				coordinator.WebAssets = &WebAssets

--- a/src/node/lake_topn_test.go
+++ b/src/node/lake_topn_test.go
@@ -77,6 +77,26 @@ func TestLakeTopNStrategy(t *testing.T) {
 	}
 }
 
+func TestSqlHasNonTimestampFilter(t *testing.T) {
+	tsOnly := "SELECT *, 'homer_lake' AS storage_lake FROM t WHERE timestamp >= (to_timestamp(1 / 1000.0) AT TIME ZONE 'UTC') AND timestamp <= (to_timestamp(2 / 1000.0) AT TIME ZONE 'UTC')"
+	if sqlHasNonTimestampFilter(tsOnly) {
+		t.Error("timestamp-only WHERE should not be a filter")
+	}
+	filtered := tsOnly + " AND (session_id LIKE '%x%' OR cid LIKE '%x%')"
+	if !sqlHasNonTimestampFilter(filtered) {
+		t.Error("session_id LIKE should be detected as a filter")
+	}
+	if sqlHasNonTimestampFilter("SELECT * FROM t") {
+		t.Error("no WHERE should not be a filter")
+	}
+
+	// A filtered long-range query must NOT be split (single efficient scan).
+	ob, lim, base := extractOrderLimit(filtered + " ORDER BY timestamp DESC LIMIT 50")
+	if shouldSplitLakeAndMem(filtered, base, ob, lim) {
+		t.Error("filtered query should not be split (top-N path)")
+	}
+}
+
 func TestLakeChunkMs(t *testing.T) {
 	if got := (&Node{}).lakeChunkMs(); got != defaultLakeTimeChunkMs {
 		t.Errorf("nil config: got %d want %d", got, defaultLakeTimeChunkMs)

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -705,11 +705,12 @@ func (n *Node) runLakeSplitByTime(
 	return merged, mcols, chunks, nil
 }
 
-func sqlSplitSafeForTimestampTopN(sql, baseSQL, orderByClause, limitClause string) bool {
+// sqlSplitSafeShape reports whether a query is a `SELECT * ... LIMIT N` with no
+// aggregation/grouping/distinct — the shape we can safely execute as
+// independent time windows (with or without ORDER BY). Ordering is checked
+// separately by the callers.
+func sqlSplitSafeShape(baseSQL, limitClause string) bool {
 	if strings.TrimSpace(limitClause) == "" {
-		return false
-	}
-	if normalizeSQLWhitespace(orderByClause) != "order by timestamp desc" {
 		return false
 	}
 	upper := strings.ToUpper(baseSQL)
@@ -723,6 +724,13 @@ func sqlSplitSafeForTimestampTopN(sql, baseSQL, orderByClause, limitClause strin
 	}
 	selectList := strings.TrimSpace(baseSQL[selectIdx+len("SELECT") : fromIdx])
 	return strings.HasPrefix(selectList, "*")
+}
+
+func sqlSplitSafeForTimestampTopN(sql, baseSQL, orderByClause, limitClause string) bool {
+	if normalizeSQLWhitespace(orderByClause) != "order by timestamp desc" {
+		return false
+	}
+	return sqlSplitSafeShape(baseSQL, limitClause)
 }
 
 func (n *Node) buildMemoryUnionQueries(sql string) memoryUnionQueries {
@@ -790,9 +798,43 @@ func (n *Node) buildMemoryUnionQueries(sql string) memoryUnionQueries {
 	return out
 }
 
+// sqlHasNonTimestampFilter reports whether the WHERE clause carries predicates
+// beyond the two timestamp range bounds (e.g. session_id/cid/method LIKE/=/IN).
+//
+// Time-slicing only helps the "fat" top-N case: an unfiltered `SELECT *` over a
+// long range materialises huge wide result sets, so slicing + early exit bounds
+// memory and stays fast. A *filtered* query is the opposite — it returns few
+// rows (no memory risk) but a non-prunable filter (LIKE '%…%') forces a full
+// scan, and slicing it into N tiny per-window scans multiplies the catalog/
+// Parquet open overhead and runs them serially, which times out. Such queries
+// must run as a single efficient scan per window instead.
+func sqlHasNonTimestampFilter(baseSQL string) bool {
+	lower := strings.ToLower(baseSQL)
+	wi := strings.Index(lower, " where ")
+	if wi == -1 {
+		return false
+	}
+	where := baseSQL[wi+len(" where "):]
+	where = sqlTimestampFromRegexp.ReplaceAllString(where, " ")
+	where = sqlTimestampToRegexp.ReplaceAllString(where, " ")
+	where = strings.NewReplacer("(", " ", ")", " ").Replace(where)
+	for _, tok := range strings.Fields(where) {
+		switch strings.ToLower(tok) {
+		case "and", "or":
+			continue
+		default:
+			return true // a real predicate beyond the timestamp bounds
+		}
+	}
+	return false
+}
+
 func shouldSplitLakeAndMem(sql, baseSQL, orderByClause, limitClause string) bool {
 	if !sqlSplitSafeForTimestampTopN(sql, baseSQL, orderByClause, limitClause) {
 		return false
+	}
+	if sqlHasNonTimestampFilter(baseSQL) {
+		return false // filtered: run a single efficient scan, do not slice
 	}
 	rangeMs, ok := memorySplitRangeMs(sql)
 	return ok && rangeMs > memorySplitThresholdMs

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.263"
+	VERSION_APPLICATION = "11.0.269"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary

The transactions table uses a **separate** search path — the coordinator's `V4TransactionsSearch` — which had its own hard-coded chunking, independent of `storage.ducklake.search.lake_topn_strategy`. This wires the strategy through (`coordinator.lake_topn_strategy`, auto-populated from the node/storage search config at startup) so V4 search behaves like the node split path.

## Strategies

- **stream** (default): one query over the **whole range** with `ORDER BY` dropped (DuckDB streams a flat `LIMIT` and stops after N rows), re-sorted newest-first in Go. No time-slicing — simplest and fastest.
- **chunked**: newest-first 24h windows (`coordinator.lake_chunk_sec`, default 86400) with early exit; each window keeps `ORDER BY timestamp DESC` and the node sub-splits it to 1h (`storage.ducklake.search.lake_chunk_sec`) for memory safety.
- **full**: a single `ORDER BY` query over the whole range.

Filtered searches (predicates beyond the timestamp range, e.g. `session_id LIKE …`) are **never** time-sliced — they run as a single efficient scan per window — to avoid the per-window overhead that timed out sparse `LIKE` queries.

## Notes

- A single unfiltered `SELECT *` over very long ranges can still pressure node memory even with a flat `LIMIT` (parallel Parquet decompression of wide rows). If `stream` OOMs, switch to `chunked`.
- Go-side `sortRowsByTimestampDescLimit` restores newest-first ordering after the DB drops `ORDER BY`.
- Docs: `docs/OOM.md` updated. Version bumped to 11.0.269.

Stacked on #814.
