### PR TITLE
feat(ui): close floating windows with Escape (11.0.278)

### DIFF
--- a/src/ui/src/components/ui/floating-window.tsx
+++ b/src/ui/src/components/ui/floating-window.tsx
@@ -89,7 +89,17 @@ export function FloatingWindow({
 
   const bringToFront = useCallback(() => {
     setZ(++topZ)
-  }, [])
+    useWindowRegistry.getState().focus(resolvedId)
+  }, [resolvedId])
+
+  useEffect(() => {
+    if (!open) return
+    useWindowRegistry.getState().register({
+      id: resolvedId,
+      onClose,
+      bringToFront,
+    })
+  }, [open, resolvedId, onClose, bringToFront])
 
   /** After drag/resize, assign a fresh stacking value so order stays coherent without leaving a huge gap. */
   const settleOnTop = useCallback(() => {
@@ -206,10 +216,13 @@ export function FloatingWindow({
     useWindowRegistry.getState().minimize({
       id: resolvedId,
       title,
-      onRestore: () => setIsMinimized(false),
+      onRestore: () => {
+        setIsMinimized(false)
+        bringToFront()
+      },
       onClose,
     })
-  }, [resolvedId, title, onClose])
+  }, [resolvedId, title, onClose, bringToFront])
 
   if (!open) return null
   if (isMinimized) return null

--- a/src/ui/src/dashboard/stores/window-registry.test.ts
+++ b/src/ui/src/dashboard/stores/window-registry.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useWindowRegistry } from './window-registry'
+
+function resetRegistry() {
+  useWindowRegistry.setState({
+    minimized: [],
+    open: {},
+    focusStack: [],
+  })
+}
+
+describe('useWindowRegistry focus stack', () => {
+  afterEach(() => {
+    resetRegistry()
+  })
+
+  it('tracks focus order as windows register and focus', () => {
+    const a = { id: 'a', onClose: vi.fn(), bringToFront: vi.fn() }
+    const b = { id: 'b', onClose: vi.fn(), bringToFront: vi.fn() }
+    useWindowRegistry.getState().register(a)
+    useWindowRegistry.getState().register(b)
+    expect(useWindowRegistry.getState().focusStack).toEqual(['a', 'b'])
+
+    useWindowRegistry.getState().focus('a')
+    expect(useWindowRegistry.getState().focusStack).toEqual(['b', 'a'])
+  })
+
+  it('closeFocused closes the top visible window and focuses the previous one', () => {
+    const closeA = vi.fn()
+    const closeB = vi.fn()
+    const frontA = vi.fn()
+    const frontB = vi.fn()
+    useWindowRegistry.getState().register({ id: 'a', onClose: closeA, bringToFront: frontA })
+    useWindowRegistry.getState().register({ id: 'b', onClose: closeB, bringToFront: frontB })
+
+    useWindowRegistry.getState().closeFocused()
+
+    expect(closeB).toHaveBeenCalledOnce()
+    expect(frontA).toHaveBeenCalledOnce()
+    expect(closeA).not.toHaveBeenCalled()
+  })
+
+  it('skips minimized windows when closing via closeFocused', () => {
+    const closeA = vi.fn()
+    const closeB = vi.fn()
+    const frontA = vi.fn()
+    useWindowRegistry.getState().register({ id: 'a', onClose: closeA, bringToFront: frontA })
+    useWindowRegistry.getState().register({ id: 'b', onClose: closeB, bringToFront: vi.fn() })
+    useWindowRegistry.getState().minimize({
+      id: 'b',
+      title: 'B',
+      onRestore: vi.fn(),
+      onClose: closeB,
+    })
+
+    useWindowRegistry.getState().closeFocused()
+
+    expect(closeA).toHaveBeenCalledOnce()
+    expect(closeB).not.toHaveBeenCalled()
+  })
+
+  it('updates callbacks on re-register without changing focus order', () => {
+    const close1 = vi.fn()
+    const close2 = vi.fn()
+    useWindowRegistry.getState().register({ id: 'a', onClose: close1, bringToFront: vi.fn() })
+    useWindowRegistry.getState().register({ id: 'b', onClose: vi.fn(), bringToFront: vi.fn() })
+    useWindowRegistry.getState().register({ id: 'a', onClose: close2, bringToFront: vi.fn() })
+
+    expect(useWindowRegistry.getState().focusStack).toEqual(['a', 'b'])
+    useWindowRegistry.getState().focus('a')
+    useWindowRegistry.getState().closeFocused()
+    expect(close2).toHaveBeenCalledOnce()
+    expect(close1).not.toHaveBeenCalled()
+  })
+})

--- a/src/ui/src/dashboard/stores/window-registry.ts
+++ b/src/ui/src/dashboard/stores/window-registry.ts
@@ -8,23 +8,128 @@ export interface MinimizedEntry {
   onClose: () => void
 }
 
