### PR TITLE
fix(security): validate statistics/query rawquery (11.0.282)

### DIFF
--- a/docs/AUTH_LDAP_AND_OAUTH.md
+++ b/docs/AUTH_LDAP_AND_OAUTH.md
@@ -17,11 +17,11 @@ Password login with **`type`** omitted or **`internal`** on `POST /api/v4/auth/s
 | Format | When used | Verification |
 |--------|-----------|--------------|
 | **bcrypt** (`$2a$…`, `$2b$…`, `$2y$…`) | New or updated passwords via Users API / `PATCH /me` | `bcrypt.CompareHashAndPassword` |
-| **SHA-256 hex** (64 chars) | Default bootstrap admin (`sipcapture`), migrated homer-app rows, `--reset-admin-password` | Legacy compare (hex digest of password) |
+| **SHA-256 hex** (64 chars) | Explicit bootstrap hash in config, migrated homer-app rows, `--reset-admin-password` | Legacy compare (hex digest of password) |
 
 The coordinator accepts **either** format at login. Prefer letting the API create bcrypt hashes for new users instead of hand-editing SHA-256 in DuckDB.
 
-If **`coordinator.auth` is omitted** entirely (no `auth` key), the loader behaves like **`{"type":"internal"}`**: default admin `admin`, default bootstrap hash for **`sipcapture`**, and the same startup insert into **`users`** when missing.
+If **`coordinator.auth` is omitted** entirely (no `auth` key), the loader behaves like **`{"type":"internal"}`**: default admin name **`admin`**, internal bootstrap on startup when no `users` row exists. If **`admin_password_hash`** is also omitted, the coordinator generates a **random** bootstrap password and logs it once (see [SECURITY.md](./SECURITY.md#bootstrap-admin-password-coordinatorauth)).
 
 ### Password login fallback (`fallback_auth_type`)
 
@@ -65,10 +65,12 @@ Other **`type`** values (no internal bootstrap; LDAP/OAuth still follow their ow
 
 Meaning (string or `{"type":"internal"}` without custom hash):
 
-- The loader treats **`"internal"`** (case-insensitive) or **`{"type":"internal"}`** as **built-in local auth** with default admin name **`admin`** and a **fixed bootstrap password hash** (SHA-256 hex of **`sipcapture`**):  
-  `883ffc1f37fd0fe542b0fb9740035c4383e7d976c411161d24e62edace280f90`.
-- On coordinator startup, if there is **no** row in `users` whose **`username`** equals the configured admin name (default `admin`), the coordinator **inserts** that admin once (`is_admin` / `is_active` true) with that hash. If a row for that username **already** exists, nothing is inserted automatically (empty `password_hash` may still be repaired on startup in recent builds).
+- The loader treats **`"internal"`** (case-insensitive) or **`{"type":"internal"}`** as **built-in local auth** with default admin name **`admin`**.
+- On coordinator startup, if there is **no** row in `users` whose **`username`** equals the configured admin name (default `admin`), the coordinator **inserts** that admin once (`is_admin` / `is_active` true). If **`admin_password_hash`** is set (config or env), that hash is used; if empty, a **random password** is generated, stored as bcrypt, and logged once at startup.
+- If a row for that username **already** exists with a non-empty `password_hash`, bootstrap does not change the password (upgrade-safe). Empty `password_hash` on an existing row may be repaired from config hash or a new random password when hash is omitted.
 - After first login, operators should **change the password** (Settings → Users, or `PATCH /me`). Updates store a **bcrypt** hash. Further logins use the stored hash only.
+
+**Docker / explicit bootstrap:** `examples/docker/docker-compose.yaml` sets `HOMER_COORDINATOR_AUTH_ADMIN_PASSWORD_HASH` to the SHA-256 hex of **`sipcapture`** — that path is unchanged and still yields first login **`admin` / `sipcapture`** on fresh installs using those examples.
 
 ### Legacy object: only `admin_user` / `admin_password_hash` (no `type`)
 
@@ -81,7 +83,7 @@ You may still use an object **without** `type` (for environment overrides, confi
 }
 ```
 
