### PR TITLE
feat(cli): rebuild-catalog registers parquet in place via add_data_files (11.0.274)

### DIFF
--- a/docs/OOM.md
+++ b/docs/OOM.md
@@ -324,14 +324,19 @@ homer system --config-path /etc/homer/config.json --rebuild-catalog
 ```
 
 This backs up the existing catalog to `*.corrupt.<timestamp>`, attaches a fresh
-empty catalog, and re-ingests every on-disk parquet table through DuckLake (so
-all snapshot/file ids are allocated by DuckLake and the result is consistent).
-After verifying queries work, reclaim the old files with either:
+empty catalog, and **registers every on-disk parquet file in place** via
+`ducklake_add_data_files` (so all snapshot/file ids are allocated by DuckLake and
+the result is consistent). The files are not read, decompressed or rewritten, so
+the rebuild is fast, needs almost no memory, and — crucially — **keeps the
+original parquet files** instead of replacing them with fresh copies. There are
+therefore no orphaned originals to reclaim afterwards.
+
+The `--rebuild-cleanup-orphans` flag now only sweeps genuinely unreferenced
+leftover files (e.g. half-written files); the registered originals are always
+kept:
 
 ```bash
 homer system --config-path /etc/homer/config.json --rebuild-catalog --rebuild-cleanup-orphans
