### PR TITLE
fix(ducklake): harden catalog auto-repair for 'multiple snapshots returned' (11.0.270)

### DIFF
--- a/src/storage/ducklake/ducklake.go
+++ b/src/storage/ducklake/ducklake.go
@@ -427,14 +427,49 @@ func (mtw *MultiTableWriter) connect() error {
 	// Lossless: only duplicate snapshot/table metadata rows are collapsed.
 	if mtw.config.AutoRepairCatalog &&
 		(mtw.config.CatalogType == CatalogSQLite || mtw.config.CatalogType == "") {
-		if res, err := RepairCatalogSnapshots(mtw.config.CatalogPath); err != nil {
+		res, err := RepairCatalogSnapshots(mtw.config.CatalogPath)
+		switch {
+		case err != nil && res.Malformed:
+			logger.Error("DuckLake catalog file is physically malformed; row-level "+
+				"auto-repair cannot recover it. Salvage with "+
+				"`sqlite3 CATALOG .dump | sqlite3 CATALOG.fixed` then swap the file, "+
+				"or run `homer system --rebuild-catalog` to rebuild from parquet.",
+				"err", err, "catalog", mtw.config.CatalogPath)
+		case err != nil:
 			logger.Warn("DuckLake catalog auto-repair failed (non-fatal); "+
 				"run `homer system --rebuild-catalog` if queries still error", "err", err)
-		} else if res.Changed() {
+		case res.Changed():
 			logger.Warn("DuckLake catalog auto-repair: removed duplicate metadata rows "+
 				"(fixed 'Corrupt DuckLake - multiple snapshots returned')",
 				"duplicate_snapshots", res.DuplicateSnapshots,
+				"duplicate_snapshot_changes", res.DuplicateSnapshotChanges,
 				"duplicate_tables", res.DuplicateTables,
+				"latest_snapshot_rows", res.LatestSnapshotRows,
+				"catalog", mtw.config.CatalogPath)
+		default:
+			logger.Debug("DuckLake catalog auto-repair: catalog healthy, nothing to fix",
+				"latest_snapshot_rows", res.LatestSnapshotRows,
+				"catalog", mtw.config.CatalogPath)
+		}
+		// Even after a (no-op or successful) repair the latest-snapshot probe may
+		// still return >1 row — e.g. corruption the lightweight dedup can't reach.
+		// Surface this loudly so the operator runs the heavyweight rebuild instead
+		// of chasing silent 500s.
+		if err == nil && !res.Healthy() {
+			logger.Error("DuckLake catalog still reports multiple latest snapshots after "+
+				"auto-repair; queries will fail with 'Corrupt DuckLake - multiple snapshots "+
+				"returned'. Run `homer system --rebuild-catalog` to rebuild from parquet.",
+				"latest_snapshot_rows", res.LatestSnapshotRows,
+				"catalog", mtw.config.CatalogPath)
+		}
+		// Duplicate table registrations (same table_name, different table_id) are
+		// the deeper corruption from two concurrent writers (sipcapture/homer#809).
+		// We don't auto-delete them (it can orphan data files), so warn explicitly.
+		if err == nil && res.DuplicateTableNames > 0 {
+			logger.Warn("DuckLake catalog has duplicate table registrations (same name, "+
+				"different ids) from a concurrent-writer event; per-table queries may fail. "+
+				"Run `homer system --rebuild-catalog` to rebuild the catalog from parquet.",
+				"duplicate_table_names", res.DuplicateTableNames,
 				"catalog", mtw.config.CatalogPath)
 		}
 	}

--- a/src/storage/ducklake/repair.go
+++ b/src/storage/ducklake/repair.go
@@ -4,19 +4,68 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"strings"
 
 	_ "modernc.org/sqlite" // pure-Go SQLite driver for out-of-band catalog repair
 )
 
-// RepairResult summarizes what a startup catalog repair changed.
+// RepairResult summarizes what a startup catalog repair changed (or detected).
 type RepairResult struct {
-	DuplicateSnapshots int // ducklake_snapshot rows removed
-	DuplicateTables    int // ducklake_table rows removed
+	DuplicateSnapshots       int // ducklake_snapshot rows removed
+	DuplicateSnapshotChanges int // ducklake_snapshot_changes rows removed
+	DuplicateTables          int // ducklake_table rows removed (by table_id)
+	// LatestSnapshotRows is the number of rows matching the latest snapshot_id
+	// AFTER repair, evaluated the way DuckLake itself evaluates it. >1 means the
+	// fatal "multiple snapshots returned" condition is still present and the
+	// lightweight repair was not enough (operator must --rebuild-catalog).
+	LatestSnapshotRows int
+
+	// --- Detection-only signals (NOT auto-fixed) -------------------------------
+	// These are the broader corruption shapes seen when two writers raced on the
+	// same catalog (sipcapture/homer#809). We deliberately do not auto-delete
+	// them: dropping a duplicate table/column/schema row can orphan the
+	// data-file rows that reference its table_id and silently lose data. They are
+	// surfaced so the operator runs the authoritative `--rebuild-catalog`.
+
+	// DuplicateTableNames counts ducklake_table rows that share a table_name but
+	// were registered with different table_ids (two writers each created the
+	// table). Cleaning these correctly requires knowing which table_id the
+	// data files reference, so we only report it.
+	DuplicateTableNames int
+	// Malformed is set when an operation failed because the SQLite file is
+	// physically corrupt ("database disk image is malformed"). Only a
+	// .dump/reimport salvage or a full rebuild recovers from this.
+	Malformed bool
 }
 
 // Changed reports whether the repair removed anything.
 func (r RepairResult) Changed() bool {
-	return r.DuplicateSnapshots > 0 || r.DuplicateTables > 0
+	return r.DuplicateSnapshots > 0 || r.DuplicateSnapshotChanges > 0 || r.DuplicateTables > 0
+}
+
+// NeedsRebuild reports whether the lightweight repair was insufficient and the
+// operator should run `homer system --rebuild-catalog`.
+func (r RepairResult) NeedsRebuild() bool {
+	return r.Malformed || r.DuplicateTableNames > 0 || !r.Healthy()
+}
+
+// isMalformedErr reports whether a SQLite error indicates physical file
+// corruption that row-level repair cannot fix.
+func isMalformedErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "malformed") || strings.Contains(msg, "disk image") ||
+		strings.Contains(msg, "database is corrupt") || strings.Contains(msg, "not a database")
+}
+
+// Healthy reports whether, after repair, the catalog presents exactly one
+// latest snapshot (the precondition DuckLake's GetSnapshot requires). A value
+// of 0 means the check could not run (e.g. fresh/missing catalog) and is
+// treated as healthy.
+func (r RepairResult) Healthy() bool {
+	return r.LatestSnapshotRows <= 1
 }
 
 // RepairCatalogSnapshots removes duplicate metadata rows from a DuckLake SQLite
