### PR TITLE
fix(search): hyphenated custom header virtual fields (#844)

### DIFF
--- a/docs/SEARCH_MAPPINGS_AND_FIELDS.md
+++ b/docs/SEARCH_MAPPINGS_AND_FIELDS.md
@@ -204,7 +204,7 @@ Virtual fields search inside the DuckLake **`data_extra`** JSON column instead o
 | Property | Values | Meaning |
 |----------|--------|---------|
 | `kind` | `data_extra_json` | Only supported kind today ([`fields_virtual.go`](../src/coordinator/services/fields_virtual.go)). |
-| `path` | dotted path, e.g. `to_tag`, `foo.bar` | JSON path under `data_extra` (segments: `[a-zA-Z_][a-zA-Z0-9_]*`). |
+| `path` | dotted path, e.g. `to_tag`, `custom_headers.X-icc_uuid` | JSON path under `data_extra`. Segments: letters, digits, `_`, `-` (hyphenated SIP header keys are quoted in DuckDB JSONPath). |
 | `match` | `like` (default), `equals`, `absent`, `present` | How the value is applied in SQL. |
 
 ### `match` modes
@@ -232,6 +232,26 @@ Example absent/present pair (SIP seed):
   "virtual": { "kind": "data_extra_json", "path": "to_tag", "match": "present" }
 }
 ```
+
+### Custom SIP headers (`ingest.sip.custom_headers`)
+
+When `ingest.sip.custom_headers` lists a header (e.g. `X-icc_uuid`), values land in `data_extra.custom_headers` with the **exact header name** as the JSON key. Use a virtual field with a dotted path; hyphens in the key are supported (Homer 11.0.284+):
+
+```json
+{
+  "id": "x_icc_uuid",
+  "name": "X-icc_uuid",
+  "type": "string",
+  "form_type": "input",
+  "virtual": {
+    "kind": "data_extra_json",
+    "path": "custom_headers.X-icc_uuid",
+    "match": "equals"
+  }
+}
+```
+
+`path` must match the stored key (`X-icc_uuid`, not `x_icc_uuid`). Requires `ingest.sip.custom_headers` in `homer.json` and a coordinator restart after mapping changes.
 
 Virtual rules are loaded for the active `hepid` + `profile` on each search. OTLP (`200`–`202`) and Line Protocol (`300`) skip virtual handling.
 

--- a/src/coordinator/handlers/transactions_sql_test.go
+++ b/src/coordinator/handlers/transactions_sql_test.go
@@ -414,6 +414,33 @@ func TestBuildSearchSQLV4_VirtualDataExtraEquals(t *testing.T) {
 	}
 }
 
+func TestBuildSearchSQLV4_VirtualDataExtraCustomHeader(t *testing.T) {
+	req := SearchObjectV4{}
+	req.Filter.ProtoType = 1
+	req.Filter.EventType = "call"
+	req.Filter.Virtual = map[string]string{"x_icc_uuid": "uuid-123"}
+
+	rules := map[string]services.VirtualFieldRule{
+		"x_icc_uuid": {
+			Kind:  services.VirtualKindDataExtraJSON,
+			Path:  "custom_headers.X-icc_uuid",
+			Match: services.VirtualMatchEquals,
+		},
+	}
+
+	sql, err := buildSearchSQLV4("homer_lake", &req, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `json_extract(data_extra, '$.custom_headers."X-icc_uuid"')`
+	if !strings.Contains(sql, want) {
+		t.Fatalf("expected %q in SQL, got:\n%s", want, sql)
+	}
+	if !strings.Contains(sql, "= 'uuid-123'") {
+		t.Fatalf("expected filter value in SQL, got:\n%s", sql)
+	}
+}
+
 func TestBuildSearchSQLV4_VirtualAbsentToTag(t *testing.T) {
 	req := SearchObjectV4{}
 	req.Filter.ProtoType = 1

--- a/src/coordinator/services/fields_virtual.go
+++ b/src/coordinator/services/fields_virtual.go
@@ -26,7 +26,10 @@ const (
 	VirtualMatchPresent = "present"
 )
 
-var virtualPathSegmentRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+var virtualPathSegmentRe = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_-]*$`)
+
+// simpleJSONPathSegmentRe matches keys that DuckDB accepts without quoting.
+var simpleJSONPathSegmentRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
 // VirtualFieldRule is a validated rule derived from fields_mapping[].virtual.
 type VirtualFieldRule struct {
@@ -115,7 +118,9 @@ func validateVirtualJSONPath(path string) error {
 	return nil
 }
 
-// DuckJSONPath returns a DuckDB JSON path literal like '$.to_tag' or '$.a.b'.
+// DuckJSONPath returns a DuckDB JSON path literal like '$.to_tag' or
+// '$.custom_headers."X-icc_uuid"' when a segment contains hyphens or other
+// characters that require JSONPath quoting.
 func DuckJSONPath(logicalPath string) string {
 	parts := strings.Split(logicalPath, ".")
 	escaped := make([]string, 0, len(parts))
@@ -124,7 +129,26 @@ func DuckJSONPath(logicalPath string) string {
 		if p == "" {
 			continue
 		}
-		escaped = append(escaped, p)
+		escaped = append(escaped, duckJSONPathSegment(p))
 	}
 	return "$." + strings.Join(escaped, ".")
+}
+
+func duckJSONPathSegment(segment string) string {
+	if simpleJSONPathSegmentRe.MatchString(segment) {
+		return segment
+	}
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range segment {
+		switch r {
+		case '\\', '"':
+			b.WriteByte('\\')
+			b.WriteRune(r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
 }

--- a/src/coordinator/services/fields_virtual_path_test.go
+++ b/src/coordinator/services/fields_virtual_path_test.go
@@ -1,0 +1,57 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package services
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestVirtualRulesFromFieldsMapping_HyphenatedPath(t *testing.T) {
+	raw := json.RawMessage(`[
+		{"id": "x_icc_uuid", "virtual": {"kind": "data_extra_json", "path": "custom_headers.X-icc_uuid", "match": "equals"}}
+	]`)
+	rules, err := VirtualRulesFromFieldsMapping(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, ok := rules["x_icc_uuid"]
+	if !ok {
+		t.Fatal("missing x_icc_uuid rule")
+	}
+	if r.Path != "custom_headers.X-icc_uuid" {
+		t.Fatalf("path: got %q", r.Path)
+	}
+}
+
+func TestDuckJSONPath_HyphenatedSegment(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"to_tag", "$.to_tag"},
+		{"custom_headers.X-icc_uuid", `$.custom_headers."X-icc_uuid"`},
+		{"custom_headers.P-Charging-Vector", `$.custom_headers."P-Charging-Vector"`},
+		{"foo.bar", "$.foo.bar"},
+	}
+	for _, tt := range tests {
+		if got := DuckJSONPath(tt.path); got != tt.want {
+			t.Errorf("DuckJSONPath(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestValidateVirtualJSONPath_RejectsUnsafeSegments(t *testing.T) {
+	for _, path := range []string{
+		`custom_headers.foo"bar`,
+		`custom_headers.foo'bar`,
+		`custom_headers..x`,
+		`.leading`,
+	} {
+		if err := validateVirtualJSONPath(path); err == nil {
+			t.Errorf("expected error for path %q", path)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Allow `-` in `virtual.path` segments for `data_extra_json` fields (SIP custom headers like `X-icc_uuid`, `P-Charging-Vector`).
- `DuckJSONPath` emits DuckDB-quoted JSONPath for non-simple segments (e.g. `$.custom_headers."X-icc_uuid"`).
- Document custom header virtual field setup in SEARCH_MAPPINGS.

Fixes #844.

## Root cause
`virtualPathSegmentRe` only allowed `[a-zA-Z_][a-zA-Z0-9_]*`, so paths like `custom_headers.X-icc_uuid` failed validation. Search then ran with **no WHERE filter** (warn log only).

## Correct mapping (reporter)
```json
"path": "custom_headers.X-icc_uuid"
```
Key must match the stored JSON key (case-sensitive), not `x_icc_uuid`.

## Test plan
- [x] `go test -race ./coordinator/services/ -run 'Virtual|DuckJSON'`
- [x] `go test -race ./coordinator/handlers/ -run TestBuildSearchSQLV4_Virtual`