### PR TITLE
feat(ui): widgets.control to disable Games/NetGames (11.0.281)

### DIFF
--- a/docs/VOIPGames.md
+++ b/docs/VOIPGames.md
@@ -11,7 +11,34 @@ On first login (or after a `Reset` from `DashboardSettingsDialog`) the coordinat
 3. **Games** — Packet Defender, SIP Dialog Master, Jitter Buffer Hero, SIPetris, Chess. Single-player only — no coordinator hubs required.
 4. **NetGames** — Netris, NetChess. Multiplayer over WebSocket; both widgets show a connection error until the corresponding hub is reachable, so we keep them on a separate tab.
 
+Items 3–4 are omitted when `coordinator.widgets.control.games` is `false` (see below).
+
 Users can rename, reorder, or delete any of these dashboards at runtime; the seed only runs when `ListDashboards` returns an empty set.
+
+### Disabling games in production
+
+To hide Games / NetGames from the widget picker and skip seeding those default dashboards, set:
+
+```json
+"coordinator": {
+  "widgets": {
+    "control": {
+      "games": false
+    }
+  }
+}
+```
+
+When `games` is `false`:
+
+- The **Games** category is hidden in Add Widget.
+- Default **Games** and **NetGames** tabs are not created on reset / first login.
+- Multiplayer hubs (`/api/v4/games/netris`, `/api/v4/games/netchess`) are not started (endpoints return 503).
+- The `/gamedata/` static route (Doom IWAD) is not registered.
+
+Existing dashboards that already contain game widgets may remain until removed manually; those widgets show a short “category disabled” message instead of loading the game UI.
+
+Other picker categories (`search`, `visualize`, `external`, `utility`) can be set to `false` the same way; today that only hides them in Add Widget (no extra backend gates yet).
 
 ---
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -426,6 +426,9 @@ type CoordinatorConfig struct {
 	// governs what the coordinator itself is willing to forward to the UI.
 	HepStream CoordinatorHepStreamConfig `json:"hep_stream" mapstructure:"hep_stream"`
 
+	// Widgets configures dashboard widget picker categories (see widgets.control).
+	Widgets WidgetsConfig `json:"widgets" mapstructure:"widgets"`
+
 	// FlightSQLServer exposes Arrow FlightSQL on the coordinator and proxies SQL
 	// to node flightsql_port endpoints (Grafana single entrypoint).
 	FlightSQLServer FlightSQLServerConfig `json:"flightsql_server" mapstructure:"flightsql_server"`
@@ -1458,6 +1461,9 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("coordinator.hep_stream.allow_payload", false)
 	v.SetDefault("coordinator.hep_stream.fan_out_timeout_ms", 2000)
 	v.SetDefault("coordinator.hep_stream.history_limit", 200)
+	for _, cat := range WidgetControlCategories {
+		v.SetDefault("coordinator.widgets.control."+cat, true)
+	}
 
 	// MCP defaults
 	v.SetDefault("mcp.enable", false)

--- a/src/config/widgets.go
+++ b/src/config/widgets.go
@@ -1,0 +1,58 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package config
+
+import "strings"
+
+// WidgetControlCategories lists dashboard picker categories (lowercase keys).
+var WidgetControlCategories = []string{
+	"search", "visualize", "external", "utility", "games",
+}
+
+// WidgetsConfig configures which widget picker categories are available.
+type WidgetsConfig struct {
+	// Control maps category key → enabled. Missing key or true = enabled.
+	Control map[string]bool `json:"control" mapstructure:"control"`
+}
+
+// DefaultWidgetControl returns all categories enabled.
+func DefaultWidgetControl() map[string]bool {
+	out := make(map[string]bool, len(WidgetControlCategories))
+	for _, c := range WidgetControlCategories {
+		out[c] = true
+	}
+	return out
+}
+
+// NormalizeWidgetControl merges operator overrides onto defaults so API/UI
+// always see a full map.
+func NormalizeWidgetControl(control map[string]bool) map[string]bool {
+	out := DefaultWidgetControl()
+	for k, v := range control {
+		key := strings.ToLower(strings.TrimSpace(k))
+		if key == "" {
+			continue
+		}
+		out[key] = v
+	}
+	return out
+}
+
+// WidgetCategoryEnabled reports whether a picker category is enabled.
+// category is the UI label (e.g. "Games") or config key (e.g. "games").
+func WidgetCategoryEnabled(control map[string]bool, category string) bool {
+	key := strings.ToLower(strings.TrimSpace(category))
+	if control == nil {
+		return true
+	}
+	v, ok := control[key]
+	if !ok {
+		return true
+	}
+	return v
+}

--- a/src/config/widgets_test.go
+++ b/src/config/widgets_test.go
@@ -1,0 +1,38 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package config
+
+import "testing"
+
+func TestWidgetCategoryEnabled(t *testing.T) {
+	control := map[string]bool{"games": false}
+	if WidgetCategoryEnabled(control, "Games") {
+		t.Fatal("Games should be disabled")
+	}
+	if !WidgetCategoryEnabled(control, "Search") {
+		t.Fatal("Search should default enabled")
+	}
+	if !WidgetCategoryEnabled(nil, "games") {
+		t.Fatal("nil control: missing key means enabled")
+	}
+}
+
+func TestNormalizeWidgetControl(t *testing.T) {
+	out := NormalizeWidgetControl(map[string]bool{"games": false})
+	for _, c := range WidgetControlCategories {
+		if c == "games" {
+			if out[c] {
+				t.Fatal("games should be false")
+			}
+			continue
+		}
+		if !out[c] {
+			t.Fatalf("%s should default true", c)
+		}
+	}
+}

--- a/src/coordinator/coordinator.go
+++ b/src/coordinator/coordinator.go
@@ -226,7 +226,10 @@ func (c *Coordinator) setupRoutes() {
 	)
 	usersHandler := handlers.NewUsersHandler(userService)
 	userSettingsHandler := handlers.NewUserSettingsHandler(userSettingsService, userMappingService)
-	dashboardsHandler := handlers.NewDashboardsHandler(services.NewDashboardService(c.settingsDB))
+	widgetControl := config.NormalizeWidgetControl(c.config.Widgets.Control)
+	dashboardsHandler := handlers.NewDashboardsHandler(
+		services.NewDashboardService(c.settingsDB, widgetControl),
+	)
 	mappingsHandler := handlers.NewMappingsHandler(mapSvc, userMappingService)
 	hepsubsHandler := handlers.NewHepsubsHandler(services.NewHepsubService(c.settingsDB))
 	aliasesHandler := handlers.NewAliasesHandler(aliasSvc)
@@ -239,6 +242,7 @@ func (c *Coordinator) setupRoutes() {
 	scriptsHandler := handlers.NewScriptsHandler(services.NewScriptsService(c.settingsDB))
 	alertsHandler := handlers.NewAlertsHandler(services.NewAlertsService(c.settingsDB))
 	modulesHandler := handlers.NewModulesHandler()
+	modulesHandler.SetWidgetControl(widgetControl)
 	statisticsHandler := handlers.NewStatisticsHandler(c.flightService)
 	// LineProtoHandler exposes read-only discovery for the dynamic LP
 	// tables created by the line-protocol receiver. The receiver and
@@ -254,8 +258,10 @@ func (c *Coordinator) setupRoutes() {
 	// reconnect and re-pair. Always wired (no separate config knob)
 	// because it costs nothing when nobody is playing.
 	gamesHandler := handlers.NewGamesHandler()
-	gamesHandler.SetNetrisHub(netris.NewHub(netris.Config{}))
-	gamesHandler.SetNetChessHub(netchess.NewHub(netchess.Config{}))
+	if config.WidgetCategoryEnabled(widgetControl, "games") {
+		gamesHandler.SetNetrisHub(netris.NewHub(netris.Config{}))
+		gamesHandler.SetNetChessHub(netchess.NewHub(netchess.Config{}))
+	}
 	// Reuse the same LLM client that powers MCP. NewLLMClient returns
 	// nil when llm.enable=false, in which case the Chess widget will
 	// hide the LLM toggle (V4ChessLLMStatus reports enabled=false).
@@ -577,9 +583,11 @@ func (c *Coordinator) setupStaticRoutes() {
 	// gamedata_dir and intentionally kept out of the embedded UI bundle so
 	// they never inflate the binary. Registered before the SPA handlers so
 	// /gamedata/* never falls through to index.html.
-	if dir := c.config.HTTPServer.GamedataDir; dir != "" {
-		logger.Info("Coordinator: Serving game data from filesystem", "path", dir)
-		c.echo.Static("/gamedata", dir)
+	if config.WidgetCategoryEnabled(c.config.Widgets.Control, "games") {
+		if dir := c.config.HTTPServer.GamedataDir; dir != "" {
+			logger.Info("Coordinator: Serving game data from filesystem", "path", dir)
+			c.echo.Static("/gamedata", dir)
+		}
 	}
 
 	// Serve from filesystem if static_path is configured

--- a/src/coordinator/handlers/system_v4.go
+++ b/src/coordinator/handlers/system_v4.go
@@ -19,10 +19,15 @@ type ModulesHandler struct {
 	lokiEnabled     bool
 	lokiTemplate    string
 	lokiExternalURL string
+	widgetControl   map[string]bool
 }
 
 func NewModulesHandler() *ModulesHandler {
 	return &ModulesHandler{}
+}
+
+func (h *ModulesHandler) SetWidgetControl(control map[string]bool) {
+	h.widgetControl = control
 }
 
 type ModulesStatusResponseV4 struct {
@@ -32,6 +37,9 @@ type ModulesStatusResponseV4 struct {
 			Template    string `json:"template,omitempty"`
 			ExternalURL string `json:"external_url,omitempty"`
 		} `json:"loki"`
+		Widgets struct {
+			Control map[string]bool `json:"control"`
+		} `json:"widgets"`
 	} `json:"data"`
 	Meta Meta `json:"meta"`
 }
@@ -41,6 +49,7 @@ func (h *ModulesHandler) V4ModulesStatus(c echo.Context) error {
 	resp.Data.Loki.Enable = h.lokiEnabled
 	resp.Data.Loki.Template = h.lokiTemplate
 	resp.Data.Loki.ExternalURL = h.lokiExternalURL
+	resp.Data.Widgets.Control = h.widgetControl
 	resp.Meta = buildMeta(c, "")
 	return c.JSON(http.StatusOK, resp)
 }

--- a/src/coordinator/handlers/system_v4_modules_test.go
+++ b/src/coordinator/handlers/system_v4_modules_test.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/sipcapture/homer-core/src/config"
+)
+
+func TestV4ModulesStatus_WidgetControl(t *testing.T) {
+	e := echo.New()
+	h := NewModulesHandler()
+	h.SetWidgetControl(config.NormalizeWidgetControl(map[string]bool{"games": false}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v4/modules", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.V4ModulesStatus(c); err != nil {
+		t.Fatalf("V4ModulesStatus: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d", rec.Code)
+	}
+
+	var body ModulesStatusResponseV4
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Data.Widgets.Control["games"] {
+		t.Fatal("games should be false")
+	}
+	if !body.Data.Widgets.Control["search"] {
+		t.Fatal("search should default true")
+	}
+}

--- a/src/coordinator/services/dashboard_service.go
+++ b/src/coordinator/services/dashboard_service.go
@@ -13,15 +13,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/sipcapture/homer-core/src/config"
 )
 
 // DashboardService provides dashboard operations backed by dashboard_settings.
 type DashboardService struct {
-	db *sql.DB
+	db            *sql.DB
+	widgetControl map[string]bool
 }
 
-func NewDashboardService(db *sql.DB) *DashboardService {
-	return &DashboardService{db: db}
+func NewDashboardService(db *sql.DB, widgetControl map[string]bool) *DashboardService {
+	return &DashboardService{db: db, widgetControl: widgetControl}
 }
 
 func (s *DashboardService) ListDashboards(ctx context.Context, username string) ([]UserSetting, error) {
@@ -219,40 +222,42 @@ func (s *DashboardService) ResetDashboards(ctx context.Context, username string)
 		return err
 	}
 
-	// Default "Games" dashboard with all single-player game widgets pre-laid out
-	// on the 12-col grid. Players land here and try every game without having
-	// to use the Add Widget dialog.
-	gamesData, _ := json.Marshal(map[string]interface{}{
-		"name": "Games", "param": "games", "shared": false, "type": 2, "weight": 30,
-		"config": map[string]interface{}{"columns": 12, "grid_type": "fit", "locked": false},
-		"widgets": []map[string]interface{}{
-			{"id": "packet-defender-1", "type": "packet_defender", "x": 0, "y": 0, "w": 6, "h": 10, "title": "Packet Defender"},
-			{"id": "sip-dialog-master-1", "type": "sip_dialog_master", "x": 6, "y": 0, "w": 6, "h": 10, "title": "SIP Dialog Master"},
-			{"id": "jitter-buffer-hero-1", "type": "jitter_buffer_hero", "x": 0, "y": 10, "w": 6, "h": 10, "title": "Jitter Buffer Hero"},
-			{"id": "sipetris-1", "type": "sipetris", "x": 6, "y": 10, "w": 6, "h": 12, "title": "SIPetris"},
-			{"id": "chess-1", "type": "chess", "x": 0, "y": 22, "w": 8, "h": 12, "title": "Chess"},
-		},
-	})
-	if _, err := s.CreateDashboard(ctx, username, "games", gamesData); err != nil {
-		return err
-	}
+	if config.WidgetCategoryEnabled(s.widgetControl, "games") {
+		// Default "Games" dashboard with all single-player game widgets pre-laid out
+		// on the 12-col grid. Players land here and try every game without having
+		// to use the Add Widget dialog.
+		gamesData, _ := json.Marshal(map[string]interface{}{
+			"name": "Games", "param": "games", "shared": false, "type": 2, "weight": 30,
+			"config": map[string]interface{}{"columns": 12, "grid_type": "fit", "locked": false},
+			"widgets": []map[string]interface{}{
+				{"id": "packet-defender-1", "type": "packet_defender", "x": 0, "y": 0, "w": 6, "h": 10, "title": "Packet Defender"},
+				{"id": "sip-dialog-master-1", "type": "sip_dialog_master", "x": 6, "y": 0, "w": 6, "h": 10, "title": "SIP Dialog Master"},
+				{"id": "jitter-buffer-hero-1", "type": "jitter_buffer_hero", "x": 0, "y": 10, "w": 6, "h": 10, "title": "Jitter Buffer Hero"},
+				{"id": "sipetris-1", "type": "sipetris", "x": 6, "y": 10, "w": 6, "h": 12, "title": "SIPetris"},
+				{"id": "chess-1", "type": "chess", "x": 0, "y": 22, "w": 8, "h": 12, "title": "Chess"},
+			},
+		})
+		if _, err := s.CreateDashboard(ctx, username, "games", gamesData); err != nil {
+			return err
+		}
 
-	// Default "NetGames" dashboard with the multiplayer game widgets. They
-	// require coordinator hubs (netris, netchess), so we surface them in a
-	// dedicated tab to avoid surprising single-user installs. Both widgets
-	// share an 8x12 footprint — their boards are very different shapes
-	// (10x20 vs 8x8) but both fit comfortably in that area thanks to the
-	// per-widget useArenaCellSize auto-fit.
-	netGamesData, _ := json.Marshal(map[string]interface{}{
-		"name": "NetGames", "param": "netgames", "shared": false, "type": 3, "weight": 40,
-		"config": map[string]interface{}{"columns": 12, "grid_type": "fit", "locked": false},
-		"widgets": []map[string]interface{}{
-			{"id": "netris-1", "type": "netris", "x": 0, "y": 0, "w": 8, "h": 12, "title": "Netris"},
-			{"id": "netchess-1", "type": "netchess", "x": 0, "y": 12, "w": 8, "h": 12, "title": "NetChess"},
-		},
-	})
-	if _, err := s.CreateDashboard(ctx, username, "netgames", netGamesData); err != nil {
-		return err
+		// Default "NetGames" dashboard with the multiplayer game widgets. They
+		// require coordinator hubs (netris, netchess), so we surface them in a
+		// dedicated tab to avoid surprising single-user installs. Both widgets
+		// share an 8x12 footprint — their boards are very different shapes
+		// (10x20 vs 8x8) but both fit comfortably in that area thanks to the
+		// per-widget useArenaCellSize auto-fit.
+		netGamesData, _ := json.Marshal(map[string]interface{}{
+			"name": "NetGames", "param": "netgames", "shared": false, "type": 3, "weight": 40,
+			"config": map[string]interface{}{"columns": 12, "grid_type": "fit", "locked": false},
+			"widgets": []map[string]interface{}{
+				{"id": "netris-1", "type": "netris", "x": 0, "y": 0, "w": 8, "h": 12, "title": "Netris"},
+				{"id": "netchess-1", "type": "netchess", "x": 0, "y": 12, "w": 8, "h": 12, "title": "NetChess"},
+			},
+		})
+		if _, err := s.CreateDashboard(ctx, username, "netgames", netGamesData); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/src/coordinator/services/dashboard_service_test.go
+++ b/src/coordinator/services/dashboard_service_test.go
@@ -12,6 +12,8 @@ import (
 	"encoding/json"
 	"path/filepath"
 	"testing"
+
+	"github.com/sipcapture/homer-core/src/config"
 )
 
 // TestResetDashboards_SeedsDefaultsIncludingGames pins the set of dashboards
@@ -30,7 +32,7 @@ func TestResetDashboards_SeedsDefaultsIncludingGames(t *testing.T) {
 		t.Fatalf("EnsureSettingsSchema: %v", err)
 	}
 
-	svc := NewDashboardService(db)
+	svc := NewDashboardService(db, config.DefaultWidgetControl())
 	ctx := context.Background()
 	const user = "alice"
 
@@ -88,6 +90,49 @@ func TestResetDashboards_SeedsDefaultsIncludingGames(t *testing.T) {
 	}
 }
 
+func TestResetDashboards_SkipsGamesWhenDisabled(t *testing.T) {
+	dir := t.TempDir()
+	db, err := OpenSettingsDB(filepath.Join(dir, "settings.duckdb"))
+	if err != nil {
+		t.Fatalf("OpenSettingsDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := EnsureSettingsSchema(db); err != nil {
+		t.Fatalf("EnsureSettingsSchema: %v", err)
+	}
+
+	control := config.NormalizeWidgetControl(map[string]bool{"games": false})
+	svc := NewDashboardService(db, control)
+	ctx := context.Background()
+
+	if err := svc.ResetDashboards(ctx, "carol"); err != nil {
+		t.Fatalf("ResetDashboards: %v", err)
+	}
+
+	settings, err := svc.ListDashboards(ctx, "carol")
+	if err != nil {
+		t.Fatalf("ListDashboards: %v", err)
+	}
+
+	byParam := make(map[string]json.RawMessage, len(settings))
+	for _, s := range settings {
+		byParam[s.Param] = s.Data
+	}
+
+	expected := []string{"home", "smartsearch"}
+	for _, p := range expected {
+		if _, ok := byParam[p]; !ok {
+			t.Fatalf("dashboard %q missing; got %v", p, keys(byParam))
+		}
+	}
+	if _, ok := byParam["games"]; ok {
+		t.Fatal("games dashboard should not be seeded when disabled")
+	}
+	if _, ok := byParam["netgames"]; ok {
+		t.Fatal("netgames dashboard should not be seeded when disabled")
+	}
+}
+
 // TestResetDashboards_IsIdempotent confirms a second call replaces the
 // dashboards in place rather than duplicating them — the API handler calls
 // Reset whenever ListDashboards returns nothing, so a partially-deleted user
@@ -103,7 +148,7 @@ func TestResetDashboards_IsIdempotent(t *testing.T) {
 		t.Fatalf("EnsureSettingsSchema: %v", err)
 	}
 
-	svc := NewDashboardService(db)
+	svc := NewDashboardService(db, config.DefaultWidgetControl())
 	ctx := context.Background()
 
 	if err := svc.ResetDashboards(ctx, "bob"); err != nil {

--- a/src/ui/src/dashboard/DashboardLayout.tsx
+++ b/src/ui/src/dashboard/DashboardLayout.tsx
@@ -10,7 +10,8 @@ import PanelChrome from './components/PanelChrome'
 import AddWidgetDialog from './components/AddWidgetDialog'
 import DashboardSettingsDialog from './components/DashboardSettingsDialog'
 import SearchWidgetSettings from './components/SearchWidgetSettings'
-import { getWidgetMeta } from './widgets/registry'
+import { getWidgetMeta, isWidgetCategoryEnabled } from './widgets/registry'
+import { useModules } from '@/hooks/useModules'
 import { GRID_ROW_HEIGHT, GRID_MARGIN, computeAvailableRows, fitWidgetHeight } from './utils/grid-utils'
 import { resolveTimeRange, type CalendarPreset } from './utils/resolveTimeRange'
 import { Button } from '@/components/ui/button'
@@ -41,6 +42,7 @@ function DashboardGrid() {
   const [containerHeight, setContainerHeight] = useState(0)
   const widgetsRef = useRef(widgets)
   const skipLayoutChangeRef = useRef(false)
+  const { widgetControl } = useModules()
 
   useEffect(() => { widgetsRef.current = widgets }, [widgets])
 
@@ -343,6 +345,9 @@ function DashboardGrid() {
             {widgets.map((widget) => {
               const meta = getWidgetMeta(widget.type)
               const WidgetComponent = meta?.component
+              const categoryDisabled =
+                meta?.category != null &&
+                !isWidgetCategoryEnabled(widgetControl, meta.category)
               return (
                 <div key={widget.id}>
                   <PanelChrome
@@ -365,7 +370,11 @@ function DashboardGrid() {
                         </div>
                       }
                     >
-                      {WidgetComponent ? (
+                      {categoryDisabled ? (
+                        <div className="flex h-full items-center justify-center px-4 text-center text-sm text-muted-foreground">
+                          This widget category is disabled on this server ({meta?.category}).
+                        </div>
+                      ) : WidgetComponent ? (
                         <WidgetComponent
                           widgetId={widget.id}
                           config={widget.config || {}}
@@ -385,7 +394,13 @@ function DashboardGrid() {
         )}
       </div>
 
-      {addOpen && <AddWidgetDialog onAdd={handleAddWidget} onClose={() => setAddOpen(false)} />}
+      {addOpen && (
+        <AddWidgetDialog
+          onAdd={handleAddWidget}
+          onClose={() => setAddOpen(false)}
+          widgetControl={widgetControl}
+        />
+      )}
       {settingsOpen && activeDash && (
         <DashboardSettingsDialog
           dashboard={activeDash}

--- a/src/ui/src/dashboard/components/AddWidgetDialog.tsx
+++ b/src/ui/src/dashboard/components/AddWidgetDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -8,7 +8,11 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { cn } from '@/lib/utils'
-import { widgetRegistry, widgetCategories } from '../widgets/registry'
+import {
+  isWidgetCategoryEnabled,
+  widgetCategories,
+  widgetRegistry,
+} from '../widgets/registry'
 import { PanelIcon } from './PanelChrome'
 
 /**
@@ -28,8 +32,28 @@ interface PickerEntry {
   defaultConfig: Record<string, unknown>
 }
 
-export default function AddWidgetDialog({ onAdd, onClose }) {
-  const [activeCategory, setActiveCategory] = useState('Search')
+interface AddWidgetDialogProps {
+  onAdd: (widget: {
+    id: string
+    type: string
+    x: number
+    y: number
+    w: number
+    h: number
+    title: string
+    config: Record<string, unknown>
+  }) => void
+  onClose: () => void
+  widgetControl?: Record<string, boolean>
+}
+
+export default function AddWidgetDialog({ onAdd, onClose, widgetControl }: AddWidgetDialogProps) {
+  const visibleCategories = useMemo(
+    () =>
+      widgetCategories.filter((cat) => isWidgetCategoryEnabled(widgetControl, cat)),
+    [widgetControl],
+  )
+  const [activeCategory, setActiveCategory] = useState(visibleCategories[0] ?? 'Search')
 
   const handleAdd = (entry: PickerEntry) => {
     onAdd({
@@ -53,13 +77,13 @@ export default function AddWidgetDialog({ onAdd, onClose }) {
         </DialogHeader>
         <Tabs value={activeCategory} onValueChange={setActiveCategory}>
           <TabsList className="w-full">
-            {widgetCategories.map((cat) => (
+            {visibleCategories.map((cat) => (
               <TabsTrigger key={cat} value={cat}>
                 {cat}
               </TabsTrigger>
             ))}
           </TabsList>
-          {widgetCategories.map((cat) => {
+          {visibleCategories.map((cat) => {
             const entries: PickerEntry[] = []
             Object.entries(widgetRegistry).forEach(([type, meta]) => {
               if (meta.category !== cat || meta.hidden) return

--- a/src/ui/src/dashboard/widgets/registry.ts
+++ b/src/ui/src/dashboard/widgets/registry.ts
@@ -331,6 +331,29 @@ export const widgetRegistry: Record<string, WidgetMeta> = {
 
 export const widgetCategories = ['Search', 'Visualize', 'External', 'Utility', 'Games']
 
+export function categoryConfigKey(category: string): string {
+  return category.toLowerCase()
+}
+
+export const DEFAULT_WIDGET_CONTROL: Record<string, boolean> = {
+  search: true,
+  visualize: true,
+  external: true,
+  utility: true,
+  games: true,
+}
+
+export function isWidgetCategoryEnabled(
+  control: Record<string, boolean> | undefined,
+  category: string,
+): boolean {
+  if (!control) return true
+  const key = categoryConfigKey(category)
+  const v = control[key]
+  if (v === undefined) return true
+  return v
+}
+
 export function getWidgetMeta(type) {
   return widgetRegistry[type] || null
 }

--- a/src/ui/src/hooks/useModules.ts
+++ b/src/ui/src/hooks/useModules.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+import { apiGet } from '@/api'
+import { DEFAULT_WIDGET_CONTROL } from '@/dashboard/widgets/registry'
+
+type ModulesResponse = {
+  data?: {
+    widgets?: {
+      control?: Record<string, boolean>
+    }
+  }
+}
+
+export function useModules() {
+  const [widgetControl, setWidgetControl] =
+    useState<Record<string, boolean>>(DEFAULT_WIDGET_CONTROL)
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    apiGet<ModulesResponse>('/modules')
+      .then((res) => {
+        if (cancelled) return
+        const control = res?.data?.widgets?.control
+        if (control) {
+          setWidgetControl({ ...DEFAULT_WIDGET_CONTROL, ...control })
+        }
+        setLoaded(true)
+      })
+      .catch(() => {
+        if (!cancelled) setLoaded(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return { widgetControl, loaded }
+}

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.280"
+	VERSION_APPLICATION = "11.0.281"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Add `coordinator.widgets.control` map (`games`, `search`, `visualize`, `external`, `utility`; default all `true`)
- `games: false` — hide Games picker category, skip Games/NetGames default dashboards, no netris/netchess hubs, no `/gamedata/`
- Expose full map via `GET /api/v4/modules` → `data.widgets.control`
- UI filters Add Widget tabs and shows placeholder on existing disabled-category widgets

Fixes #835

## Config example

```json
"coordinator": {
  "widgets": {
    "control": { "games": false }
  }
}
```

## Test plan
- [x] `go test ./config/... ./coordinator/handlers/...` (modules + dashboard seed)
- [x] `npm run check-types` + `npm test`
- [ ] Set `games: false`, reload UI — no Games tab in Add Widget; reset dashboards omit Games/NetGames
- [ ] Existing game widgets show disabled message