@@ -26,12 +75,31 @@ func (r RepairResult) Changed() bool {
 // Root cause: when two writers (or a writer + an out-of-band native compactor)
 // committed against the same SQLite catalog without coordination, they could
 // insert two rows sharing the same snapshot_id (or table_id). DuckLake's
-// get-by-id reads then return >1 row and abort the whole query path.
+// get-by-id reads then return >1 row and abort the whole query path. DuckLake's
+// own latest-snapshot probe is:
+//
+//	SELECT ... FROM ducklake_snapshot
+//	WHERE snapshot_id = (SELECT MAX(snapshot_id) FROM ducklake_snapshot);
+//
+// so anything that makes that return >1 row is fatal.
 //
 // The fix is surgical and lossless for data: for each duplicated key we keep
 // the most recently written row (highest rowid) and delete the rest. The kept
 // row still references the same Parquet data files, so no data is lost — only
 // the conflicting duplicate metadata rows are dropped.
+//
+// Two robustness details matter here, because the previous implementation could
+// silently find "0 duplicates" while DuckDB still aborted:
+//
+//  1. We checkpoint the WAL (TRUNCATE) before AND after so a leftover, never
+//     checkpointed WAL from an OOM-killed writer is folded into the main DB and
+//     the cleaned state is what DuckDB reads when it ATTACHes.
+//  2. We group by CAST(key AS INTEGER), not the raw column. SQLite groups by
+//     storage class, so an id stored once as INTEGER 5 and once as TEXT '5'
+//     looks like two distinct keys to a plain GROUP BY (no duplicate found),
+//     yet DuckLake reads the column as BIGINT and sees two rows with the same
+//     id — exactly the "multiple snapshots" abort. Casting makes our view match
+//     DuckLake's.
 //
 // MUST be called while no other process has the catalog open (the same
 // pre-ATTACH window GCOrphanInlineTables uses). Best-effort: a missing file or
@@ -58,13 +126,29 @@ func RepairCatalogSnapshots(catalogPath string) (RepairResult, error) {
 		return res, fmt.Errorf("ping catalog for repair: %w", err)
 	}
 
+	// Fold a leftover WAL (e.g. from an OOM-killed previous writer) into the
+	// main DB so the rows we inspect are the same rows DuckDB will read.
+	checkpointWAL(db)
+
 	// ducklake_snapshot: collapse duplicate snapshot_id rows, keeping the last.
 	if exists, _ := sqliteTableExists(db, "ducklake_snapshot"); exists {
 		n, err := dedupeByKey(db, "ducklake_snapshot", "snapshot_id")
 		if err != nil {
+			res.Malformed = isMalformedErr(err)
 			return res, err
 		}
 		res.DuplicateSnapshots = n
+	}
+
+	// ducklake_snapshot_changes shares the snapshot_id PK and is read alongside
+	// the snapshot during commit/cleanup; collapse its duplicates too.
+	if exists, _ := sqliteTableExists(db, "ducklake_snapshot_changes"); exists {
+		n, err := dedupeByKey(db, "ducklake_snapshot_changes", "snapshot_id")
+		if err != nil {
+			res.Malformed = isMalformedErr(err)
+			return res, err
+		}
+		res.DuplicateSnapshotChanges = n
 	}
 
 	// ducklake_table: duplicate table_id rows are the secondary corruption two
@@ -72,12 +156,93 @@ func RepairCatalogSnapshots(catalogPath string) (RepairResult, error) {
 	if exists, _ := sqliteTableExists(db, "ducklake_table"); exists {
 		n, err := dedupeByKey(db, "ducklake_table", "table_id")
 		if err != nil {
+			res.Malformed = isMalformedErr(err)
 			return res, err
 		}
 		res.DuplicateTables = n
+
+		// Detect (do NOT auto-fix) the harder case from sipcapture/homer#809:
+		// two writers each registered the same table_name under a different
+		// table_id. Removing one orphans the data files referencing its id, so
+		// this requires `--rebuild-catalog`, not a blind dedup.
+		res.DuplicateTableNames = countDuplicateTableNames(db)
+	}
+
+	// Push the cleaned state back into the main DB file so the about-to-run
+	// DuckLake ATTACH reads it without depending on our WAL frames.
+	checkpointWAL(db)
+
+	// Verify the way DuckLake does: how many rows match the latest snapshot_id?
+	// If still >1 the lightweight repair could not resolve it and the caller
+	// should surface the --rebuild-catalog hint.
+	if exists, _ := sqliteTableExists(db, "ducklake_snapshot"); exists {
+		res.LatestSnapshotRows = countLatestSnapshotRows(db)
 	}
 
 	return res, nil
+}
+
+// checkpointWAL best-effort folds the WAL back into the main database file.
+func checkpointWAL(db *sql.DB) {
+	// TRUNCATE checkpoints and then truncates the WAL to zero bytes.
+	_, _ = db.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+}
+
+// countDuplicateTableNames returns how many extra (active) ducklake_table rows
+// share a table_name with another row — the duplicate-registration corruption
+// from sipcapture/homer#809. Only currently-live rows (end_snapshot IS NULL)
+// are considered so historically renamed/dropped tables don't count. Returns 0
+// on any error (best-effort detection).
+func countDuplicateTableNames(db *sql.DB) int {
+	// end_snapshot may not exist on very old catalogs; fall back to all rows.
+	filter := ""
+	if columnExists(db, "ducklake_table", "end_snapshot") {
+		filter = "WHERE end_snapshot IS NULL"
+	}
+	q := fmt.Sprintf(
+		`SELECT COALESCE(SUM(c-1),0) FROM (SELECT COUNT(*) c FROM ducklake_table %s GROUP BY table_name HAVING c>1)`,
+		filter)
+	var n int
+	if err := db.QueryRow(q).Scan(&n); err != nil {
+		return 0
+	}
+	return n
+}
+
+// columnExists reports whether a column is present on a SQLite table.
+func columnExists(db *sql.DB, table, column string) bool {
+	rows, err := db.Query(fmt.Sprintf("PRAGMA table_info(%q)", table))
+	if err != nil {
+		return false
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull, pk int
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			return false
+		}
+		if name == column {
+			return true
+		}
+	}
+	return false
+}
+
+// countLatestSnapshotRows reproduces DuckLake's latest-snapshot probe under the
+// same integer interpretation DuckLake uses. Returns the number of rows that
+// share the maximum snapshot_id (the value DuckLake's ParseSnapshot iterates).
+// Returns -1 if the probe itself errors.
+func countLatestSnapshotRows(db *sql.DB) int {
+	const q = `SELECT COUNT(*) FROM ducklake_snapshot
+WHERE CAST(snapshot_id AS INTEGER) = (SELECT MAX(CAST(snapshot_id AS INTEGER)) FROM ducklake_snapshot)`
+	var n int
+	if err := db.QueryRow(q).Scan(&n); err != nil {
+		return -1
+	}
+	return n
 }
 
 // sqliteTableExists reports whether a table is present in the SQLite schema.
