### PR TITLE
fix(config): indexed ENV for primitive slices (aleg_ids/custom_headers) — fixes #728

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -1173,6 +1173,13 @@ func Load(configPath string) (*Config, error) {
 	// homer.json via ENV in docker-compose.
 	applySliceEnvOverrides(v)
 
+	// Pre-scan ENV for indexed slices of primitives
+	// (HOMER_INGEST_SIP_ALEG_IDS_<idx>, HOMER_INGEST_SIP_CUSTOM_HEADERS_<idx>,
+	// HOMER_LOG_OUTPUT_<idx>, ...). The documented docker-compose convention
+	// uses this indexed form, which viper's AutomaticEnv() does not handle for
+	// []string fields on its own.
+	applyPrimitiveSliceEnvOverrides(v)
+
 	// Pre-populate the struct from `default:"..."` struct tags BEFORE
 	// Unmarshal. mapstructure's default decoder runs with ZeroFields=false,
 	// so it will only override fields that are explicitly present in the

--- a/src/config/env.go
+++ b/src/config/env.go
@@ -140,6 +140,93 @@ func applySliceEnvOverrides(v *viper.Viper) {
 	})
 }
 
+// applyPrimitiveSliceEnvOverrides finds every slice-of-primitive field
+// reachable from Config{} (e.g. ingest.sip.aleg_ids, ingest.sip.custom_headers,
+// log.output) and converts indexed HOMER_<PATH>_<idx> ENV variables into an
+// ordered slice written to viper via v.Set().
+//
+// This complements bindAllEnvs, which only binds the non-indexed HOMER_<PATH>
+// form for primitive slices. The docker-compose convention documented for
+// these fields uses the indexed form (HOMER_INGEST_SIP_ALEG_IDS_0=X-Session),
+// which viper's AutomaticEnv() does not understand on its own.
+//
+// Behaviour:
+//   - sparse indices (0, 2, 5) are allowed — gaps are filled with empty
+//     strings, final length = max(idx)+1;
+//   - the suffix after the prefix must be a pure integer, which keeps this
+//     from colliding with slice-of-struct overrides (HOMER_<PATH>_<idx>_<field>)
+//     handled by applySliceEnvOverrides;
+//   - values are kept as strings, mapstructure performs type coercion.
+func applyPrimitiveSliceEnvOverrides(v *viper.Viper) {
+	walkSliceOfPrimitive(reflect.TypeOf(Config{}), nil, func(path []string) {
+		prefix := "HOMER_" + strings.ToUpper(strings.Join(path, "_")) + "_"
+		entries := map[int]string{}
+		for _, env := range os.Environ() {
+			if !strings.HasPrefix(env, prefix) {
+				continue
+			}
+			eq := strings.IndexByte(env, '=')
+			if eq < 0 {
+				continue
+			}
+			idx, err := strconv.Atoi(env[len(prefix):eq])
+			if err != nil || idx < 0 {
+				continue
+			}
+			entries[idx] = env[eq+1:]
+		}
+		if len(entries) == 0 {
+			return
+		}
+		maxIdx := 0
+		for i := range entries {
+			if i > maxIdx {
+				maxIdx = i
+			}
+		}
+		slice := make([]string, maxIdx+1)
+		for i, val := range entries {
+			slice[i] = val
+		}
+		v.Set(strings.Join(path, "."), slice)
+	})
+}
+
+// walkSliceOfPrimitive recursively walks a struct type and calls visit on
+// every slice-of-primitive field, passing the accumulated mapstructure path.
+func walkSliceOfPrimitive(t reflect.Type, path []string, visit func([]string)) {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return
+	}
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		tag := mapstructureName(f)
+		if tag == "" {
+			continue
+		}
+		full := append(append([]string(nil), path...), tag)
+		ft := f.Type
+		if ft.Kind() == reflect.Ptr {
+			ft = ft.Elem()
+		}
+		switch ft.Kind() {
+		case reflect.Struct:
+			walkSliceOfPrimitive(ft, full, visit)
+		case reflect.Slice:
+			elem := ft.Elem()
+			if elem.Kind() == reflect.Ptr {
+				elem = elem.Elem()
+			}
+			if elem.Kind() != reflect.Struct {
+				visit(full)
+			}
+		}
+	}
+}
+
 // walkSliceOfStruct recursively walks a struct type and calls visit on
 // every slice-of-struct field, passing the accumulated mapstructure path.
 func walkSliceOfStruct(t reflect.Type, path []string, visit func([]string, reflect.Type)) {

--- a/src/config/env_test.go
+++ b/src/config/env_test.go
@@ -501,9 +501,12 @@ func TestLoad_Precedence_NoFileDefaultsThenEnv(t *testing.T) {
 }
 
 // TestLoad_EnvSlice_LogOutput is the simplest case: a slice of strings
-// (log.output). docker-compose convention: HOMER_LOG_OUTPUT_0=stdout.
+// (log.output). docker-compose convention: HOMER_LOG_OUTPUT_0=...
+// Uses non-default values so it actually exercises the indexed primitive
+// slice path (log.output defaults to ["stdout"], which would mask a no-op).
 func TestLoad_EnvSlice_LogOutput(t *testing.T) {
-	t.Setenv("HOMER_LOG_OUTPUT_0", "stdout")
+	t.Setenv("HOMER_LOG_OUTPUT_0", "file")
+	t.Setenv("HOMER_LOG_OUTPUT_1", "syslog")
 
 	path := writeTmpConfig(t, `{}`)
 	cfg, err := Load(path)
@@ -511,8 +514,37 @@ func TestLoad_EnvSlice_LogOutput(t *testing.T) {
 		t.Fatalf("Load failed: %v", err)
 	}
 
-	if len(cfg.Log.Output) != 1 || cfg.Log.Output[0] != "stdout" {
-		t.Errorf("log.output: want [stdout], got %v", cfg.Log.Output)
+	if len(cfg.Log.Output) != 2 || cfg.Log.Output[0] != "file" || cfg.Log.Output[1] != "syslog" {
+		t.Errorf("log.output: want [file syslog], got %v", cfg.Log.Output)
+	}
+}
+
+// TestLoad_EnvSlice_SIPAlegCustomHeaders covers issue #728: the indexed
+// docker-compose form for SIP custom-header extraction must reach
+// ingest.sip.aleg_ids / custom_headers (otherwise XCallID/cid correlation
+// and data_extra.custom_headers stay empty even with a correct parser).
+func TestLoad_EnvSlice_SIPAlegCustomHeaders(t *testing.T) {
+	t.Setenv("HOMER_INGEST_SIP_FORCE_ALEG_ID", "true")
+	t.Setenv("HOMER_INGEST_SIP_ALEG_IDS_0", "X-Session")
+	t.Setenv("HOMER_INGEST_SIP_CUSTOM_HEADERS_0", "X-Session")
+	t.Setenv("HOMER_INGEST_SIP_CUSTOM_HEADERS_1", "X-CID")
+
+	path := writeTmpConfig(t, `{}`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if !cfg.Ingest.SIP.ForceALegID {
+		t.Errorf("ingest.sip.force_aleg_id: want true, got false")
+	}
+	if len(cfg.Ingest.SIP.AlegIDs) != 1 || cfg.Ingest.SIP.AlegIDs[0] != "X-Session" {
+		t.Errorf("ingest.sip.aleg_ids: want [X-Session], got %#v", cfg.Ingest.SIP.AlegIDs)
+	}
+	if len(cfg.Ingest.SIP.CustomHeaders) != 2 ||
+		cfg.Ingest.SIP.CustomHeaders[0] != "X-Session" ||
+		cfg.Ingest.SIP.CustomHeaders[1] != "X-CID" {
+		t.Errorf("ingest.sip.custom_headers: want [X-Session X-CID], got %#v", cfg.Ingest.SIP.CustomHeaders)
 	}
 }
 

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.274"
+	VERSION_APPLICATION = "11.0.275"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary

Issue #728 (`aleg_ids` / `custom_headers` have no effect) stayed reproducible on **11.0.273** even though the zero-copy SIP parser fix (#729 / commit `0556c24`) was already merged. This PR fixes the **remaining half** of the bug, which lives in the config layer rather than the parser.

### Root cause

Operators configure these fields with the documented indexed docker-compose form:

```
HOMER_INGEST_SIP_FORCE_ALEG_ID=true
HOMER_INGEST_SIP_ALEG_IDS_0=X-Session
HOMER_INGEST_SIP_CUSTOM_HEADERS_0=X-Session
```

In `src/config/env.go`, indexed `HOMER_<PATH>_<idx>` variables were only decoded for **slices of structs** (`volumes`, `nodes`) via `applySliceEnvOverrides`. **Slices of primitives** — `ingest.sip.aleg_ids []string`, `ingest.sip.custom_headers []string`, `log.output []string` — were only bound in their non-indexed form (`HOMER_INGEST_SIP_ALEG_IDS`). So the indexed values were silently dropped, `AlegIDs`/`CustomHeaders` stayed empty, `XCallID` was never set, and `cid` always fell back to `Call-ID`.

Reproduced in a unit test:
- `HOMER_INGEST_SIP_ALEG_IDS_0=X-Session` → `AlegIDs = nil` ❌
- `HOMER_INGEST_SIP_ALEG_IDS=X-Session`   → `AlegIDs = [X-Session]` ✅

The existing `TestLoad_EnvSlice_LogOutput` was a false positive: `log.output` defaults to `["stdout"]`, so it passed regardless of whether the indexed var was read.

### Changes

- Add `applyPrimitiveSliceEnvOverrides` + `walkSliceOfPrimitive` (`src/config/env.go`): scan `HOMER_<PATH>_<idx>` for every `[]<primitive>` config field and feed the ordered slice to viper via `v.Set`. The pure-integer suffix check keeps it from colliding with the slice-of-struct path (`HOMER_<PATH>_<idx>_<field>`).
- Wire it into `Load()` right after `applySliceEnvOverrides` (`src/config/config.go`).
- Harden `TestLoad_EnvSlice_LogOutput` to use non-default values.
- Add `TestLoad_EnvSlice_SIPAlegCustomHeaders` covering the exact #728 scenario (force_aleg_id + aleg_ids_0 + custom_headers_0/_1).
- Bump version to `11.0.275`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./config/ ./sipparser/ ./decoder/` — pass
- [x] full `go test ./...` — only pre-existing, unrelated failures in `coordinator/services` (`TestSeedDefaultMappingSchema_*`, present on clean `homer11`)
- [ ] Manual: deploy with `HOMER_INGEST_SIP_ALEG_IDS_0=X-Session` and confirm `cid` = X-Session value for both legs and `data_extra.custom_headers` is populated

Fixes #728