### PR TITLE
fix(sip): populate callee from RURI with To fallback (11.0.276)

### DIFF
--- a/src/sipparser/parties.go
+++ b/src/sipparser/parties.go
@@ -1,0 +1,18 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sipparser
+
+// CalleeUser returns the party stored as callee / to_user.
+// Request-URI user is preferred when present; otherwise the To header user
+// is used (responses and host-only RURI requests).
+func (s *SipMsg) CalleeUser() string {
+	if s == nil {
+		return ""
+	}
+	if s.URIUser != "" {
+		return s.URIUser
+	}
+	return s.ToUser
+}

--- a/src/sipparser/parties_test.go
+++ b/src/sipparser/parties_test.go
@@ -1,0 +1,58 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sipparser
+
+import "testing"
+
+func TestCalleeUser_RuriFallbackTo(t *testing.T) {
+	raw := []byte("INVITE sip:gateway.example.com SIP/2.0\r\n" +
+		"From: <sip:alice@example.com>\r\n" +
+		"To: <sip:bob@example.com>\r\n" +
+		"Call-ID: cid-ruri@host\r\n" +
+		"CSeq: 1 INVITE\r\n\r\n")
+	s := ParseMsgZeroCopy(raw, nil)
+	if s.Error != nil {
+		t.Fatalf("parse: %v", s.Error)
+	}
+	if s.URIUser != "" {
+		t.Fatalf("URIUser: want empty, got %q", s.URIUser)
+	}
+	if s.ToUser != "bob" {
+		t.Fatalf("ToUser: want bob, got %q", s.ToUser)
+	}
+	if got := s.CalleeUser(); got != "bob" {
+		t.Fatalf("CalleeUser: want bob, got %q", got)
+	}
+}
+
+func TestCalleeUser_PrefersRuri(t *testing.T) {
+	raw := []byte("INVITE sip:ruri@example.com SIP/2.0\r\n" +
+		"From: <sip:alice@example.com>\r\n" +
+		"To: <sip:to@example.com>\r\n" +
+		"Call-ID: cid-pref@host\r\n" +
+		"CSeq: 1 INVITE\r\n\r\n")
+	s := ParseMsgZeroCopy(raw, nil)
+	if s.Error != nil {
+		t.Fatalf("parse: %v", s.Error)
+	}
+	if got := s.CalleeUser(); got != "ruri" {
+		t.Fatalf("CalleeUser: want ruri, got %q", got)
+	}
+}
+
+func TestCalleeUser_ResponseUsesTo(t *testing.T) {
+	raw := []byte("SIP/2.0 200 OK\r\n" +
+		"From: <sip:alice@example.com>\r\n" +
+		"To: <sip:bob@example.com>;tag=abc\r\n" +
+		"Call-ID: cid-resp@host\r\n" +
+		"CSeq: 1 INVITE\r\n\r\n")
+	s := ParseMsgZeroCopy(raw, nil)
+	if s.Error != nil {
+		t.Fatalf("parse: %v", s.Error)
+	}
+	if got := s.CalleeUser(); got != "bob" {
+		t.Fatalf("CalleeUser: want bob, got %q", got)
+	}
+}

--- a/src/sipparser/zerocopy.go
+++ b/src/sipparser/zerocopy.go
@@ -253,7 +253,9 @@ func zcParseHeaderLine(line []byte, s *SipMsg) {
 		return
 	}
 