@@ -94,13 +259,19 @@ func sqliteTableExists(db *sql.DB, name string) (bool, error) {
 // dedupeByKey deletes rows of table sharing the same keyCol value, keeping the
 // one with the highest rowid (the most recently written). Returns the number of
 // rows removed. The DELETE runs in a single implicit transaction.
+//
+// The key is normalized with CAST(... AS INTEGER) so that ids differing only by
+// SQLite storage class (INTEGER 5 vs TEXT '5') are treated as the same key —
+// matching how DuckLake reads these BIGINT id columns.
 func dedupeByKey(db *sql.DB, table, keyCol string) (int, error) {
+	keyExpr := fmt.Sprintf(`CAST("%s" AS INTEGER)`, keyCol)
+
 	// Count duplicates first so we can skip the (locking) DELETE on a healthy
 	// catalog — the common case on every startup.
 	var dupRows int
 	countSQL := fmt.Sprintf(
-		`SELECT COALESCE(SUM(c-1),0) FROM (SELECT COUNT(*) c FROM "%s" GROUP BY "%s" HAVING c>1)`,
-		table, keyCol)
+		`SELECT COALESCE(SUM(c-1),0) FROM (SELECT COUNT(*) c FROM "%s" GROUP BY %s HAVING c>1)`,
+		table, keyExpr)
 	if err := db.QueryRow(countSQL).Scan(&dupRows); err != nil {
 		return 0, fmt.Errorf("count duplicate %s: %w", keyCol, err)
 	}
@@ -109,8 +280,8 @@ func dedupeByKey(db *sql.DB, table, keyCol string) (int, error) {
 	}
 
 	delSQL := fmt.Sprintf(
-		`DELETE FROM "%s" WHERE rowid NOT IN (SELECT MAX(rowid) FROM "%s" GROUP BY "%s")`,
-		table, table, keyCol)
+		`DELETE FROM "%s" WHERE rowid NOT IN (SELECT MAX(rowid) FROM "%s" GROUP BY %s)`,
+		table, table, keyExpr)
 	resExec, err := db.Exec(delSQL)
 	if err != nil {
 		return 0, fmt.Errorf("dedupe %s by %s: %w", table, keyCol, err)

--- a/src/storage/ducklake/repair_e2e_test.go
+++ b/src/storage/ducklake/repair_e2e_test.go
@@ -1,0 +1,196 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//go:build !vet
+// +build !vet
+
+package ducklake
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	duckdb "github.com/duckdb/duckdb-go/v2"
+	_ "modernc.org/sqlite"
+)
+
+// openDuckLake opens a real DuckDB connection and ATTACHes the DuckLake catalog
+// exactly like the writer does. It skips the test if the ducklake/sqlite DuckDB
+// extensions cannot be loaded (no network / offline CI), so the suite stays
+// green in restricted environments while still giving real end-to-end proof
+// wherever the extensions are available.
+func openDuckLake(t *testing.T, catalogPath, dataPath string) *sql.DB {
+	t.Helper()
+	connector, err := duckdb.NewConnector("", func(execer driver.ExecerContext) error {
+		return nil
+	})
+	if err != nil {
+		t.Skipf("duckdb unavailable: %v", err)
+	}
+	db := sql.OpenDB(connector)
+	db.SetMaxOpenConns(1)
+
+	for _, stmt := range []string{"INSTALL ducklake;", "LOAD ducklake;", "INSTALL sqlite;", "LOAD sqlite;"} {
+		if _, err := db.Exec(stmt); err != nil {
+			db.Close()
+			t.Skipf("ducklake/sqlite extensions unavailable (%q): %v", stmt, err)
+		}
+	}
+	attach := fmt.Sprintf(
+		"ATTACH 'ducklake:sqlite:%s' AS lake (DATA_PATH '%s', AUTOMATIC_MIGRATION TRUE);",
+		catalogPath, dataPath)
+	if _, err := db.Exec(attach); err != nil {
+		db.Close()
+		t.Skipf("ATTACH ducklake failed (extension/version mismatch): %v", err)
+	}
+	return db
+}
+
+// TestRepairFixesRealDuckLakeCorruption is the end-to-end proof that the startup
+// auto-repair makes a catalog readable again after the sipcapture/homer#809
+// "multiple snapshots returned" corruption:
+//
+//  1. build a real DuckLake catalog and write data (several snapshots),
+//  2. inject the corruption a racing second writer would (a duplicate row with
+//     the current MAX snapshot_id),
+//  3. confirm DuckDB itself now aborts every query with the fatal error,
+//  4. run RepairCatalogSnapshots (what the writer runs on startup),
+//  5. confirm DuckDB can query the catalog again.
+func TestRepairFixesRealDuckLakeCorruption(t *testing.T) {
+	dir := t.TempDir()
+	catalog := filepath.Join(dir, "catalog.sqlite")
+	data := filepath.Join(dir, "data")
+	if err := os.MkdirAll(data, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// 1. Build a real catalog with a few snapshots.
+	db := openDuckLake(t, catalog, data)
+	mustExec(t, db, `CREATE TABLE lake.main.t (id INTEGER, name VARCHAR);`)
+	mustExec(t, db, `INSERT INTO lake.main.t VALUES (1,'a');`)
+	mustExec(t, db, `INSERT INTO lake.main.t VALUES (2,'b');`)
+	mustExec(t, db, `INSERT INTO lake.main.t VALUES (3,'c');`)
+	var got int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM lake.main.t`).Scan(&got); err != nil {
+		t.Fatalf("baseline query: %v", err)
+	}
+	if got != 3 {
+		t.Fatalf("baseline rows=%d want 3", got)
+	}
+	mustExec(t, db, `DETACH lake;`)
+	db.Close()
+
+	// 2. Inject the corruption: duplicate the latest snapshot row, exactly what
+	//    a second concurrent writer committing the same snapshot_id produces.
+	injectDuplicateLatestSnapshot(t, catalog)
+
+	// 3. Prove a real DuckDB+DuckLake now aborts with the #809 error.
+	if err := tryDuckLakeQuery(t, catalog, data); err == nil {
+		t.Fatalf("expected corrupt catalog to fail the latest-snapshot probe, but query succeeded")
+	} else if !strings.Contains(err.Error(), "multiple snapshots") {
+		t.Fatalf("expected 'multiple snapshots' error, got: %v", err)
+	}
+
+	// 4. Run the startup auto-repair.
+	res, err := RepairCatalogSnapshots(catalog)
+	if err != nil {
+		t.Fatalf("RepairCatalogSnapshots: %v", err)
+	}
+	if res.DuplicateSnapshots < 1 {
+		t.Fatalf("repair removed %d duplicate snapshots, want >=1", res.DuplicateSnapshots)
+	}
+	if !res.Healthy() {
+		t.Fatalf("repair left catalog unhealthy: latest_snapshot_rows=%d", res.LatestSnapshotRows)
+	}
+
+	// 5. Prove DuckDB can read the catalog again, with all data intact.
+	if err := tryDuckLakeQuery(t, catalog, data); err != nil {
+		t.Fatalf("catalog still broken after repair: %v", err)
+	}
+	db2 := openDuckLake(t, catalog, data)
+	defer db2.Close()
+	if err := db2.QueryRow(`SELECT COUNT(*) FROM lake.main.t`).Scan(&got); err != nil {
+		t.Fatalf("post-repair query: %v", err)
+	}
+	if got != 3 {
+		t.Fatalf("post-repair rows=%d want 3 (data must be preserved)", got)
+	}
+}
+
+func mustExec(t *testing.T, db *sql.DB, q string) {
+	t.Helper()
+	if _, err := db.Exec(q); err != nil {
+		t.Fatalf("exec %q: %v", q, err)
+	}
+}
+
+// tryDuckLakeQuery attaches the catalog and runs a query that forces DuckLake to
+// resolve the latest snapshot; returns the error (nil on success). It must use a
+// fresh connection so DuckLake re-reads the catalog rather than a cached state.
+func tryDuckLakeQuery(t *testing.T, catalogPath, dataPath string) error {
+	t.Helper()
+	connector, err := duckdb.NewConnector("", func(execer driver.ExecerContext) error { return nil })
+	if err != nil {
+		t.Skipf("duckdb unavailable: %v", err)
+	}
+	db := sql.OpenDB(connector)
+	db.SetMaxOpenConns(1)
+	defer db.Close()
+	for _, stmt := range []string{"LOAD ducklake;", "LOAD sqlite;"} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Skipf("extensions unavailable: %v", err)
+		}
+	}
+	if _, err := db.Exec(fmt.Sprintf(
+		"ATTACH 'ducklake:sqlite:%s' AS lake (DATA_PATH '%s', AUTOMATIC_MIGRATION TRUE);",
+		catalogPath, dataPath)); err != nil {
+		// A corrupt catalog can fail at ATTACH time too; that's still the bug.
+		return err
+	}
+	var n int
+	return db.QueryRow(`SELECT COUNT(*) FROM lake.main.t`).Scan(&n)
+}
+
+// injectDuplicateLatestSnapshot reproduces the state a racing second writer (or
+// catalog corruption) leaves behind: two ducklake_snapshot rows sharing the
+// current MAX snapshot_id.
+//
+// Current DuckLake creates ducklake_snapshot with `snapshot_id BIGINT PRIMARY
+// KEY`, so SQLite's UNIQUE index normally makes a literal duplicate impossible.
+// We therefore first drop that uniqueness (rebuild the table without the PK) to
+// emulate a catalog whose index no longer enforces uniqueness — e.g. a catalog
+// created by an older DuckLake, or one whose index pages were corrupted by
+// concurrent writers — and then insert the duplicate. This is exactly the
+// physical situation DuckLake's "multiple snapshots returned" probe trips on.
+func injectDuplicateLatestSnapshot(t *testing.T, catalogPath string) {
+	t.Helper()
+	sdb, err := sql.Open("sqlite", "file:"+catalogPath+"?_pragma=foreign_keys(0)")
+	if err != nil {
+		t.Fatalf("open catalog for injection: %v", err)
+	}
+	sdb.SetMaxOpenConns(1)
+	defer sdb.Close()
+
+	// Drop the UNIQUE-enforcing PRIMARY KEY by rebuilding the table without it.
+	stmts := []string{
+		`ALTER TABLE ducklake_snapshot RENAME TO _ds_old`,
+		`CREATE TABLE ducklake_snapshot (snapshot_id BIGINT, snapshot_time VARCHAR, schema_version BIGINT, next_catalog_id BIGINT, next_file_id BIGINT)`,
+		`INSERT INTO ducklake_snapshot SELECT snapshot_id, snapshot_time, schema_version, next_catalog_id, next_file_id FROM _ds_old`,
+		`DROP TABLE _ds_old`,
+		// The duplicate latest-snapshot row.
+		`INSERT INTO ducklake_snapshot (snapshot_id, snapshot_time, schema_version, next_catalog_id, next_file_id)
+		 SELECT snapshot_id, snapshot_time, schema_version, next_catalog_id, next_file_id
+		 FROM ducklake_snapshot WHERE snapshot_id = (SELECT MAX(snapshot_id) FROM ducklake_snapshot)`,
+	}
+	for _, s := range stmts {
+		if _, err := sdb.Exec(s); err != nil {
+			t.Fatalf("inject duplicate snapshot %q: %v", s, err)
+		}
+	}
+}

--- a/src/storage/ducklake/repair_test.go
+++ b/src/storage/ducklake/repair_test.go
@@ -52,6 +52,12 @@ func TestRepairCatalogSnapshots(t *testing.T) {
 	if !res.Changed() {
 		t.Errorf("Changed()=false want true")
 	}
+	if res.LatestSnapshotRows != 1 {
+		t.Errorf("LatestSnapshotRows=%d want 1 after repair", res.LatestSnapshotRows)
+	}
+	if !res.Healthy() {
+		t.Errorf("Healthy()=false want true after repair")
+	}
 
 	// Verify the kept snapshot row is the last-written one (next_file_id=31).
 	db2 := openTestCatalog(t, path)
@@ -67,6 +73,111 @@ func TestRepairCatalogSnapshots(t *testing.T) {
 	}
 	if keptFileID != 31 {
 		t.Errorf("kept next_file_id=%d want 31 (latest)", keptFileID)
+	}
+}
+
+// TestRepairCatalogSnapshotsAffinity reproduces the silent-failure case: the
+// duplicate latest snapshot_id is stored once as INTEGER and once as TEXT. A
+// plain GROUP BY snapshot_id sees two distinct keys and finds no duplicate,
+// but DuckLake reads the column as BIGINT and aborts with "multiple snapshots".
+// The CAST-normalized dedup must catch and fix it.
+func TestRepairCatalogSnapshotsAffinity(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "catalog.sqlite")
+	db := openTestCatalog(t, path)
+	for _, s := range []string{
+		`CREATE TABLE ducklake_snapshot (snapshot_id, next_file_id BIGINT)`,
+		`INSERT INTO ducklake_snapshot VALUES (1,10),(2,20)`,
+		// snapshot 2 duplicated, but stored as TEXT '2' so a raw GROUP BY misses it.
+		`INSERT INTO ducklake_snapshot VALUES ('2',21)`,
+	} {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("setup %q: %v", s, err)
+		}
+	}
+	db.Close()
+
+	res, err := RepairCatalogSnapshots(path)
+	if err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+	if res.DuplicateSnapshots != 1 {
+		t.Errorf("DuplicateSnapshots=%d want 1 (affinity duplicate)", res.DuplicateSnapshots)
+	}
+	if res.LatestSnapshotRows != 1 {
+		t.Errorf("LatestSnapshotRows=%d want 1 after repair", res.LatestSnapshotRows)
+	}
+	if !res.Healthy() {
+		t.Errorf("Healthy()=false want true after repair")
+	}
+}
+
+func TestRepairCatalogSnapshotChanges(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "catalog.sqlite")
+	db := openTestCatalog(t, path)
+	for _, s := range []string{
+		`CREATE TABLE ducklake_snapshot (snapshot_id BIGINT, next_file_id BIGINT)`,
+		`CREATE TABLE ducklake_snapshot_changes (snapshot_id BIGINT, changes_made TEXT)`,
+		`INSERT INTO ducklake_snapshot VALUES (1,10),(2,20)`,
+		`INSERT INTO ducklake_snapshot_changes VALUES (1,'a'),(2,'b'),(2,'b')`,
+	} {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("setup %q: %v", s, err)
+		}
+	}
+	db.Close()
+
+	res, err := RepairCatalogSnapshots(path)
+	if err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+	if res.DuplicateSnapshotChanges != 1 {
+		t.Errorf("DuplicateSnapshotChanges=%d want 1", res.DuplicateSnapshotChanges)
+	}
+	if !res.Changed() {
+		t.Errorf("Changed()=false want true")
+	}
+}
+
+// TestRepairCatalogDuplicateTableNames covers the sipcapture/homer#809 case:
+// two writers each registered the same table_name under a different table_id.
+// We must DETECT (not auto-delete) it so the operator runs --rebuild-catalog.
+func TestRepairCatalogDuplicateTableNames(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "catalog.sqlite")
+	db := openTestCatalog(t, path)
+	for _, s := range []string{
+		`CREATE TABLE ducklake_snapshot (snapshot_id BIGINT, next_file_id BIGINT)`,
+		`INSERT INTO ducklake_snapshot VALUES (1,10)`,
+		`CREATE TABLE ducklake_table (table_id BIGINT, table_name TEXT, end_snapshot BIGINT)`,
+		// hep_proto_1_siprec registered twice under ids 313 and 400, both live.
+		`INSERT INTO ducklake_table VALUES (313,'hep_proto_1_siprec',NULL),(400,'hep_proto_1_siprec',NULL),(5,'hep_proto_1_call',NULL)`,
+	} {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("setup %q: %v", s, err)
+		}
+	}
+	db.Close()
+
+	res, err := RepairCatalogSnapshots(path)
+	if err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+	if res.DuplicateTableNames != 1 {
+		t.Errorf("DuplicateTableNames=%d want 1", res.DuplicateTableNames)
+	}
+	if res.DuplicateTables != 0 {
+		t.Errorf("DuplicateTables=%d want 0 (ids are distinct, must not auto-delete)", res.DuplicateTables)
+	}
+	if !res.NeedsRebuild() {
+		t.Errorf("NeedsRebuild()=false want true")
+	}
+	// The duplicate-name rows must still be present (we only detect, never delete).
+	db2 := openTestCatalog(t, path)
+	var cnt int
+	if err := db2.QueryRow(`SELECT COUNT(*) FROM ducklake_table`).Scan(&cnt); err != nil {
+		t.Fatal(err)
+	}
+	if cnt != 3 {
+		t.Errorf("ducklake_table rows=%d want 3 (no rows deleted)", cnt)
 	}
 }
 

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.269"
+	VERSION_APPLICATION = "11.0.270"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary

Hardens the startup DuckLake catalog auto-repair so it actually resolves the `Corrupt DuckLake - multiple snapshots returned from database` error instead of silently doing nothing. Closes the gap reported in #809.

The previous auto-repair could log **nothing** (it only logged when it removed rows) while DuckDB kept aborting every query. Root causes:

- **Wrong engine / stale WAL.** The repair read the catalog through the pure‑Go `modernc` SQLite driver — a different engine than DuckDB — and never folded a leftover WAL (from an OOM‑killed writer) into the main DB before counting. It now runs `PRAGMA wal_checkpoint(TRUNCATE)` before and after the dedup, so it inspects exactly the rows DuckDB will read and leaves a consolidated main DB for the ATTACH.
- **SQLite type affinity.** Dedup grouped by raw `snapshot_id`; SQLite groups by storage class, so an id stored once as `INTEGER 5` and once as `TEXT '5'` looked like two distinct keys (no duplicate found) while DuckLake reads both as `BIGINT` and aborts. Dedup now groups by `CAST(id AS INTEGER)` to match DuckLake's view.
- **Missing table.** Also dedups `ducklake_snapshot_changes` (shares the `snapshot_id` PK).

Added a **post‑repair verification** that reproduces DuckLake's exact latest‑snapshot probe. If it still returns >1 row, the writer logs a loud `ERROR` pointing at `homer system --rebuild-catalog` instead of failing silently.