-- If **`admin_user`** is unset or **`admin`** and **`admin_password_hash`** is empty or equals the default sipcapture hash, the loader treats this as **`internal`** (same bootstrap as `{"type":"internal"}`). Any other combination is legacy credentials-only: provision **`users`** via API / SQL, or set **`{"type":"internal"}`** explicitly.
+- If **`admin_user`** is unset or **`admin`** and **`admin_password_hash`** is empty, the loader treats this as **`internal`** with random bootstrap password when no `users` row exists. If **`admin_password_hash`** is set (including the legacy sipcapture SHA-256 hex from docker examples), bootstrap uses that hash.
 - For **`--reset-admin-password`**, the config field **`admin_password_hash`** remains **SHA-256 hex** (see [Reset admin password](#reset-admin-password)). User records created or updated through the API use **bcrypt** instead.
 
 ### Reset admin password
@@ -109,7 +111,7 @@ The homer-core CLI flag **`--reset-admin-password`** (together with **`--config-
 }
 ```
 
-If you only set **`"auth": "internal"`** (string) or **`{"type":"internal"}`** without an explicit `admin_password_hash`, config normalization still supplies the **default** hash for cleartext **`sipcapture`**. In that case **`--reset-admin-password` will write that default hash** into `users` (useful to “reset” the account to the well-known bootstrap password).
+If you set **`"auth": "internal"`** or **`{"type":"internal"}`** **without** an explicit `admin_password_hash`, **`--reset-admin-password` fails** because `admin_password_hash` must be non-empty in the effective config. Set the hash in JSON or `HOMER_COORDINATOR_AUTH_ADMIN_PASSWORD_HASH` before running the command.
 
 **Environment overrides:** you can set **`HOMER_COORDINATOR_AUTH_ADMIN_PASSWORD_HASH`** (and optionally **`HOMER_COORDINATOR_AUTH_ADMIN_USER`**) instead of embedding the hash in JSON — see `config/env.go` / `env_test` in this repo.
 
@@ -421,6 +423,7 @@ Combined Azure-only + no auto-provision:
 
 ## JWT sessions and logout
 
+- **`coordinator.jwt.secret`** must be non-empty for signing tokens. If omitted in config, Homer auto-generates a secret and persists **`/.homer_jwt_secret`** beside `settings_db_path` (see [SECURITY.md](./SECURITY.md#jwt-secret-coordinatorjwtsecret)). Protected API routes always require authentication.
 - Session id is JWT **`jti`**.
 - `DELETE /api/v4/auth/sessions/{sessionId}` revokes the current `jti` for the remaining token lifetime (in-memory store).
 

--- a/docs/COORDINATOR.md
+++ b/docs/COORDINATOR.md
@@ -341,7 +341,7 @@ The deprecated **`oauth2_providers`** array is still accepted at startup and mig
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| POST | `/api/v4/statistics/query` | Execute statistics query |
+| POST | `/api/v4/statistics/query` | Execute statistics query (`rawquery` validated; read-only SQL only) |
 | GET | `/api/v4/statistics/databases` | List databases |
 | GET | `/api/v4/statistics/measurements` | List measurements |
 | GET | `/api/v4/statistics/metrics` | List metrics |
@@ -455,8 +455,9 @@ See examples in the `examples/` directory:
 
 ## Security Considerations
 
-1. **JWT Secret** - Use a strong, random secret (minimum 32 characters)
-2. **Admin Password** - Store as SHA256 hash, never plain text
-3. **TLS** - Enable `use_tls` for node connections in production
-4. **Network** - Restrict coordinator access via firewall/reverse proxy
-5. **OAuth2** - Use HTTPS callback URLs in production
+1. **JWT secret** — Set `coordinator.jwt.secret` (or `HOMER_COORDINATOR_JWT_SECRET`) to a strong random value in production. If omitted, Homer persists **`/.homer_jwt_secret`** beside `settings_db_path` and always enforces JWT on protected routes ([SECURITY.md](./SECURITY.md)).
+2. **Admin password** — Prefer bcrypt via Users API or wizard; explicit `admin_password_hash` (SHA-256 hex) for bootstrap and `--reset-admin-password`. No default cleartext password is injected when hash is omitted.
+3. **Statistics SQL** — `POST /api/v4/statistics/query` validates `rawquery` (same rules as `/api/v4/query`).
+4. **TLS** — Enable `use_tls` for node connections in production
+5. **Network** — Restrict coordinator access via firewall/reverse proxy
+6. **OAuth2** — Use HTTPS callback URLs in production

--- a/docs/LINE_PROTOCOL.md
+++ b/docs/LINE_PROTOCOL.md
@@ -284,9 +284,7 @@ The Statistics API also works out of the box for the same tables:
 - `GET /api/v4/statistics/databases` → schemas (catalogs)
 - `GET /api/v4/statistics/measurements?db=<schema>` → table names
 - `GET /api/v4/statistics/metrics?db=<schema>` → column names
-- `POST /api/v4/statistics/query` with a `rawquery` ⇒ free-form SQL
-  (`SELECT ... FROM cpu WHERE host = 'node-1'`) for Grafana-style
-  panels.
+- `POST /api/v4/statistics/query` with a `rawquery` ⇒ read-only SQL for Grafana-style panels (`SELECT …`). Since 11.0.282+ each `rawquery` is validated (same rules as `POST /api/v4/query`); DML/DDL and multi-statement SQL are rejected.
 
 ## Auto-published mapping_schema rows (11.0.123+)
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,95 @@
+# Security hardening (11.0.282+)
+
+Homer 11.0.282–11.0.284 closes three coordinator security issues. This page summarizes **operator impact** and how upgrades stay compatible with existing installs.
+
+## Summary
+
+| Issue | Risk (before) | Fix | Typical upgrade impact |
+|-------|----------------|-----|-------------------------|
+| Empty `coordinator.jwt.secret` | Protected API routes were **unauthenticated** | JWT middleware always enforced; empty secret → auto-generated persisted secret | Installs with explicit JWT env/config: **no change**. Installs with empty secret: API now requires login or `Auth-Token` |
+| Default admin `sipcapture` | Predictable first-login password | No auto-filled hash; random bootstrap password logged once when hash omitted | Docker examples with explicit `ADMIN_PASSWORD_HASH`: **no change**. Existing `users` row with old hash: **login still works** |
+| `POST /api/v4/statistics/query` `rawquery` | Unvalidated SQL passthrough | Same `ValidateRawSQL` rules as `/api/v4/query` | Legitimate `SELECT` / `WITH` / `SHOW` queries: **no change** |
+
+GitHub Security Advisories: [GHSA-rqcc-94gv-wjm9](https://github.com/sipcapture/homer/security/advisories/GHSA-rqcc-94gv-wjm9), [GHSA-6xp5-7rcx-xfgx](https://github.com/sipcapture/homer/security/advisories/GHSA-6xp5-7rcx-xfgx), [GHSA-f46q-3v67-fmm4](https://github.com/sipcapture/homer/security/advisories/GHSA-f46q-3v67-fmm4).
+
+---
+
+## JWT secret (`coordinator.jwt.secret`)
+
+**Before:** When the signing secret was empty, JWT middleware was not registered and handlers skipped validation — every protected route was open.
+
+**After:**
+
+1. **Non-empty secret in config or env** — unchanged (recommended for production).
+2. **Empty secret** — on coordinator startup Homer generates a random secret, writes **`/.homer_jwt_secret`** beside `coordinator.settings_db_path` (mode `0600`), and reuses it on restart so sessions stay valid.
+3. Protected routes under `/api/v1`, `/api/v3`, and `/api/v4` **always** require authentication (JWT cookie/Bearer, or valid **`Auth-Token`** when `api_settings.enable_token_access` is true).
+
+```json
+"coordinator": {
+  "settings_db_path": "/var/lib/homer/homer_settings.duckdb",
+  "jwt": {
+    "secret": "use-a-long-random-string-at-least-32-bytes",
+    "expire_hours": 24
+  }
+}
+```
+
+Environment: `HOMER_COORDINATOR_JWT_SECRET`.
+
+**Docker Compose** (`examples/docker/docker-compose.yaml`) already sets `HOMER_COORDINATOR_JWT_SECRET` — no action required.
+
+---
+
+## Bootstrap admin password (`coordinator.auth`)
+
+**Before:** Internal auth normalization injected a fixed SHA-256 hash for cleartext password **`sipcapture`**.
+
+**After:**
+
+| Config | First startup (no `users` row) | Existing `users` row |
+|--------|--------------------------------|----------------------|
+| Explicit `admin_password_hash` or env | Uses configured hash | Unchanged if row already has a password |
+| Empty hash | Random password generated; **logged once** at startup | Unchanged if row already has a password |
+| Docker example env with sipcapture hash | Inserts configured hash | Login `admin` / `sipcapture` still works |
+
+Legacy SHA-256 rows (including migrated homer-app users and explicit sipcapture hash in env) **still authenticate** at login.
+
+**Wizard:** empty admin password field → random password (bcrypt in JSON) shown once after save.
+
+**Recovery:** `homer --config-path … --reset-admin-password` still requires explicit `admin_password_hash` (SHA-256 hex) in config or env.
+
+See [AUTH_LDAP_AND_OAUTH.md](./AUTH_LDAP_AND_OAUTH.md#internal-duckdb-authentication) and [COORDINATOR.md](./COORDINATOR.md#auth).
+
+---
+
+## Statistics SQL (`POST /api/v4/statistics/query`)
+
+**Before:** `rawquery` in the request body was passed to FlightSQL without validation.
+
+**After:** Each `rawquery` is validated with the same rules as `POST /api/v4/query`:
+
+- Allowed statement starts: `SELECT`, `WITH`, `SHOW`, `DESCRIBE`, `EXPLAIN`, `PRAGMA`
+- No semicolons (multi-statement blocked)
+- Blocked DML/DDL keywords and dangerous functions
+
+Invalid SQL returns **400** with `SQL validation failed`. Grafana-style read-only panels using single `SELECT` statements continue to work.
+
+See [LINE_PROTOCOL.md](./LINE_PROTOCOL.md) (Statistics API section).
+
+---
+
+## Upgrade checklist
+
+1. **Review JWT** — If you never set `coordinator.jwt.secret`, after upgrade check coordinator logs for `jwt_secret_file` or set an explicit secret in config.
+2. **Review admin access** — If you relied on open API without JWT, enable `Auth-Token` tokens or use UI login.
+3. **Docker / explicit env** — `HOMER_COORDINATOR_JWT_SECRET` + `HOMER_COORDINATOR_AUTH_ADMIN_PASSWORD_HASH` (as in `examples/docker/`) → no credential changes.
+4. **Automation** — Scripts calling protected endpoints need `Authorization: Bearer …` or `Auth-Token` after upgrade if JWT was previously empty.
+
+---
+
+## See also
+
+- [COORDINATOR.md](./COORDINATOR.md) — `jwt`, `auth` parameters
+- [UI_COORDINATOR_AUTH_AND_TOKENS.md](./UI_COORDINATOR_AUTH_AND_TOKENS.md) — login, cookies, API tokens
+- [WIZARD.md](./WIZARD.md) — generated credentials
+- [AUTH_LDAP_AND_OAUTH.md](./AUTH_LDAP_AND_OAUTH.md) — `--reset-admin-password`

--- a/docs/UI_COORDINATOR_AUTH_AND_TOKENS.md
+++ b/docs/UI_COORDINATOR_AUTH_AND_TOKENS.md
@@ -76,7 +76,7 @@ API clients and SPAs should **exchange** the query `token` for the JWT and then 
   - **Browser UI (recommended):** HttpOnly cookie — automatic on same-origin `/api/v4` with `credentials: include`; not readable from JS (mitigates XSS token theft).
   - **Scripts / API clients:** `Authorization: Bearer <jwt>` (unchanged).
   - **WebSocket:** cookie on the handshake when using the UI; otherwise `?access_token=<jwt>` (browsers cannot set `Authorization` on WS upgrade).
-- **Lifetime:** `coordinator.jwt.expire_hours` (default 24) and `coordinator.jwt.secret`.
+- **Lifetime:** `coordinator.jwt.expire_hours` (default 24) and `coordinator.jwt.secret`. If `secret` is empty in config, Homer generates and persists **`/.homer_jwt_secret`** beside `settings_db_path` at startup ([SECURITY.md](./SECURITY.md)).
 - **Cookie settings** (`coordinator.jwt`): `cookie_enable` (default true), `cookie_name` (default `homer_session`), `cookie_same_site` (`Lax` | `Strict` | `None`), `cookie_secure` (optional; auto from TLS / `X-Forwarded-Proto`).
 - **CSRF:** Cookie-authenticated **POST/PUT/PATCH/DELETE** requests validate `Origin` / `Referer` against the request host (defense in depth with `SameSite=Lax`).
 - **Logout / revocation:** JWT **`jti`** is the session id. **`DELETE /api/v4/auth/sessions/current`** revokes the caller’s session and clears the cookie (bundled UI logout). **`DELETE /api/v4/auth/sessions/{sessionId}`** revokes a specific `jti` when it matches the Bearer/cookie session.

--- a/docs/WIZARD.md
+++ b/docs/WIZARD.md
@@ -92,8 +92,8 @@ Choose a profile to pre-fill module settings. Selecting `all-in-one` enables all
 
 - API HTTP port (default: 8080)
 - Node host and port to query (default: 127.0.0.1:50051)
-- JWT secret (auto-generated if empty)
-- Admin username and password (password is SHA-256 hashed in the config)
+- JWT secret (auto-generated in TUI if empty; always stored in config when using wizard)
+- Admin username and password (empty password → auto-generated; stored as bcrypt in config)
 - Settings DB path
 
 **Step 6 -- System Settings**
@@ -162,8 +162,9 @@ Disabled modules have `"enable": false` but retain their default settings, so th
 
 ## Security Notes
 
-- **Admin bootstrap** uses **`"coordinator.auth": "internal"`** in the generated file (default first login: **`admin` / `sipcapture`** until changed). The wizard embeds the default **SHA-256 hex** bootstrap hash for `sipcapture`; if you set a **custom** admin password in the TUI, the generated config stores a **bcrypt** hash instead. Passwords are never written in plaintext in JSON.
-- **JWT secret** is auto-generated using `crypto/rand` if left empty (64 hex characters).
+- **Admin bootstrap** uses **`"coordinator.auth": {"type":"internal"}`** in the generated file. If you leave **Admin Password** empty in the TUI, the wizard generates a random password, stores its **bcrypt** hash in JSON, and displays the cleartext **once** after save. If you enter a password, that value is bcrypt-hashed in the config. Passwords are never written in plaintext in JSON.
+- On coordinator startup **without** wizard (empty `admin_password_hash`), a random bootstrap password is logged once — see [SECURITY.md](./SECURITY.md).
+- **JWT secret** in the TUI: if left empty, a random value is generated and embedded in the saved `homer.json`. Coordinator startup with empty JWT in a hand-edited config instead persists **`/.homer_jwt_secret`** beside the settings DB.
 - The generated config file is written with `0644` permissions. Restrict access if it contains sensitive tokens.
 
 ## Post-Generation

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ ingest, DuckLake storage, Node (FlightSQL), and Coordinator (REST API).
 | CLI search | [Search CLI](SEARCH.md) |
 | Dashboard search & mappings | [URL search](SEARCH_URL.md) · [External app Call-ID links](SEARCH_URL.md#external-apps) · [Mappings & fields](SEARCH_MAPPINGS_AND_FIELDS.md) |
 | REST API | [Coordinator](COORDINATOR.md) · [OpenAPI (Swagger)](swagger/index.html) |
+| Authentication & security | [Security hardening](SECURITY.md) · [LDAP & OAuth](AUTH_LDAP_AND_OAUTH.md) · [UI tokens](UI_COORDINATOR_AUTH_AND_TOKENS.md) |
 | Storage | [Architecture](STORAGE_ARCHITECTURE.md) · [Policies](STORAGE_POLICIES.md) |
 | Performance | [Ingest tuning](INGEST_PERFORMANCE.md) · [DuckDB tuning](DUCKDB_TUNING.md) · [OOM troubleshooting](OOM.md) |
 | MCP / LLM | [MCP server](MCP.md) · [MCP UI guide](MCP_UI_GUIDE.md) |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1831,6 +1831,11 @@ paths:
     post:
       tags: [Statistics]
       summary: Statistics query
+      description: |
+        Executes a read-only SQL query for Grafana-style statistics panels.
+        Each `rawquery` in the request body is validated before execution (same
+        rules as `POST /api/v4/query`): allowed statement types include SELECT,
+        WITH, SHOW, DESCRIBE, EXPLAIN, PRAGMA; semicolons and DML/DDL are rejected.
       operationId: statisticsQuery
       requestBody:
         required: true
@@ -2460,7 +2465,8 @@ components:
           example: admin
         password:
           type: string
-          example: sipcapture
+          description: User password (not the default bootstrap password unless configured explicitly)
+          example: your-password
     LoginResponse:
       type: object
       properties:

--- a/docs/swagger/standalone.html
+++ b/docs/swagger/standalone.html
@@ -1497,6 +1497,11 @@ paths:
     post:
       tags: [Statistics]
       summary: Statistics query
+      description: |
+        Executes a read-only SQL query for Grafana-style statistics panels.
+        Each `rawquery` in the request body is validated before execution (same
+        rules as `POST /api/v4/query`): allowed statement types include SELECT,
+        WITH, SHOW, DESCRIBE, EXPLAIN, PRAGMA; semicolons and DML/DDL are rejected.
       operationId: statisticsQuery
       requestBody:
         required: true
@@ -2132,7 +2137,7 @@ components:
           example: admin
         password:
           type: string
-          example: sipcapture
+          example: your-password
     LoginResponse:
       type: object
       properties:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
       - Grafana integration: GRAFANA_INTEGRATION.md
       - Lua correlation: LUA_CORRELATION.md
   - Authentication:
+      - Security hardening: SECURITY.md
       - LDAP & OAuth: AUTH_LDAP_AND_OAUTH.md
       - OAuth reference: AUTH_OAUTH.md
       - UI tokens: UI_COORDINATOR_AUTH_AND_TOKENS.md

--- a/src/coordinator/docs/openapi.yaml
+++ b/src/coordinator/docs/openapi.yaml
@@ -1910,6 +1910,11 @@ paths:
     post:
       tags: [Statistics]
       summary: Statistics query
+      description: |
+        Executes a read-only SQL query for Grafana-style statistics panels.
+        Each `rawquery` in the request body is validated before execution (same
+        rules as `POST /api/v4/query`): allowed statement types include SELECT,
+        WITH, SHOW, DESCRIBE, EXPLAIN, PRAGMA; semicolons and DML/DDL are rejected.
       operationId: statisticsQuery
       requestBody:
         required: true
@@ -2539,7 +2544,8 @@ components:
           example: admin
         password:
           type: string
-          example: sipcapture
+          description: User password (not the default bootstrap password unless configured explicitly)
+          example: your-password
         type:
           type: string
           description: Password backend — internal (DuckDB users / admin hash) or ldap when LDAP is enabled.

--- a/src/coordinator/handlers/statistics_v4.go
+++ b/src/coordinator/handlers/statistics_v4.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/sipcapture/homer-core/src/coordinator/services"
+	"github.com/sipcapture/homer-core/src/coordinator/sqlvalidator"
 )
 
 type StatisticsHandler struct {
@@ -84,15 +85,19 @@ func (h *StatisticsHandler) V4StatisticsQuery(c echo.Context) error {
 	results := make([]StatisticQueryResultV4, 0, len(req.Param.Query))
 	total := 0
 	for _, query := range req.Param.Query {
-		if strings.TrimSpace(query.RawQuery) == "" {
+		raw := strings.TrimSpace(query.RawQuery)
+		if raw == "" {
 			return writeError(c, http.StatusBadRequest, "Bad Request", "rawquery is required")
 		}
-		items, err := h.flightService.Query(c.Request().Context(), query.RawQuery)
+		if err := sqlvalidator.ValidateRawSQL(raw); err != nil {
+			return writeError(c, http.StatusBadRequest, "Bad Request", fmt.Sprintf("SQL validation failed: %v", err))
+		}
+		items, err := h.flightService.Query(c.Request().Context(), raw)
 		if err != nil {
 			return writeError(c, http.StatusInternalServerError, "Server Error", "Failed to execute query")
 		}
 		results = append(results, StatisticQueryResultV4{
-			Query: query.RawQuery,
+			Query: raw,
 			Items: items,
 		})
 		total += len(items)

--- a/src/coordinator/handlers/statistics_v4_test.go
+++ b/src/coordinator/handlers/statistics_v4_test.go
@@ -1,0 +1,78 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/sipcapture/homer-core/src/coordinator/services"
+)
+
+func TestV4StatisticsQuery_RejectsUnsafeSQL(t *testing.T) {
+	e := echo.New()
+	h := NewStatisticsHandler(services.NewFlightService(nil, 0))
+
+	body, err := json.Marshal(map[string]interface{}{
+		"param": map[string]interface{}{
+			"query": []map[string]string{
+				{"rawquery": "DELETE FROM hep_proto_1_call"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v4/statistics/query", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.V4StatisticsQuery(c); err != nil {
+		t.Fatalf("V4StatisticsQuery: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("SQL validation failed")) {
+		t.Fatalf("expected validation error message, got %s", rec.Body.String())
+	}
+}
+
+func TestV4StatisticsQuery_RejectsMultiStatement(t *testing.T) {
+	e := echo.New()
+	h := NewStatisticsHandler(services.NewFlightService(nil, 0))
+
+	body, err := json.Marshal(map[string]interface{}{
+		"param": map[string]interface{}{
+			"query": []map[string]string{
+				{"rawquery": "SELECT 1; DELETE FROM hep"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v4/statistics/query", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.V4StatisticsQuery(c); err != nil {
+		t.Fatalf("V4StatisticsQuery: %v", err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.281"
+	VERSION_APPLICATION = "11.0.282"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Validate `rawquery` with `sqlvalidator.ValidateRawSQL` in `V4StatisticsQuery` before calling FlightSQL (same pattern as `/api/v4/query` and search handlers)
- Rejects DML, multi-statement, and dangerous DuckDB primitives at the API layer

Addresses [GHSA-f46q-3v67-fmm4](https://github.com/sipcapture/homer/security/advisories/GHSA-f46q-3v67-fmm4)

## Test plan
- [x] `go test ./coordinator/handlers/ -run TestV4StatisticsQuery`
- [ ] `DELETE FROM ...` via statistics/query returns 400
- [ ] Valid `SELECT` still works for authenticated users