-	if nameLen == 2 {
+	// RFC 3261 compact form for To is only "t" / "T" (1 char). Full "To" is 2 chars.
+	// Do not treat every 2-char header name as To (e.g. vendor "TH:" must not overwrite To).
+	if nameLen == 2 && zcEqCI2(name, 't', 'o') {
 		zcParseFromTo(val, s, 't')
 		return
 	}
@@ -302,10 +304,6 @@ func zcParseHeaderLine(line []byte, s *SipMsg) {
 	case 's':
 		if nameLen == 6 && zcEqCI(name, []byte("server")) {
 			s.Server = btos(zcTrimWS(val))
-		}
-	case 't':
-		if nameLen == 2 {
-			zcParseFromTo(val, s, 't')
 		}
 	case 'm':
 		if nameLen == 12 && zcEqCI(name, []byte("max-forwards")) {
@@ -602,6 +600,13 @@ func zcEqCI(a, b []byte) bool {
 		}
 	}
 	return true
+}
+
+// Specialized 2-byte case-insensitive comparison (inlineable).
+func zcEqCI2(a []byte, b0, b1 byte) bool {
+	return len(a) == 2 &&
+		(a[0]|0x20) == b0 &&
+		(a[1]|0x20) == b1
 }
 
 // Specialized 3-byte and 4-byte case-insensitive comparisons (inlineable).

--- a/src/sipparser/zerocopy.go
+++ b/src/sipparser/zerocopy.go
@@ -475,6 +475,7 @@ func zcParsePAIUser(val []byte, s *SipMsg) {
 // zcExtractUserHost extracts user and host from a SIP URI.
 func zcExtractUserHost(uri []byte) (user, host string) {
 	raw := uri
+	isTel := false
 
 	// Strip scheme: sip:, sips:, tel:
 	if len(raw) > 4 {
@@ -484,6 +485,7 @@ func zcExtractUserHost(uri []byte) (user, host string) {
 		} else if raw[3] == ':' &&
 			(raw[0]|0x20) == 't' && (raw[1]|0x20) == 'e' && (raw[2]|0x20) == 'l' {
 			raw = raw[4:]
+			isTel = true
 		} else if len(raw) > 5 && raw[4] == ':' &&
 			(raw[0]|0x20) == 's' && (raw[1]|0x20) == 'i' &&
 			(raw[2]|0x20) == 'p' && (raw[3]|0x20) == 's' {
@@ -523,6 +525,10 @@ func zcExtractUserHost(uri []byte) (user, host string) {
 			host = btos(hostPart[:colon])
 		} else {
 			host = btos(hostPart)
+		}
+		// tel: URIs without @ carry the dial string as the user part (legacy parser behavior).
+		if isTel && host != "" {
+			user = host
 		}
 	}
 	return

--- a/src/sipparser/zerocopy_opts_test.go
+++ b/src/sipparser/zerocopy_opts_test.go
@@ -108,6 +108,29 @@ func TestParseMsgZeroCopyLegacy(t *testing.T) {
 	}
 }
 
+func TestParseMsgZeroCopy_THHeaderDoesNotOverwriteTo(t *testing.T) {
+	raw := []byte("INVITE sip:CALLEE@pbx-proxy.example.com SIP/2.0\r\n" +
+		"Via: SIP/2.0/UDP 192.168.1.104:5061;TH=div;branch=z9hG4bK3446998277\r\n" +
+		"From: <sip:CALLER@pbx-proxy.example.com>;tag=1786784267\r\n" +
+		"To: <sip:CALLEE@pbx-proxy.example.com>\r\n" +
+		"TH: dih\r\n" +
+		"Call-ID: cid-th@host\r\n" +
+		"CSeq: 2 INVITE\r\n\r\n")
+	s := ParseMsgZeroCopy(raw, nil)
+	if s.Error != nil {
+		t.Fatalf("parse: %v", s.Error)
+	}
+	if s.ToUser != "CALLEE" {
+		t.Fatalf("ToUser: want CALLEE, got %q (TH header must not overwrite To)", s.ToUser)
+	}
+	if s.ToHost != "pbx-proxy.example.com" {
+		t.Fatalf("ToHost: want pbx-proxy.example.com, got %q", s.ToHost)
+	}
+	if got := s.CalleeUser(); got != "CALLEE" {
+		t.Fatalf("CalleeUser: want CALLEE, got %q", got)
+	}
+}
+
 func TestParseMsgZeroCopy_TelToUser(t *testing.T) {
 	raw := []byte("INVITE tel:+15551234567 SIP/2.0\r\n" +
 		"From: <sip:alice@example.com>\r\n" +

--- a/src/sipparser/zerocopy_opts_test.go
+++ b/src/sipparser/zerocopy_opts_test.go
@@ -108,6 +108,25 @@ func TestParseMsgZeroCopyLegacy(t *testing.T) {
 	}
 }
 
+func TestParseMsgZeroCopy_TelToUser(t *testing.T) {
+	raw := []byte("INVITE tel:+15551234567 SIP/2.0\r\n" +
+		"From: <sip:alice@example.com>\r\n" +
+		"To: <tel:+15551234567>\r\n" +
+		"Call-ID: cid-tel@host\r\n" +
+		"CSeq: 1 INVITE\r\n\r\n")
+	s := ParseMsgZeroCopy(raw, nil)
+	if s.Error != nil {
+		t.Fatalf("parse: %v", s.Error)
+	}
+	if s.ToUser != "+15551234567" {
+		t.Fatalf("ToUser: want +15551234567, got %q", s.ToUser)
+	}
+	legacy := ParseMsg(string(raw), nil, nil)
+	if legacy.ToUser != s.ToUser {
+		t.Fatalf("legacy ToUser %q != zero-copy ToUser %q", legacy.ToUser, s.ToUser)
+	}
+}
+
 func TestParseMsgZeroCopy_XRTPStatPlusCustom(t *testing.T) {
 	raw := minimalSIP("X-RTP-Stat: stats\r\nX-Extra: e")
 	opts := &ZeroCopyOpts{CustomHeaders: []string{"X-Extra"}}

--- a/src/storage/ducklake/hep_adapter.go
+++ b/src/storage/ducklake/hep_adapter.go
@@ -224,7 +224,7 @@ func (a *MultiTableAdapter) buildSIPCallValues(hep *decoder.HEP, uid string, dat
 	if hep.SIP != nil {
 		sessionID = hep.SIP.CallID
 		caller = hep.SIP.FromUser
-		callee = hep.SIP.ToUser
+		callee = hep.SIP.CalleeUser()
 		method = hep.SIP.FirstMethod
 		responseCode = hep.SIP.FirstResp
 		cseqMethod = hep.SIP.CseqMethod
@@ -446,7 +446,7 @@ func (a *HEPAdapter) convertHEP(hep *decoder.HEP) HEPRecord {
 	if hep.SIP != nil {
 		record.SessionID = hep.SIP.CallID
 		record.Caller = hep.SIP.FromUser
-		record.Callee = hep.SIP.ToUser
+		record.Callee = hep.SIP.CalleeUser()
 		record.Event = hep.SIP.FirstMethod
 		record.DataExtra = buildExtraJSON(hep)
 	} else {

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.276"
+	VERSION_APPLICATION = "11.0.277"
 
 	// BuildDate is the build date
 	BuildDate = ""

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.275"
+	VERSION_APPLICATION = "11.0.276"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Add `CalleeUser()` to resolve stored `callee` as Request-URI user when present, otherwise fall back to the To header user (covers host-only RURI and SIP responses).
- Fix zero-copy `tel:` URI parsing so dial strings populate `ToUser` (legacy parser parity).
- Bump version to **11.0.276**.

Fixes #822

## Test plan
- [x] `go test ./sipparser/...`
- [x] Deploy on affected site and verify `callee` is populated for INVITE/dialog rows where RURI is host-only
- [x] Confirm `tel:` To headers store callee correctly