+export interface OpenWindowEntry {
+  id: string
+  onClose: () => void
+  bringToFront: () => void
+  minimized: boolean
+}
+
 interface WindowRegistryState {
   minimized: MinimizedEntry[]
+  open: Record<string, OpenWindowEntry>
+  /** Window ids in focus order (oldest → newest). */
+  focusStack: string[]
   minimize: (entry: MinimizedEntry) => void
   restore: (id: string) => void
   remove: (id: string) => void
+  register: (entry: Omit<OpenWindowEntry, 'minimized'>) => void
+  focus: (id: string) => void
+  closeFocused: () => void
 }
 
-export const useWindowRegistry = create<WindowRegistryState>((set) => ({
+let escapeListenerAttached = false
+
+function visibleFocusStack(open: Record<string, OpenWindowEntry>, focusStack: string[]): string[] {
+  return focusStack.filter((id) => open[id] && !open[id].minimized)
+}
+
+function shouldDeferEscapeToOverlay(): boolean {
+  return !!document.querySelector(
+    '[data-slot="dialog-content"][data-state="open"], [data-slot="select-content"][data-state="open"], [data-slot="dropdown-menu-content"][data-state="open"]',
+  )
+}
+
+function attachEscapeListener() {
+  if (escapeListenerAttached || typeof document === 'undefined') return
+  escapeListenerAttached = true
+  document.addEventListener('keydown', (e) => {
+    if (e.key !== 'Escape' || e.defaultPrevented) return
+    if (shouldDeferEscapeToOverlay()) return
+    const { open, focusStack, closeFocused } = useWindowRegistry.getState()
+    const visible = visibleFocusStack(open, focusStack)
+    if (visible.length === 0) return
+    e.preventDefault()
+    closeFocused()
+  })
+}
+
+export const useWindowRegistry = create<WindowRegistryState>((set, get) => ({
   minimized: [],
+  open: {},
+  focusStack: [],
+
   minimize: (entry) =>
-    set((s) => ({
-      minimized: s.minimized.some((e) => e.id === entry.id)
-        ? s.minimized.map((e) => (e.id === entry.id ? entry : e))
-        : [...s.minimized, entry],
-    })),
+    set((s) => {
+      const open = { ...s.open }
+      if (open[entry.id]) {
+        open[entry.id] = { ...open[entry.id], minimized: true }
+      }
+      return {
+        minimized: s.minimized.some((e) => e.id === entry.id)
+          ? s.minimized.map((e) => (e.id === entry.id ? entry : e))
+          : [...s.minimized, entry],
+        open,
+        focusStack: s.focusStack.filter((id) => id !== entry.id),
+      }
+    }),
+
   restore: (id) =>
-    set((s) => ({ minimized: s.minimized.filter((e) => e.id !== id) })),
+    set((s) => {
+      const open = { ...s.open }
+      if (open[id]) {
+        open[id] = { ...open[id], minimized: false }
+      }
+      const focusStack = s.focusStack.filter((fid) => fid !== id)
+      focusStack.push(id)
+      return {
+        minimized: s.minimized.filter((e) => e.id !== id),
+        open,
+        focusStack,
+      }
+    }),
+
   remove: (id) =>
-    set((s) => ({ minimized: s.minimized.filter((e) => e.id !== id) })),
+    set((s) => ({
+      minimized: s.minimized.filter((e) => e.id !== id),
+      open: Object.fromEntries(Object.entries(s.open).filter(([k]) => k !== id)),
+      focusStack: s.focusStack.filter((fid) => fid !== id),
+    })),
+
+  register: (entry) => {
+    attachEscapeListener()
+    set((s) => {
+      const existing = s.open[entry.id]
+      const open = {
+        ...s.open,
+        [entry.id]: { ...entry, minimized: existing?.minimized ?? false },
+      }
+      if (existing) return { open }
+      const focusStack = [...s.focusStack, entry.id]
+      return { open, focusStack }
+    })
+  },
+
+  focus: (id) =>
+    set((s) => {
+      if (!s.open[id] || s.open[id].minimized) return s
+      const focusStack = s.focusStack.filter((fid) => fid !== id)
+      focusStack.push(id)
+      return { focusStack }
+    }),
+
+  closeFocused: () => {
+    const { open, focusStack } = get()
+    const visible = visibleFocusStack(open, focusStack)
+    if (visible.length === 0) return
+    const focusedId = visible[visible.length - 1]
+    const previousId = visible.length > 1 ? visible[visible.length - 2] : null
+    const focused = open[focusedId]
+    if (!focused) return
+    focused.onClose()
+    if (previousId && open[previousId]) {
+      open[previousId].bringToFront()
+      get().focus(previousId)
+    }
+  },
 }))

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.277"
+	VERSION_APPLICATION = "11.0.278"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Pressing Escape closes the focused floating window (message view, flow/dialog view, etc.) and brings the previously focused window back to the front.
- Focus order is tracked in the window registry; minimized windows are skipped.
- Escape is deferred when a Radix dialog, select, or dropdown menu is open.

Fixes #828

## Test plan
- [x] Open two floating windows (e.g. message + flow view); press Escape — top window closes, other is focused
- [x] Press Escape again — second window closes
- [x] Minimize one window; Escape closes the visible focused window, not the minimized one
- [x] Open a dialog/select inside a floating window; Escape closes overlay first, not the window
- [x] `npm test -- src/dashboard/stores/window-registry.test.ts` passes