### PR TITLE
fix(cli): compaction-retention-days TIMESTAMP comparison (11.0.280)

### DIFF
--- a/src/cli/system_cmd.go
+++ b/src/cli/system_cmd.go
@@ -231,10 +231,11 @@ func runCompaction(f SystemFlags) error {
 			return fmt.Errorf("failed to discover DuckLake tables: %w", err)
 		}
 
-		cutoff := time.Now().AddDate(0, 0, -f.CompactionRetentionDays).UnixNano()
+		cutoff := time.Now().AddDate(0, 0, -f.CompactionRetentionDays)
+		cutoffStr := cutoff.UTC().Format("2006-01-02 15:04:05")
 		var totalRowsDeleted int64
 		for _, table := range tables {
-			query := fmt.Sprintf("DELETE FROM %s WHERE timestamp < %d", table, cutoff)
+			query := fmt.Sprintf("DELETE FROM %s WHERE timestamp < TIMESTAMP '%s'", table, cutoffStr)
 			result, err := db.Exec(query)
 			if err != nil {
 				logger.Error(fmt.Sprintf("Retention failed for %s: %v", table, err))

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.279"
+	VERSION_APPLICATION = "11.0.280"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Fix `--compaction-retention-days` CLI retention DELETE to use `TIMESTAMP '...'` instead of nanosecond integer literals
- Matches `CompactionService.runRetention` in `writer/compaction.go`

Fixes #833

## Test plan
- [ ] `docker exec homer /homer system --compaction-retention-days 1` completes without Binder Error
- [x] `go test ./cli/...`