-# or, later:
-homer system --config-path /etc/homer/config.json --compaction-force
 ```
 
 Notes:

--- a/src/cli/system_cmd.go
+++ b/src/cli/system_cmd.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -132,8 +131,8 @@ func RegisterSystemFlags() (*flag.FlagSet, *systemFlagRefs) {
 	refs.CompactionRetentionDays = fs.Int("compaction-retention-days", 0, "delete data older than N days and exit")
 	refs.CompactionMergeList = fs.Bool("compaction-merge-list", false, "list smallest DuckLake files before/after merge")
 	refs.CompactionMergeListLimit = fs.Int("compaction-merge-list-limit", 50, "limit for compaction-merge-list output")
-	refs.RebuildCatalog = fs.Bool("rebuild-catalog", false, "fix a corrupt catalog: back up the existing catalog and fully rebuild it from the parquet files on disk, then exit")
-	refs.RebuildCleanupOrphans = fs.Bool("rebuild-cleanup-orphans", false, "with --rebuild-catalog: after a successful rebuild, delete the now-orphaned original parquet files to reclaim space")
+	refs.RebuildCatalog = fs.Bool("rebuild-catalog", false, "fix a corrupt catalog: back up the existing catalog and rebuild it by registering the on-disk parquet files in place (no rewrite), then exit")
+	refs.RebuildCleanupOrphans = fs.Bool("rebuild-cleanup-orphans", false, "with --rebuild-catalog: after a successful rebuild, sweep genuinely unreferenced leftover files (registered originals are kept)")
 	refs.InstallExtensions = fs.Bool("install-extensions", false, "install DuckDB extensions (ducklake, sqlite) and exit")
 	refs.Reload = fs.Bool("reload", false, "send SIGHUP to running homer-core process to reload config")
 	refs.PidFile = fs.String("pid-file", "/var/run/homer-core.pid", "path to PID file (used with --reload)")
@@ -541,10 +540,13 @@ func recoverCatalog(db *sql.DB, lakeName, dataPath string) (int, error) {
 //  1. backs up the existing catalog file (+ -wal/-shm) to *.corrupt.<ts>,
 //  2. ATTACHes a brand-new empty catalog at the same path (DuckLake creates the
 //     known HEP tables automatically),
-//  3. re-ingests every on-disk parquet table through DuckLake, so all snapshot
-//     and file ids are allocated by DuckLake itself (never out-of-band) and the
-//     resulting catalog is internally consistent,
-//  4. optionally deletes the now-orphaned original parquet files.
+//  3. REGISTERS every on-disk parquet file into the fresh catalog *in place*
+//     via ducklake_add_data_files — the files are not read, decompressed or
+//     rewritten; DuckLake takes ownership of them where they sit and records
+//     their metadata (file ids, statistics, name mapping) from each footer.
+//     This is fast, needs almost no memory (no OOM risk), and KEEPS the
+//     original files: they become referenced by the catalog instead of being
+//     replaced by fresh copies, so nothing is left orphaned to be deleted later.
 //
 // Limitations: rows that were only ever stored inline in the old catalog (never
 // written to parquet) cannot be recovered. Run this with the writer stopped.
@@ -596,29 +598,10 @@ func rebuildCatalog(f SystemFlags) error {
 	db := manager.GetDB()
 	lakeName := manager.GetLakeName()
 
-	// Force a low-memory DuckDB session for the re-ingest: parallel decompression
-	// of wide SIP rows (payload) across threads multiplies peak memory and OOMs
-	// even on a single ~450 MB file under a 2 GB limit. Rebuild is offline, so we
-	// trade speed for safety: single-threaded, no insertion-order buffering.
-	// SET GLOBAL (not plain SET) is required because db is a database/sql pool —
-	// a session-local SET would not apply to the connection that runs the INSERT.
-	if _, err := db.Exec("SET GLOBAL threads=1"); err != nil {
-		logger.Warn("rebuild-catalog: could not set threads=1 (continuing)", "error", err)
-	} else {
-		logger.Info("rebuild-catalog: re-ingest runs single-threaded to bound memory")
-	}
-	if _, err := db.Exec("SET GLOBAL preserve_insertion_order=false"); err != nil {
-		logger.Warn("rebuild-catalog: could not disable preserve_insertion_order (continuing)", "error", err)
-	}
-	if memLimit := rebuildMemoryLimit(); memLimit != "" {
-		if _, err := db.Exec(fmt.Sprintf("SET GLOBAL memory_limit='%s'", memLimit)); err != nil {
-			logger.Warn("rebuild-catalog: could not raise memory_limit (continuing)", "error", err)
-		} else {
-			logger.Info("rebuild-catalog: raised memory_limit for offline re-ingest", "memory_limit", memLimit)
-		}
-	}
+	// No memory/thread tuning needed: register-in-place only reads parquet
+	// footers for statistics, it never decompresses or rewrites row data.
 
-	// 3) Discover on-disk tables and re-ingest each through DuckLake.
+	// 3) Discover on-disk tables and register each table's files through DuckLake.
 	tables, err := listOnDiskTables(dataPath)
 	if err != nil {
 		return fmt.Errorf("rebuild-catalog: failed to list data directory: %w", err)
@@ -629,6 +612,7 @@ func rebuildCatalog(f SystemFlags) error {
 	}
 
 	var rebuilt, skipped int
+	var totalFiles int
 	var totalRows int64
 	var failed []string
 	for _, table := range tables {
@@ -638,41 +622,45 @@ func rebuildCatalog(f SystemFlags) error {
 			continue
 		}
 
-		rows, err := reingestTable(db, lakeName, dataPath, table)
+		files, rows, err := registerTableFiles(db, lakeName, dataPath, table)
 		if err != nil {
 			logger.Error("rebuild-catalog: failed to rebuild table", "table", table, "error", err)
 			failed = append(failed, table)
 			continue
 		}
-		logger.Info("rebuild-catalog: rebuilt table", "table", table, "rows", rows)
-		totalRows += rows
+		logger.Info("rebuild-catalog: registered table", "table", table, "files", files, "rows", rows)
+		totalFiles += files
+		if rows > 0 {
+			totalRows += rows
+		}
 		rebuilt++
 	}
 
 	logger.Info("rebuild-catalog: rebuild complete",
-		"tables_rebuilt", rebuilt, "tables_skipped", skipped, "tables_failed", len(failed), "total_rows", totalRows)
+		"tables_rebuilt", rebuilt, "tables_skipped", skipped, "tables_failed", len(failed),
+		"total_files", totalFiles, "total_rows", totalRows)
 
 	if len(failed) > 0 {
 		return fmt.Errorf("rebuild-catalog: %d table(s) failed: %s (original catalog preserved at %q)",
 			len(failed), strings.Join(failed, ", "), backup)
 	}
 
-	// 4) The originals are now orphaned (DuckLake wrote fresh files during
-	//    re-ingest). Only delete them on explicit request and only after a
-	//    fully successful rebuild.
+	// 4) With register-in-place the on-disk parquet are now REFERENCED by the
+	//    fresh catalog (DuckLake took ownership of them) — they are NOT orphaned
+	//    and are NOT deleted. The flag now only sweeps genuinely unreferenced
+	//    leftovers (e.g. half-written files, or files that could not be
+	//    registered); the registered originals are always kept.
 	if f.RebuildCleanupOrphans {
 		orphanSQL := fmt.Sprintf("CALL ducklake_delete_orphaned_files('%s', cleanup_all => true)", lakeName)
 		if _, err := db.Exec(orphanSQL); err != nil {
 			logger.Warn("rebuild-catalog: orphaned-file cleanup failed (not critical)", "error", err)
 		} else {
-			logger.Info("rebuild-catalog: deleted orphaned original parquet files")
+			logger.Info("rebuild-catalog: swept unreferenced leftover files (registered originals kept)")
 		}
-	} else {
-		logger.Info("rebuild-catalog: original parquet files are now orphaned; verify queries, then run " +
-			"'homer system --compaction-force' or re-run with --rebuild-cleanup-orphans to reclaim space")
 	}
 
-	logger.Info("rebuild-catalog: done — verify with a query, then restart the homer writer")
+	logger.Info("rebuild-catalog: done — files registered in place, originals preserved; " +
+		"verify with a query, then restart the homer writer")
 	return nil
 }
 
@@ -748,27 +736,34 @@ func duckLakeTableExists(db *sql.DB, lakeName, table string) bool {
 // any DuckLake version (with or without lineage columns) re-ingest cleanly.
 const duckLakeUserColumnsProjection = `COLUMNS(c -> NOT regexp_matches(c, '^_ducklake_internal'))`
 
-// reingestTable reads all of a table's on-disk parquet files and inserts them
-// into the (fresh) DuckLake table, creating the table first if it is not one of
-// the auto-created HEP tables. DuckLake allocates all snapshot/file ids, so the
-// rebuilt catalog is consistent. Returns the number of rows ingested.
+// registerTableFiles registers a table's existing on-disk parquet files into the
+// (fresh) DuckLake catalog *in place* via ducklake_add_data_files, creating the
+// table first if it is not one of the auto-created HEP tables. The files are NOT
+// read, decompressed or rewritten: DuckLake takes ownership of them exactly
+// where they sit (main/<table>/date=.../*.parquet) and derives the catalog
+// metadata (file ids, statistics, name mapping) from each footer. Returns the
+// number of files registered and the resulting row count (-1 if uncountable).
 //
-// Files are ingested ONE AT A TIME rather than as a single glob insert: a
-// single `INSERT ... SELECT FROM read_parquet('<all files>')` buffers many
-// files' row groups at once and OOMs on large tables under a small
-// memory_limit. Per-file inserts cap peak memory at one (~128 MB) parquet file.
-func reingestTable(db *sql.DB, lakeName, dataPath, table string) (int64, error) {
+// Why register-in-place instead of INSERT ... SELECT re-ingest:
+//   - no row decompression and no per-file parquet rewrite → orders of
+//     magnitude faster and essentially no memory pressure (no OOM risk), so the
+//     offline single-thread / raised memory_limit dance is no longer needed;
+//   - the ORIGINAL files are KEPT and become referenced by the catalog, instead
+//     of being replaced by fresh copies that left the originals orphaned and
+//     later deleted by delete_orphaned_files.
+func registerTableFiles(db *sql.DB, lakeName, dataPath, table string) (filesRegistered int, rows int64, err error) {
 	pattern := parquetDataGlobPattern(dataPath, table)
-	globReadExpr := fmt.Sprintf("read_parquet('%s', union_by_name=true, hive_partitioning=true)", pattern)
 	fqn := fmt.Sprintf("%s.main.%s", lakeName, table)
 
 	if !duckLakeTableExists(db, lakeName, table) {
 		// Unknown/custom table (e.g. otlp_*, lp_*): create it from the parquet
-		// schema (minus DuckLake's reserved lineage columns), partition/sort like
-		// the HEP tables (best-effort), then ingest.
+		// schema (minus DuckLake's reserved lineage columns; the hive `date`
+		// partition column is materialised by hive_partitioning), partition/sort
+		// like the HEP tables (best-effort), then register.
+		globReadExpr := fmt.Sprintf("read_parquet('%s', union_by_name=true, hive_partitioning=true)", pattern)
 		createSQL := fmt.Sprintf("CREATE TABLE %s AS SELECT %s FROM %s WHERE 1=0", fqn, duckLakeUserColumnsProjection, globReadExpr)
 		if _, err := db.Exec(createSQL); err != nil {
-			return 0, fmt.Errorf("create table: %w", err)
+			return 0, 0, fmt.Errorf("create table: %w", err)
 		}
 		if _, err := db.Exec(fmt.Sprintf("ALTER TABLE %s SET PARTITIONED BY (date)", fqn)); err != nil {
 			logger.Info("rebuild-catalog: table not partitioned by date (ok)", "table", table, "reason", err.Error())
@@ -780,77 +775,69 @@ func reingestTable(db *sql.DB, lakeName, dataPath, table string) (int64, error) 
 
 	files, err := listTableParquetFiles(db, pattern)
 	if err != nil {
-		return 0, fmt.Errorf("list files: %w", err)
+		return 0, 0, fmt.Errorf("list files: %w", err)
 	}
 	if len(files) == 0 {
-		return 0, nil
+		return 0, 0, nil
 	}
 
-	var total int64
-	for i, file := range files {
-		// hive_partitioning=true still extracts the date=… value from the single
-		// file's path; BY NAME lines columns up with the table definition; the
-		// projection strips DuckLake's internal lineage columns.
-		fileRead := fmt.Sprintf("read_parquet('%s', union_by_name=true, hive_partitioning=true)", escapeSQLLiteral(file))
-		insertSQL := fmt.Sprintf("INSERT INTO %s BY NAME SELECT %s FROM %s", fqn, duckLakeUserColumnsProjection, fileRead)
-		result, err := db.Exec(insertSQL)
-		if err != nil {
-			return total, fmt.Errorf("insert file %d/%d (%s): %w", i+1, len(files), file, err)
-		}
-		if rows, errRows := result.RowsAffected(); errRows == nil {
-			total += rows
-		}
-		if len(files) > 20 && (i+1)%20 == 0 {
-			logger.Info("rebuild-catalog: re-ingest progress", "table", table, "files_done", i+1, "files_total", len(files), "rows", total)
-		}
-	}
-	return total, nil
-}
+	// add_data_files options used throughout:
+	//   - hive_partitioning => true    : read the date=… value from the file path
+	//   - allow_missing => true        : files written before a column was added
+	//                                    get that column's default on read
+	//   - ignore_extra_columns => true : files carrying _ducklake_internal_*
+	//                                    (written by an older DuckLake) register
+	//                                    cleanly; the extra lineage columns are
+	//                                    simply ignored
+	const addOpts = "hive_partitioning => true, allow_missing => true, ignore_extra_columns => true"
 
-// rebuildMemoryLimit returns a generous DuckDB memory_limit for the OFFLINE
-// re-ingest (writer is stopped, so the conservative live 2 GB cap does not
-// apply). Writing a sorted parquet for wide SIP rows buffers the whole file, so
-// a small cap OOMs. We use ~70% of host RAM, clamped to [4 GB, 32 GB]. Returns
-// "" if total RAM cannot be determined (keep the existing limit).
-func rebuildMemoryLimit() string {
-	total := systemTotalRAMBytes()
-	if total == 0 {
-		return ""
+	// Fast path: register every file of the table in ONE metadata-only call, so
+	// the whole table lands in a single snapshot. add_data_files is transactional
+	// per call, so if any file in the batch is unreadable the call rolls back
+	// fully (no partial registration) and we drop to the per-file slow path.
+	globAdd := fmt.Sprintf("CALL ducklake_add_data_files('%s', '%s', '%s', %s)",
+		lakeName, table, escapeSQLLiteral(pattern), addOpts)
+	if _, e := db.Exec(globAdd); e == nil {
+		filesRegistered = len(files)
+	} else {
+		logger.Warn("rebuild-catalog: bulk register failed, retrying file-by-file",
+			"table", table, "files", len(files), "error", e.Error())
+		var skipped int
+		for i, file := range files {
+			if isGhostOrCorruptCLI(file) {
+				logger.Warn("rebuild-catalog: skipping unreadable/corrupt parquet", "table", table, "file", file)
+				skipped++
+				continue
+			}
+			addOne := fmt.Sprintf("CALL ducklake_add_data_files('%s', '%s', '%s', %s)",
+				lakeName, table, escapeSQLLiteral(file), addOpts)
+			if _, e := db.Exec(addOne); e != nil {
+				logger.Warn("rebuild-catalog: skipping file that failed to register",
+					"table", table, "file", file, "error", e.Error())
+				skipped++
+				continue
+			}
+			filesRegistered++
+			if len(files) > 50 && (i+1)%50 == 0 {
+				logger.Info("rebuild-catalog: register progress", "table", table, "files_done", i+1, "files_total", len(files))
+			}
+		}
+		if skipped > 0 {
+			logger.Warn("rebuild-catalog: some files could not be registered and were skipped",
+				"table", table, "skipped", skipped, "registered", filesRegistered)
+		}
+		if filesRegistered == 0 {
+			return 0, 0, fmt.Errorf("no files could be registered (bulk error: %w)", e)
+		}
 	}
-	limit := total * 70 / 100
-	const minLimit = 4 << 30  // 4 GB
-	const maxLimit = 32 << 30 // 32 GB
-	if limit < minLimit {
-		limit = minLimit
-	}
-	if limit > maxLimit {
-		limit = maxLimit
-	}
-	return fmt.Sprintf("%dGB", limit>>30)
-}
 
-// systemTotalRAMBytes reads MemTotal from /proc/meminfo (Linux). Returns 0 if
-// unavailable.
-func systemTotalRAMBytes() uint64 {
-	data, err := os.ReadFile("/proc/meminfo")
-	if err != nil {
-		return 0
+	// Row count is metadata-only after registration (catalog statistics).
+	rows = -1
+	if err := db.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM %s", fqn)).Scan(&rows); err != nil {
+		logger.Info("rebuild-catalog: could not count rows after register (ok)", "table", table, "error", err.Error())
+		rows = -1
 	}
-	for _, line := range strings.Split(string(data), "\n") {
-		if !strings.HasPrefix(line, "MemTotal:") {
-			continue
-		}
-		fields := strings.Fields(line)
-		if len(fields) < 2 {
-			return 0
-		}
-		kb, err := strconv.ParseUint(fields[1], 10, 64)
-		if err != nil {
-			return 0
-		}
-		return kb * 1024
-	}
-	return 0
+	return filesRegistered, rows, nil
 }
 
 // listTableParquetFiles returns the on-disk data parquet files matching pattern,

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.273"
+	VERSION_APPLICATION = "11.0.274"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Rework `homer system --rebuild-catalog` to **register on-disk parquet files in place** via `ducklake_add_data_files` instead of re-ingesting them with `INSERT ... SELECT FROM read_parquet(...)`.
- This fixes the issue where, after a rebuild, the **original parquet files were deleted**: the old re-ingest wrote *fresh* copies and left the originals orphaned, so `delete_orphaned_files` (via `--rebuild-cleanup-orphans` or the next compaction maintenance cycle that runs `cleanup_all => true`) removed them.
- Bump version to `11.0.274`.

## What changed
- `cli/system_cmd.go`:
  - `reingestTable` → `registerTableFiles`: registers files where they sit (no read/decompress/rewrite). The originals become **referenced** by the fresh catalog, not orphaned.
  - Bulk register per table (single snapshot) with a **per-file fallback** that skips unreadable/corrupt files (`isGhostOrCorruptCLI`) instead of failing the whole table.
  - Options `hive_partitioning => true, allow_missing => true, ignore_extra_columns => true` handle the `date=` path partition, schema evolution, and older files carrying `_ducklake_internal_*` columns.
  - `--rebuild-cleanup-orphans` now only sweeps **genuinely unreferenced** leftovers; registered originals are always kept.
  - Removed the now-unnecessary OOM mitigation (`SET GLOBAL threads=1` / `preserve_insertion_order` / `memory_limit`) and the unused `rebuildMemoryLimit` / `systemTotalRAMBytes` helpers + `strconv` import.
  - Updated flag help text.
- `docs/OOM.md`: updated the `--rebuild-catalog` description to reflect register-in-place semantics.
- `version.go`: `11.0.273` → `11.0.274`.

## Benefits
- No data churn: old parquet are no longer rewritten/duplicated/deleted.
- Much faster and essentially memory-free rebuild (only parquet footers are read), eliminating the OOM risk that the previous code worked around.

## Test plan
- [x] `go build ./...` and `go vet ./cli/...` (done locally, green).
- [ ] On a host with the runtime ducklake extension, run `--rebuild-catalog` against a corrupt catalog and verify:
  - [ ] queries return rows and the hive `date` partition is populated (not NULL), e.g. `SELECT date, COUNT(*) FROM homer_lake.main.hep_proto_1_call GROUP BY date LIMIT 5;`
  - [ ] the original on-disk parquet files are **still present** after rebuild and after a subsequent compaction cycle.
  - [ ] a corrupt parquet in a table triggers the per-file fallback and is skipped, not failing the whole table.