### PR TITLE
fix(tiering): use AWS credential_chain when S3 volume has no static keys

### DIFF
--- a/scripts/download_duckdb_extensions.sh
+++ b/scripts/download_duckdb_extensions.sh
@@ -27,7 +27,9 @@ mkdir -p "${ext_dir}"
 
 echo "Downloading DuckDB ${DUCKDB_VERSION} extensions for ${EXT_PLATFORM}..."
 
-for ext in ducklake; do
+# httpfs + aws are required for S3 secrets using PROVIDER credential_chain
+# (IAM-role / instance-profile credentials); aws depends on httpfs.
+for ext in ducklake httpfs aws; do
   url="https://extensions.duckdb.org/${DUCKDB_VERSION}/${EXT_PLATFORM}/${ext}.duckdb_extension.gz"
   dest="${ext_dir}/${ext}.duckdb_extension"
   echo "  ${url} -> ${dest}"

--- a/src/cli/system_cmd.go
+++ b/src/cli/system_cmd.go
@@ -133,7 +133,7 @@ func RegisterSystemFlags() (*flag.FlagSet, *systemFlagRefs) {
 	refs.CompactionMergeListLimit = fs.Int("compaction-merge-list-limit", 50, "limit for compaction-merge-list output")
 	refs.RebuildCatalog = fs.Bool("rebuild-catalog", false, "fix a corrupt catalog: back up the existing catalog and rebuild it by registering the on-disk parquet files in place (no rewrite), then exit")
 	refs.RebuildCleanupOrphans = fs.Bool("rebuild-cleanup-orphans", false, "with --rebuild-catalog: after a successful rebuild, sweep genuinely unreferenced leftover files (registered originals are kept)")
-	refs.InstallExtensions = fs.Bool("install-extensions", false, "install DuckDB extensions (ducklake, sqlite) and exit")
+	refs.InstallExtensions = fs.Bool("install-extensions", false, "install DuckDB extensions (ducklake, sqlite, httpfs, aws) and exit")
 	refs.Reload = fs.Bool("reload", false, "send SIGHUP to running homer-core process to reload config")
 	refs.PidFile = fs.String("pid-file", "/var/run/homer-core.pid", "path to PID file (used with --reload)")
 	refs.DuckDBVersion = fs.Bool("duckdb-version", false, "show DuckDB version and exit")
@@ -912,7 +912,7 @@ func installDuckDBExtensions() error {
 	}
 	defer db.Close()
 
-	extensions := []string{"ducklake", "sqlite"}
+	extensions := []string{"ducklake", "sqlite", "httpfs", "aws"}
 
 	for _, ext := range extensions {
 		fmt.Printf("Installing %s extension...\n", ext)

--- a/src/storage/ducklake/tiered_storage.go
+++ b/src/storage/ducklake/tiered_storage.go
@@ -134,6 +134,15 @@ func (tsm *TieredStorageManager) Start() error {
 		return fmt.Errorf("failed to load sqlite extension: %w", err)
 	}
 
+	// Load the AWS extension so S3 secrets can use PROVIDER credential_chain
+	// (resolves IAM-role / instance-profile / env credentials via the AWS SDK).
+	// Must be pre-installed (run homer-core --install-extensions, or bundled
+	// offline). Best-effort: static-key or local-only setups do not need it,
+	// so a load failure must not block startup.
+	if _, err := db.Exec("LOAD aws;"); err != nil {
+		logger.Warn("TieredStorageManager: failed to load aws extension (credential_chain unavailable; run --install-extensions)", "error", err)
+	}
+
 	// Attach each volume as a separate DuckLake
 	for _, vol := range tsm.volumes {
 		if err := tsm.attachVolume(vol); err != nil {
@@ -173,30 +182,7 @@ func (tsm *TieredStorageManager) attachVolume(vol *Volume) error {
 			region = "us-east-1"
 		}
 
-		// Create secret with S3 credentials
-		var createSecret string
-		if endpoint != "" {
-			createSecret = fmt.Sprintf(`
-				CREATE SECRET %s (
-					TYPE S3,
-					KEY_ID '%s',
-					SECRET '%s',
-					REGION '%s',
-					ENDPOINT '%s',
-					URL_STYLE 'path',
-					USE_SSL %t
-				);
-			`, secretName, vol.S3AccessKey, vol.S3SecretKey, region, endpoint, vol.S3UseSSL)
-		} else {
-			createSecret = fmt.Sprintf(`
-				CREATE SECRET %s (
-					TYPE S3,
-					KEY_ID '%s',
-					SECRET '%s',
-					REGION '%s'
-				);
-			`, secretName, vol.S3AccessKey, vol.S3SecretKey, region)
-		}
+		createSecret := buildS3SecretSQL(secretName, vol.S3AccessKey, vol.S3SecretKey, region, endpoint, vol.S3UseSSL)
 
 		logger.Info("TieredStorageManager: Creating S3 secret",
 			"volume", vol.Name,
@@ -582,6 +568,51 @@ func sortResultsByTimestamp(results []map[string]interface{}) {
 		tj, _ := results[j]["timestamp"].(time.Time)
 		return ti.After(tj) // DESC
 	})
+}
+
+// buildS3SecretSQL returns the CREATE SECRET SQL for an S3 volume.
+// When accessKey is empty and endpoint is empty (native AWS S3), the secret
+// uses PROVIDER credential_chain so DuckDB resolves credentials through the
+// AWS SDK default chain (env, container/Pod Identity, instance profile).
+// Static keys and custom endpoints (MinIO / R2) use explicit KEY_ID/SECRET.
+func buildS3SecretSQL(secretName, accessKey, secretKey, region, endpoint string, useSSL bool) string {
+	switch {
+	case strings.TrimSpace(accessKey) == "" && endpoint == "":
+		// Default region for native AWS S3 so the secret signs correctly even
+		// when no s3_region is set (the SDK can also resolve it from the
+		// environment / instance metadata, but an explicit value is safer).
+		if strings.TrimSpace(region) == "" {
+			region = "us-east-1"
+		}
+		return fmt.Sprintf(`
+			CREATE SECRET %s (
+				TYPE S3,
+				PROVIDER credential_chain,
+				REGION '%s'
+			);
+		`, secretName, region)
+	case endpoint != "":
+		return fmt.Sprintf(`
+			CREATE SECRET %s (
+				TYPE S3,
+				KEY_ID '%s',
+				SECRET '%s',
+				REGION '%s',
+				ENDPOINT '%s',
+				URL_STYLE 'path',
+				USE_SSL %t
+			);
+		`, secretName, accessKey, secretKey, region, endpoint, useSSL)
+	default:
+		return fmt.Sprintf(`
+			CREATE SECRET %s (
+				TYPE S3,
+				KEY_ID '%s',
+				SECRET '%s',
+				REGION '%s'
+			);
+		`, secretName, accessKey, secretKey, region)
+	}
 }
 
 // fileExists checks if a file exists at the given path

--- a/src/storage/ducklake/tiered_storage_test.go
+++ b/src/storage/ducklake/tiered_storage_test.go
@@ -1,0 +1,155 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package ducklake
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+)
+
+// secretProvider executes the CREATE SECRET produced by buildS3SecretSQL on a
+// real DuckDB and returns the provider recorded in duckdb_secrets(). It skips
+// (rather than fails) when the required DuckDB extensions are unavailable —
+// matching the convention in repair_e2e_test.go so CI without network/extension
+// access stays green. needAWS loads the aws extension required by the
+// credential_chain provider.
+func secretProvider(t *testing.T, accessKey, secretKey, region, endpoint string, useSSL, needAWS bool) string {
+	t.Helper()
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Skipf("duckdb unavailable: %v", err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+
+	// TYPE S3 secrets are provided by httpfs; credential_chain needs aws.
+	// LOAD only (extensions must be pre-installed); skip if unavailable.
+	if _, err := db.Exec("LOAD httpfs;"); err != nil {
+		t.Skipf("httpfs extension unavailable: %v", err)
+	}
+	if needAWS {
+		if _, err := db.Exec("LOAD aws;"); err != nil {
+			t.Skipf("aws extension unavailable: %v", err)
+		}
+	}
+
+	if _, err := db.Exec(buildS3SecretSQL("s3_secret_test", accessKey, secretKey, region, endpoint, useSSL)); err != nil {
+		t.Skipf("CREATE SECRET unavailable (extension/version): %v", err)
+	}
+
+	var name, stype, provider string
+	row := db.QueryRow("SELECT name, type, provider FROM duckdb_secrets() WHERE name = 's3_secret_test'")
+	if err := row.Scan(&name, &stype, &provider); err != nil {
+		t.Skipf("duckdb_secrets() query unavailable: %v", err)
+	}
+	if stype != "s3" {
+		t.Errorf("secret type = %q, want s3", stype)
+	}
+	return provider
+}
+
+// TestCreateSecret_CredentialChain: no static key + no custom endpoint (native
+// AWS S3) → the secret uses PROVIDER credential_chain.
+func TestCreateSecret_CredentialChain(t *testing.T) {
+	if got := secretProvider(t, "", "", "us-east-1", "", true, true); got != "credential_chain" {
+		t.Errorf("provider = %q, want credential_chain", got)
+	}
+}
+
+// TestCreateSecret_StaticKeys: explicit access keys → provider config (not
+// credential_chain), preserving prior behaviour.
+func TestCreateSecret_StaticKeys(t *testing.T) {
+	if got := secretProvider(t, "AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", "us-east-1", "", true, false); got != "config" {
+		t.Errorf("provider = %q, want config", got)
+	}
+}
+
+// TestCreateSecret_CustomEndpoint: empty key but a custom endpoint (MinIO/R2)
+// → explicit-credential path, never credential_chain.
+func TestCreateSecret_CustomEndpoint(t *testing.T) {
+	if got := secretProvider(t, "", "", "us-east-1", "minio.local:9000", false, false); got == "credential_chain" {
+		t.Errorf("custom endpoint should not use credential_chain, got provider=%q", got)
+	}
+}
+
+// TestBuildS3SecretSQL_Branches is a pure unit test of the three-way switch in
+// buildS3SecretSQL — no DuckDB required, so it always runs.
+func TestBuildS3SecretSQL_Branches(t *testing.T) {
+	cases := []struct {
+		name       string
+		accessKey  string
+		endpoint   string
+		region     string
+		wantSubstr string
+		denySubstr string
+	}{
+		{
+			name:       "empty key + no endpoint -> credential_chain",
+			accessKey:  "",
+			endpoint:   "",
+			region:     "us-east-1",
+			wantSubstr: "PROVIDER credential_chain",
+			denySubstr: "KEY_ID",
+		},
+		{
+			name:       "empty key + empty region -> credential_chain defaults region",
+			accessKey:  "",
+			endpoint:   "",
+			region:     "",
+			wantSubstr: "REGION 'us-east-1'",
+			denySubstr: "REGION ''",
+		},
+		{
+			name:       "whitespace key + no endpoint -> credential_chain",
+			accessKey:  "   ",
+			endpoint:   "",
+			region:     "us-east-1",
+			wantSubstr: "PROVIDER credential_chain",
+			denySubstr: "KEY_ID",
+		},
+		{
+			name:       "static key + no endpoint -> explicit keys",
+			accessKey:  "AKIA...",
+			endpoint:   "",
+			region:     "us-east-1",
+			wantSubstr: "KEY_ID",
+			denySubstr: "credential_chain",
+		},
+		{
+			name:       "empty key + custom endpoint -> explicit keys (MinIO path)",
+			accessKey:  "",
+			endpoint:   "minio.local:9000",
+			region:     "us-east-1",
+			wantSubstr: "KEY_ID",
+			denySubstr: "credential_chain",
+		},
+		{
+			name:       "static key + custom endpoint -> explicit keys",
+			accessKey:  "AKIA...",
+			endpoint:   "minio.local:9000",
+			region:     "us-east-1",
+			wantSubstr: "KEY_ID",
+			denySubstr: "credential_chain",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sql := buildS3SecretSQL("test_secret", tc.accessKey, "secret", tc.region, tc.endpoint, true)
+			if !strings.Contains(sql, tc.wantSubstr) {
+				t.Errorf("SQL should contain %q:\n%s", tc.wantSubstr, sql)
+			}
+			if tc.denySubstr != "" && strings.Contains(sql, tc.denySubstr) {
+				t.Errorf("SQL should not contain %q:\n%s", tc.denySubstr, sql)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #769

## Problem

`TieredStorageManager.attachVolume` always creates a DuckDB S3 secret with the configured `KEY_ID`/`SECRET`. When a cold S3 volume is configured without static keys (relying on an IAM role, ECS task role, EKS Pod Identity, or EC2 instance profile), this produces:

```sql
CREATE SECRET s3_secret_cold (TYPE S3, KEY_ID '', SECRET '', REGION '');
```

DuckDB interprets the empty credentials literally — it signs S3 requests with no authentication, and every tiering move fails with HTTP 403:

```
ERR TieringService: Failed to move partition ... error="failed to insert into destination:
    HTTP Error: Unable to connect to URL s3://bucket/... Forbidden (HTTP code 403)"
```

The `aws` extension is not loaded in `Start()` (only `ducklake` and `sqlite` are), so the credential chain provider is never available as a fallback.

## Reproduction (DuckDB 1.5.3, standalone)

```sql
-- Current behaviour: empty-credential secret → 403
CREATE SECRET s3_test (TYPE S3, KEY_ID '', SECRET '', REGION '');
SELECT * FROM 's3://my-bucket/test.parquet';
-- HTTP 403 Forbidden — "No credentials are provided."

-- Fix: credential_chain resolves ambient credentials
INSTALL aws; LOAD aws;
CREATE OR REPLACE SECRET s3_test (TYPE S3, PROVIDER credential_chain, REGION 'us-east-1');
-- DuckDB resolves temporary credentials via the AWS SDK default chain
```

## Fix

When a volume has no static access key **and** no custom endpoint (native AWS S3), create the secret with `PROVIDER credential_chain` so DuckDB resolves credentials through the AWS SDK default chain (environment variables → container credentials → instance profile). Static keys and custom endpoints (MinIO, R2, RustFS) keep the existing explicit-credential path unchanged.

Also load the `aws` extension in `TieredStorageManager.Start()` (best-effort, non-fatal) so the `credential_chain` provider is available. The extension autoloads in recent DuckDB versions, but explicit loading is more reliable across builds.

### Changes

- `tiered_storage.go`: extract `buildS3SecretSQL` helper with a three-way switch (credential_chain / custom endpoint / static keys); load `aws` extension in `Start()`
- `tiered_storage_test.go`: unit tests covering all three branches + integration tests that verify the correct DuckDB secret provider is created

## Tests

```
go test ./src/storage/ducklake/ -run TestAttachVolume -v
go test ./src/storage/ducklake/ -run TestBuildS3SecretSQL -v
```

- `TestAttachVolume_CredentialChain` — empty key, no endpoint → secret created with `provider=credential_chain`
- `TestAttachVolume_StaticKeys` — explicit keys → secret created with `provider=config`
- `TestAttachVolume_CustomEndpoint` — empty key + custom endpoint → does NOT use credential_chain (preserves MinIO/R2 path)
- `TestBuildS3SecretSQL_Branches` — pure unit test of the SQL generation switch (no DuckDB needed)

## Backwards compatibility

- Deployments using **static keys** (`s3_access_key_id` / `s3_secret_access_key` in volume config): unchanged behaviour, `provider=config` as before.
- Deployments using **custom endpoints** (MinIO, R2, RustFS): unchanged, explicit keys + endpoint + URL_STYLE path.
- Deployments using **IAM roles / instance profiles / container credentials**: previously broken (403); now works via credential_chain.
- `LOAD aws` failure: logged as a warning, does not block startup. Setups without the `aws` extension pre-installed continue to work with static keys.