For the harder #809 damage (physically **malformed** files; **duplicate table registrations** — same `table_name`, different `table_id`): these are **detected and surfaced** with the precise remediation (`.dump`/reimport salvage or `--rebuild-catalog`) rather than auto‑deleted, because blindly deleting them orphans `ducklake_data_file` rows and silently loses data.

### Note on scope
Current DuckLake declares `ducklake_snapshot(snapshot_id BIGINT PRIMARY KEY)`, which SQLite enforces as UNIQUE — so a healthy current catalog cannot accumulate literal duplicate snapshot rows. This auto‑repair fixes the duplicate‑row form (legacy/non‑enforcing catalogs, or rows left after the index stopped enforcing uniqueness). A physically malformed catalog still requires the salvage/rebuild path, which the code now detects and reports.

## Test plan

- [x] `go test ./storage/ducklake/ -run TestRepair` — all unit tests pass
- [x] New **end‑to‑end** test `TestRepairFixesRealDuckLakeCorruption` drives the real DuckDB+DuckLake engine: build a catalog with data, inject the duplicate‑latest‑snapshot corruption, confirm DuckDB aborts with the #809 error, run the repair, confirm DuckDB queries succeed again with all data preserved
- [x] `go build` + `go vet` clean
- [ ] Verify against a real corrupted catalog from a #809 reproduction