### PR TITLE
feat(search): lazy payload hydration (uuid-first search) — 11.0.273

### DIFF
--- a/docs/OOM.md
+++ b/docs/OOM.md
@@ -142,7 +142,8 @@ one hour):
   "ducklake": {
     "search": {
       "lake_topn_strategy": "stream", // stream (default) | chunked | full
-      "lake_chunk_sec": 3600           // window width for "chunked"
+      "lake_chunk_sec": 3600,          // window width for "chunked"
+      "lazy_payload": true             // narrow search + by-uuid payload hydration (default true)
     }
   }
 }
@@ -184,6 +185,31 @@ runs each window as a single efficient scan instead of slicing it into 1h
 windows. Such queries return few rows (no memory risk), and slicing a
 non-prunable full-scan filter into many tiny per-window scans multiplies the
 catalog/Parquet open overhead and serialises them — which previously timed out.
+
+### Lazy payload hydration (`search.lazy_payload`, default on)
+
+The dominant memory cost of a wide-row search is decompressing the `payload`
+(and `data_extra`) columns. DuckDB only does late materialization for small
+`Top-N`; for large `LIMIT`s it falls back to a full `ORDER BY` and eagerly
+decompresses the wide columns for **every scanned row** — so even a query that
+returns 0 rows can OOM (`LIMIT 50` is fine, `LIMIT 50000` is not).
+
+With `lazy_payload` enabled (default), a transaction search runs in two phases:
+
+1. **Search/sort over a narrow projection** — every column *except*
+   `payload` / `data_extra`. This is what does the filtering, ordering and
+   `LIMIT`, and it stays memory-flat because the wide blobs are never read.
+2. **By-uuid hydration** — a single bounded point-lookup
+   (`SELECT uuid, payload, data_extra … WHERE uuid IN (…)`, pruned to the
+   timestamp span of the matched rows) re-attaches the wide columns for *only*
+   the `<= LIMIT` rows actually returned.
+
+Net effect: the heavy `payload` column is decompressed for at most `LIMIT`
+rows, never for the whole scanned range. The API response is unchanged
+(full rows including `payload`). Disable with
+`storage.ducklake.search.lazy_payload: false` (e.g. for debugging). Applies to
+default full-row searches only — custom `select` / `group_by` and OTLP/LP
+tables bypass it. Log: `V4TransactionsSearch: hydrating payload by uuid`.
 
 ## 6) Native Go Compaction Engine
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -389,6 +389,13 @@ type CoordinatorConfig struct {
 	// single query over the whole range.
 	LakeChunkSec int `json:"lake_chunk_sec" mapstructure:"lake_chunk_sec" default:"86400"`
 
+	// LazyPayload runs transaction searches in two phases: a narrow search/sort
+	// that omits the wide blob columns (payload, data_extra), then a bounded
+	// by-uuid point-lookup that re-attaches them. Keeps memory flat on large
+	// LIMITs over wide SIP rows while preserving the full-row response.
+	// Auto-populated from storage.ducklake.search.lazy_payload at startup.
+	LazyPayload bool `json:"lazy_payload" mapstructure:"lazy_payload" default:"true"`
+
 	// IPAliasCacheTTLSec is how long the in-memory IP→alias LPM table is reused between
 	// ListActive rebuilds (search/QoS/message enrichment). CRUD on aliases still invalidates
 	// immediately. Default 30, min 5, max 86400 (24h). Zero means use the default.
@@ -693,6 +700,13 @@ type SearchConfig struct {
 	// Smaller windows bound memory tighter at the cost of more sub-queries when
 	// data is sparse. Default 3600 (1 hour).
 	LakeChunkSec int `json:"lake_chunk_sec" mapstructure:"lake_chunk_sec" default:"3600"`
+	// LazyPayload runs transaction searches in two phases: a narrow search/sort
+	// over all columns except the wide blobs (payload, data_extra), then a
+	// bounded by-uuid point-lookup that re-attaches them. This avoids
+	// decompressing the wide payload column for the whole scanned range — only
+	// the <=LIMIT returned rows pay that cost — so large LIMITs stay memory-safe
+	// without sacrificing the full-row response. Default true.
+	LazyPayload bool `json:"lazy_payload" mapstructure:"lazy_payload" default:"true"`
 }
 
 // StoragePolicyConfig configures tiered storage with hot and cold volumes

--- a/src/coordinator/coordinator.go
+++ b/src/coordinator/coordinator.go
@@ -203,6 +203,7 @@ func (c *Coordinator) setupRoutes() {
 	authTokenSvc := services.NewAuthTokenService(c.settingsDB)
 	mapSvc := services.NewMappingService(c.settingsDB)
 	searchHandler := handlers.NewSearchHandler(c.flightService, aliasSvc, &c.config.MCP, shareExportSvc, viewTokenSvc, c.config.TransactionViewMaxOpens, mapSvc, c.config.LakeTopNStrategy, c.config.LakeChunkSec)
+	searchHandler.SetLazyPayloadHydration(c.config.LazyPayload)
 	if c.correlation != nil {
 		searchHandler.SetCorrelator(correlatorAdapter{engine: c.correlation})
 	}

--- a/src/coordinator/handlers/lazy_payload_test.go
+++ b/src/coordinator/handlers/lazy_payload_test.go
@@ -1,0 +1,92 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLazyPayloadEligible(t *testing.T) {
+	mk := func(sel, group string, proto int) *SearchObjectV4 {
+		r := &SearchObjectV4{}
+		r.Param.Select = sel
+		r.Param.GroupBy = group
+		r.Filter.ProtoType = proto
+		return r
+	}
+	cases := []struct {
+		name string
+		on   bool
+		req  *SearchObjectV4
+		want bool
+	}{
+		{"default SIP", true, mk("", "", 1), true},
+		{"proto unset defaults to SIP", true, mk("", "", 0), true},
+		{"disabled by flag", false, mk("", "", 1), false},
+		{"custom select", true, mk("uuid, caller", "", 1), false},
+		{"group by", true, mk("", "method", 1), false},
+	}
+	for _, c := range cases {
+		h := &SearchHandler{lazyPayloadHydration: c.on}
+		if got := h.lazyPayloadEligible(c.req); got != c.want {
+			t.Errorf("%s: lazyPayloadEligible=%v want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestLazyPayloadEligibleOTLPAndLP(t *testing.T) {
+	h := &SearchHandler{lazyPayloadHydration: true}
+	// OTLP / LP virtual proto types have no uuid/payload pair and must be excluded.
+	for _, proto := range []int{otlpHepIDTraces, otlpHepIDMetrics, otlpHepIDLogs, lpHepID} {
+		req := &SearchObjectV4{}
+		req.Filter.ProtoType = proto
+		if h.lazyPayloadEligible(req) {
+			t.Errorf("proto %d (OTLP/LP) should not be eligible", proto)
+		}
+	}
+}
+
+func TestNarrowProjectionDropsHeavyColumns(t *testing.T) {
+	req := &SearchObjectV4{}
+	req.Filter.ProtoType = 1
+	req.Timestamp.From = 1_700_000_000_000
+	req.Timestamp.To = 1_700_003_600_000
+	req.Param.Limit = 50
+
+	sql, err := buildSearchSQLV4WithOpts("homer_lake", req, nil, searchSQLOpts{narrowNoHeavy: true})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if !strings.Contains(sql, narrowProjectionExpr) {
+		t.Errorf("narrow SQL missing projection %q: %s", narrowProjectionExpr, sql)
+	}
+	if strings.Contains(sql, "SELECT * FROM") {
+		t.Errorf("narrow SQL should not select *: %s", sql)
+	}
+
+	// Without the opt the default SELECT * is preserved.
+	full, err := buildSearchSQLV4WithOpts("homer_lake", req, nil, searchSQLOpts{})
+	if err != nil {
+		t.Fatalf("build full: %v", err)
+	}
+	if !strings.Contains(full, "SELECT * FROM") {
+		t.Errorf("default SQL should select *: %s", full)
+	}
+}
+
+func TestNarrowProjectionIgnoredWithCustomSelect(t *testing.T) {
+	req := &SearchObjectV4{}
+	req.Filter.ProtoType = 1
+	req.Param.Select = "uuid, caller, callee"
+	req.Param.Limit = 50
+
+	sql, err := buildSearchSQLV4WithOpts("homer_lake", req, nil, searchSQLOpts{narrowNoHeavy: true})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if strings.Contains(sql, narrowProjectionExpr) {
+		t.Errorf("custom select must win over narrow projection: %s", sql)
+	}
+	if !strings.Contains(sql, "uuid, caller, callee") {
+		t.Errorf("custom select columns missing: %s", sql)
+	}
+}

--- a/src/coordinator/handlers/search.go
+++ b/src/coordinator/handlers/search.go
@@ -79,6 +79,12 @@ type SearchHandler struct {
 	// lakeChunkSec is the stream-strategy time-window width in seconds (<=0 =>
 	// 1h default). Mirrors storage.ducklake.search.lake_chunk_sec.
 	lakeChunkSec int
+	// lazyPayloadHydration runs transaction searches in two phases: a narrow
+	// search/sort that omits the wide blob columns (payload, data_extra),
+	// followed by a bounded point-lookup that re-attaches those columns by
+	// uuid. This keeps memory flat on large LIMITs over wide SIP rows. Mirrors
+	// storage.ducklake.search.lazy_payload (default on).
+	lazyPayloadHydration bool
 }
 
 // NewSearchHandler creates a new search handler.
@@ -107,7 +113,14 @@ func NewSearchHandler(fs *services.FlightService, aliasSvc *services.AliasServic
 		mappingService:          mappingSvc,
 		lakeTopNStrategyCfg:     lakeTopNStrategy,
 		lakeChunkSec:            lakeChunkSec,
+		lazyPayloadHydration:    true,
 	}
+}
+
+// SetLazyPayloadHydration toggles the two-phase (narrow search + by-uuid
+// hydration) execution of transaction searches. Defaults to enabled.
+func (h *SearchHandler) SetLazyPayloadHydration(enabled bool) {
+	h.lazyPayloadHydration = enabled
 }
 
 // SetCorrelator attaches (or clears) the Lua-based correlation engine used

--- a/src/coordinator/handlers/transactions_v4.go
+++ b/src/coordinator/handlers/transactions_v4.go
@@ -677,22 +677,48 @@ func transactionSearchTopNShape(req *SearchObjectV4) bool {
 func (h *SearchHandler) queryTransactionSearch(ctx context.Context, fullSQL string, req *SearchObjectV4, virtualRules map[string]services.VirtualFieldRule) ([]map[string]interface{}, error) {
 	strategy := h.lakeTopNStrategy()
 
+	// lazy: run the search/sort over a narrow projection (no payload/data_extra)
+	// and re-attach those wide columns by uuid afterwards. Keeps memory flat on
+	// large LIMITs over wide SIP rows while preserving the full-row response.
+	lazy := h.lazyPayloadEligible(req)
+
+	rows, err := h.runTransactionSearch(ctx, fullSQL, req, virtualRules, strategy, lazy)
+	if err != nil {
+		return nil, err
+	}
+	if lazy {
+		rows = h.hydrateHeavyColumns(ctx, req, rows)
+	}
+	return rows, nil
+}
+
+// runTransactionSearch executes the search/sort phase for the configured
+// strategy. When narrow is true the wide blob columns are dropped from the
+// projection (the caller re-attaches them by uuid).
+func (h *SearchHandler) runTransactionSearch(ctx context.Context, fullSQL string, req *SearchObjectV4, virtualRules map[string]services.VirtualFieldRule, strategy string, narrow bool) ([]map[string]interface{}, error) {
 	// full, or shapes we cannot safely rewrite (aggregations, custom projection
 	// or non-default ordering must see the whole range at once): single query.
 	if strategy == topNFull || !transactionSearchTopNShape(req) {
-		return h.flightService.Query(ctx, fullSQL)
+		if !narrow {
+			return h.flightService.Query(ctx, fullSQL)
+		}
+		sql, err := buildSearchSQLV4WithOpts(h.flightService.LakeName(), req, virtualRules, searchSQLOpts{narrowNoHeavy: true})
+		if err != nil {
+			return nil, err
+		}
+		return h.flightService.Query(ctx, sql)
 	}
 
 	// stream: a single query over the whole range, ORDER BY dropped, re-sorted
 	// in Go. No chunking.
 	if strategy == topNStream {
 		limit := effectiveSearchLimit(req.Param.Limit)
-		streamSQL, err := buildSearchSQLV4WithOpts(h.flightService.LakeName(), req, virtualRules, searchSQLOpts{noOrderBy: true})
+		streamSQL, err := buildSearchSQLV4WithOpts(h.flightService.LakeName(), req, virtualRules, searchSQLOpts{noOrderBy: true, narrowNoHeavy: narrow})
 		if err != nil {
 			return nil, err
 		}
 		logger.Info("V4TransactionsSearch: stream execution (single query)", "limit", limit,
-			"from", req.Timestamp.From, "to", req.Timestamp.To)
+			"narrow", narrow, "from", req.Timestamp.From, "to", req.Timestamp.To)
 		rows, err := h.flightService.Query(ctx, streamSQL)
 		if err != nil {
 			return nil, err
@@ -706,7 +732,7 @@ func (h *SearchHandler) queryTransactionSearch(ctx context.Context, fullSQL stri
 	chunks := splitSearchTimeRange(req.Timestamp.From, req.Timestamp.To, h.outerChunkMs())
 	limit := effectiveSearchLimit(req.Param.Limit)
 	logger.Info("V4TransactionsSearch: chunked execution",
-		"strategy", strategy, "chunks", len(chunks), "limit", limit,
+		"strategy", strategy, "chunks", len(chunks), "limit", limit, "narrow", narrow,
 		"from", req.Timestamp.From, "to", req.Timestamp.To)
 
 	results := make([]map[string]interface{}, 0, limit)
@@ -718,7 +744,7 @@ func (h *SearchHandler) queryTransactionSearch(ctx context.Context, fullSQL stri
 		chunkReq.Timestamp.From = chunk.FromMs
 		chunkReq.Timestamp.To = chunk.ToMs
 		sql, err := buildSearchSQLV4WithOpts(h.flightService.LakeName(), &chunkReq, virtualRules,
-			searchSQLOpts{toExclusive: !chunk.ToInclusive})
+			searchSQLOpts{toExclusive: !chunk.ToInclusive, narrowNoHeavy: narrow})
 		if err != nil {
 			return nil, err
 		}
@@ -737,6 +763,135 @@ func (h *SearchHandler) queryTransactionSearch(ctx context.Context, fullSQL stri
 		results = results[:limit]
 	}
 	return results, nil
+}
+
+// lazyPayloadEligible reports whether a request can use the two-phase
+// (narrow search + by-uuid hydration) path. It requires the default full-row
+// projection (no custom select / group by) on a HEP proto table — OTLP and LP
+// tables have a different column layout with no uuid / payload pair.
+func (h *SearchHandler) lazyPayloadEligible(req *SearchObjectV4) bool {
+	if !h.lazyPayloadHydration {
+		return false
+	}
+	if strings.TrimSpace(req.Param.Select) != "" || strings.TrimSpace(req.Param.GroupBy) != "" {
+		return false
+	}
+	protoType := req.Filter.ProtoType
+	if protoType == 0 {
+		protoType = 1
+	}
+	if isOTLPProtoType(protoType) || isLPProtoType(protoType) {
+		return false
+	}
+	return true
+}
+
+// hydrateHeavyColumns re-attaches the wide blob columns (payload, data_extra)
+// to a narrow result set with a single bounded point-lookup keyed by uuid.
+// Because the lookup is filtered to the exact matched uuids (and pruned to the
+// timestamp span of those rows), DuckDB only decompresses the heavy columns for
+// the <=LIMIT rows we actually return — never the whole scanned range. Any
+// failure degrades gracefully: the narrow rows are returned unchanged.
+func (h *SearchHandler) hydrateHeavyColumns(ctx context.Context, req *SearchObjectV4, rows []map[string]interface{}) []map[string]interface{} {
+	if len(rows) == 0 {
+		return rows
+	}
+
+	uuids := make([]string, 0, len(rows))
+	seen := make(map[string]struct{}, len(rows))
+	var minMs, maxMs int64
+	for _, r := range rows {
+		u := rowStringValue(r["uuid"])
+		if u == "" {
+			continue
+		}
+		if _, dup := seen[u]; !dup {
+			seen[u] = struct{}{}
+			uuids = append(uuids, u)
+		}
+		if ns := rowTimestampSortKey(r); ns > 0 {
+			ms := ns / int64(time.Millisecond)
+			if minMs == 0 || ms < minMs {
+				minMs = ms
+			}
+			if ms > maxMs {
+				maxMs = ms
+			}
+		}
+	}
+	if len(uuids) == 0 {
+		// No uuid column (unexpected for HEP tables) — nothing to hydrate.
+		return rows
+	}
+
+	// Prune the lookup to the timestamp span of the matched rows (padded for
+	// sub-ms rounding). The uuid IN filter is what guarantees correctness, so
+	// these bounds only narrow the files scanned. Fall back to the request
+	// range if no row timestamps parsed.
+	const padMs = int64(60 * 1000)
+	fromMs, toMs := minMs-padMs, maxMs+padMs
+	if minMs <= 0 || maxMs <= 0 {
+		fromMs, toMs = req.Timestamp.From, req.Timestamp.To
+	}
+
+	protoType := req.Filter.ProtoType
+	if protoType == 0 {
+		protoType = 1
+	}
+	tableName := getTableName(h.flightService.LakeName(), protoType, req.Filter.EventType)
+
+	conditions := timestampRangeConditions("timestamp", fromMs, toMs, false)
+	escaped := make([]string, len(uuids))
+	for i, u := range uuids {
+		escaped[i] = "'" + sqlvalidator.SafeString(u) + "'"
+	}
+	conditions = append(conditions, "uuid IN ("+strings.Join(escaped, ",")+")")
+	sql := fmt.Sprintf("SELECT uuid, %s FROM %s WHERE %s", heavyProjectionExpr, tableName, strings.Join(conditions, " AND "))
+
+	logger.Info("V4TransactionsSearch: hydrating payload by uuid", "uuids", len(uuids),
+		"from", fromMs, "to", toMs)
+	heavyRows, err := h.flightService.Query(ctx, sql)
+	if err != nil {
+		// Degrade gracefully: return the narrow rows so the search still
+		// succeeds (payload simply absent). This also covers tables that have
+		// neither heavy column (COLUMNS lambda matches nothing).
+		logger.Warn("V4TransactionsSearch: payload hydration failed, returning narrow rows",
+			"error", err)
+		return rows
+	}
+
+	byUUID := make(map[string]map[string]interface{}, len(heavyRows))
+	for _, r := range heavyRows {
+		if u := rowStringValue(r["uuid"]); u != "" {
+			byUUID[u] = r
+		}
+	}
+
+	for _, r := range rows {
+		u := rowStringValue(r["uuid"])
+		hv := byUUID[u]
+		for _, col := range heavyColumns {
+			if v, ok := hv[col]; ok {
+				r[col] = v
+			} else if _, exists := r[col]; !exists {
+				// Keep response keys uniform even when a row had no match.
+				r[col] = nil
+			}
+		}
+	}
+	return rows
+}
+
+// rowStringValue coerces a result-set cell to a string, handling the string /
+// []byte shapes the Flight result decoder may produce.
+func rowStringValue(v interface{}) string {
+	switch s := v.(type) {
+	case string:
+		return s
+	case []byte:
+		return string(s)
+	}
+	return ""
 }
 
 func (h *SearchHandler) V4TransactionsSearch(c echo.Context) error {
@@ -2369,7 +2524,28 @@ type searchSQLOpts struct {
 	// range. The caller is expected to re-sort the rows in Go. Only honored for
 	// the default timestamp-DESC ordering (custom order_by still emits ORDER BY).
 	noOrderBy bool
+	// narrowNoHeavy replaces a default "SELECT *" with a projection that drops
+	// the wide blob columns (payload, data_extra). This keeps the search/sort
+	// phase memory-flat — the heavy columns are re-attached afterwards by uuid
+	// in a bounded point-lookup (see hydrateHeavyColumns). Ignored when a
+	// custom select is supplied.
+	narrowNoHeavy bool
 }
+
+// heavyColumns are the wide blob columns excluded from the search/sort phase
+// and re-fetched by uuid afterwards. payload is the dominant memory cost on
+// SIP rows; data_extra is a JSON blob that can also be large.
+var heavyColumns = []string{"payload", "data_extra"}
+
+// narrowProjectionExpr is a "SELECT *"-style projection that omits the heavy
+// blob columns. The COLUMNS(lambda) form is schema-agnostic and does not error
+// when a table lacks one of the columns (unlike "* EXCLUDE (...)").
+const narrowProjectionExpr = "COLUMNS(c -> c NOT IN ('payload', 'data_extra'))"
+
+// heavyProjectionExpr selects only the heavy blob columns that exist on a
+// table. Used by the phase-2 hydration query. Errors if a table has none of
+// them, which the caller treats as "nothing to hydrate".
+const heavyProjectionExpr = "COLUMNS(c -> c IN ('payload', 'data_extra'))"
 
 // timestampRangeConditions renders WHERE bounds for a [fromMs, toMs] window
 // in epoch milliseconds. Zero values omit the corresponding bound.
@@ -2554,6 +2730,10 @@ func buildSearchSQLV4WithOpts(lakeName string, req *SearchObjectV4, virtualRules
 			return "", fmt.Errorf("invalid select: %w", err)
 		}
 		selectClause = strings.TrimSpace(req.Param.Select)
+	} else if opts.narrowNoHeavy {
+		// Drop the wide blob columns for the search/sort phase; they are
+		// re-attached by uuid afterwards (hydrateHeavyColumns).
+		selectClause = narrowProjectionExpr
 	}
 
 	sql := fmt.Sprintf("SELECT %s FROM %s", selectClause, tableName)

--- a/src/coordinator/handlers/transactions_v4.go
+++ b/src/coordinator/handlers/transactions_v4.go
@@ -824,14 +824,21 @@ func (h *SearchHandler) hydrateHeavyColumns(ctx context.Context, req *SearchObje
 		return rows
 	}
 
-	// Prune the lookup to the timestamp span of the matched rows (padded for
-	// sub-ms rounding). The uuid IN filter is what guarantees correctness, so
-	// these bounds only narrow the files scanned. Fall back to the request
-	// range if no row timestamps parsed.
+	// Bound the lookup by the timestamp span of the matched rows (padded for
+	// sub-ms rounding), falling back to the request range. The timestamp
+	// predicate is REQUIRED for memory safety: DuckDB pushes a timestamp range
+	// down into the Parquet scan and late-materializes payload only for the
+	// surviving rows, but a bare "uuid IN (…)" (uuid has no useful min/max
+	// stats) forces a full eager decompression of the wide column and OOMs.
+	// If we cannot establish any bound, skip hydration and return narrow rows.
 	const padMs = int64(60 * 1000)
 	fromMs, toMs := minMs-padMs, maxMs+padMs
 	if minMs <= 0 || maxMs <= 0 {
 		fromMs, toMs = req.Timestamp.From, req.Timestamp.To
+	}
+	if fromMs <= 0 && toMs <= 0 {
+		logger.Warn("V4TransactionsSearch: no timestamp bound for payload hydration, returning narrow rows")
+		return rows
 	}
 
 	protoType := req.Filter.ProtoType

--- a/src/main.go
+++ b/src/main.go
@@ -593,6 +593,12 @@ func runServer() {
 			// NB: coordinator.lake_chunk_sec is the OUTER window (default 24h) and
 			// is intentionally NOT taken from the node's search.lake_chunk_sec
 			// (the node's 1h INNER sub-split); they are different layers.
+			// Propagate the lazy-payload (narrow search + by-uuid hydration)
+			// toggle so the coordinator search path honours the same knob.
+			cfg.Coordinator.LazyPayload = cfg.Storage.DuckLake.Search.LazyPayload
+			if cfg.Node.Enable {
+				cfg.Coordinator.LazyPayload = cfg.Node.DuckLake.Search.LazyPayload
+			}
 			cfg.Coordinator.MCP = cfg.MCP
 			if HasEmbeddedUI() {
 				coordinator.WebAssets = &WebAssets

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.272"
+	VERSION_APPLICATION = "11.0.273"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary

Implements the **uuid-first / lazy-payload** search the user asked for, in a dedicated branch. Transaction searches now run in two phases so the wide `payload` column is never the bottleneck:

1. **Narrow search/sort** — the filtering, ordering and `LIMIT` run over every column *except* the wide blobs (`payload`, `data_extra`), dropped via a schema-agnostic `COLUMNS(c -> c NOT IN ('payload','data_extra'))` projection. Memory stays flat because the blobs are never read.
2. **By-uuid hydration** — a single bounded point-lookup (`SELECT uuid, COLUMNS(... payload/data_extra ...) WHERE uuid IN (…)`, pruned to the timestamp span of the matched rows) re-attaches the wide columns for *only* the `<= LIMIT` rows we actually return.

### Why
DuckDB only does late materialization for small `Top-N`; for large `LIMIT`s it falls back to a full `ORDER BY` and eagerly decompresses the wide `payload` for **every scanned row** — so a `LIMIT 50000` can OOM even when it returns **zero** rows (`LIMIT 50` is fine). This change caps payload decompression at `LIMIT` rows regardless of range width.

### Behavior
- API response is unchanged (full rows incl. `payload`).
- Gated by `storage.ducklake.search.lazy_payload` (default **true**), propagated to `coordinator.lazy_payload`.
- Applies to default full-row searches only; custom `select` / `group_by` and OTLP/LP tables bypass it.
- Hydration failure degrades gracefully (narrow rows returned, warning logged).
- Works with all `lake_topn_strategy` values (stream / chunked / full).

### Changes
- `searchSQLOpts.narrowNoHeavy` + narrow projection in `buildSearchSQLV4WithOpts`.
- `runTransactionSearch` (narrow phase) + `hydrateHeavyColumns` (phase 2) in `transactions_v4.go`.
- `SearchHandler.lazyPayloadHydration` + `SetLazyPayloadHydration`, wired from config.
- Config: `SearchConfig.LazyPayload`, `Coordinator.LazyPayload`, propagation in `main.go`.
- Docs: `docs/OOM.md` lazy-payload section.
- Version `11.0.272 → 11.0.273`.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] New unit tests: `TestLazyPayloadEligible`, `...OTLPAndLP`, `TestNarrowProjectionDropsHeavyColumns`, `TestNarrowProjectionIgnoredWithCustomSelect`
- [x] `go test ./coordinator/... ./config/... ./node/...` green (pre-existing unrelated `mapping_seed_test` failures confirmed on base)
- [ ] Live test: large `LIMIT` search over 30 days no longer OOMs; payload present in results