### PR TITLE
fix(sip): From display-name with angle brackets (#846)

### DIFF
--- a/src/sipparser/utils.go
+++ b/src/sipparser/utils.go
@@ -92,18 +92,67 @@ func getQuoteChars(s string) (one int, two int, chk bool) {
 }
 
 func getBracks(s string) (one int, two int, chk bool) {
-	one = strings.IndexRune(s, '<')
-	if one == -1 {
-		return 0, 0, false
-	}
-	two = strings.IndexRune(s, '>')
-	if two == -1 {
-		return 0, 0, false
-	}
-	if two < one {
+	one, two, ok := findURIBrackets([]byte(s))
+	if !ok {
 		return 0, 0, false
 	}
 	return one, two, true
+}
+
+// findURIBrackets locates the SIP URI angle brackets in a From/To/Contact-style
+// header value. Angle brackets inside a leading quoted display-name are ignored;
+// otherwise the last '<...>' pair is used (display-names may contain '<' unquoted).
+func findURIBrackets(val []byte) (one int, two int, ok bool) {
+	searchFrom := 0
+	if _, q2, found := quoteSpan(val); found {
+		searchFrom = q2 + 1
+	}
+	sub := val[searchFrom:]
+	lrel := -1
+	for i := len(sub) - 1; i >= 0; i-- {
+		if sub[i] == '<' {
+			lrel = i
+			break
+		}
+	}
+	if lrel == -1 {
+		return 0, 0, false
+	}
+	one = searchFrom + lrel
+	rrel := indexByte(val[one+1:], '>')
+	if rrel == -1 {
+		return 0, 0, false
+	}
+	two = one + 1 + rrel
+	return one, two, true
+}
+
+func quoteSpan(val []byte) (one int, two int, ok bool) {
+	ct := 0
+	for i := range val {
+		if val[i] == '"' {
+			switch ct {
+			case 0:
+				one = i
+				ct = 1
+			case 1:
+				two = i
+				return one, two, true
+			default:
+				return 0, 0, false
+			}
+		}
+	}
+	return 0, 0, false
+}
+
+func indexByte(data []byte, b byte) int {
+	for i := range data {
+		if data[i] == b {
+			return i
+		}
+	}
+	return -1
 }
 
 func getName(s string) (name string, end int) {

--- a/src/sipparser/zerocopy.go
+++ b/src/sipparser/zerocopy.go
@@ -350,19 +350,24 @@ func zcParseHeaderLine(line []byte, s *SipMsg) {
 	zcApplyAlegCustomHeaders(name, val, s)
 }
 
+func zcFindURIBrackets(val []byte) (lbrack, rbrack int) {
+	one, two, ok := findURIBrackets(val)
+	if !ok {
+		return -1, -1
+	}
+	return one, two
+}
+
 // zcParseFromTo extracts user, host, tag from From/To header value.
 func zcParseFromTo(val []byte, s *SipMsg, target byte) {
 	val = zcTrimWS(val)
 
 	tag := zcExtractParam(val, []byte("tag="))
 
-	lbrack := findByte(val, '<')
+	lbrack, rbrack := zcFindURIBrackets(val)
 	var uriBytes []byte
-	if lbrack != -1 {
-		rbrack := findByte(val[lbrack:], '>')
-		if rbrack != -1 {
-			uriBytes = val[lbrack+1 : lbrack+rbrack]
-		}
+	if lbrack != -1 && rbrack != -1 {
+		uriBytes = val[lbrack+1 : rbrack]
 	}
 	if uriBytes == nil {
 		semi := findByte(val, ';')
@@ -390,13 +395,10 @@ func zcParseFromTo(val []byte, s *SipMsg, target byte) {
 // zcParseContact extracts user, host from Contact header.
 func zcParseContact(val []byte, s *SipMsg) {
 	val = zcTrimWS(val)
-	lbrack := findByte(val, '<')
+	lbrack, rbrack := zcFindURIBrackets(val)
 	var uriBytes []byte
-	if lbrack != -1 {
-		rbrack := findByte(val[lbrack:], '>')
-		if rbrack != -1 {
-			uriBytes = val[lbrack+1 : lbrack+rbrack]
-		}
+	if lbrack != -1 && rbrack != -1 {
+		uriBytes = val[lbrack+1 : rbrack]
 	}
 	if uriBytes == nil {
 		semi := findByte(val, ';')
@@ -456,13 +458,10 @@ func zcParseAuthUser(val []byte, s *SipMsg) {
 // zcParsePAIUser extracts user from P-Asserted-Identity.
 func zcParsePAIUser(val []byte, s *SipMsg) {
 	val = zcTrimWS(val)
-	lbrack := findByte(val, '<')
+	lbrack, rbrack := zcFindURIBrackets(val)
 	var uriBytes []byte
-	if lbrack != -1 {
-		rbrack := findByte(val[lbrack:], '>')
-		if rbrack != -1 {
-			uriBytes = val[lbrack+1 : lbrack+rbrack]
-		}
+	if lbrack != -1 && rbrack != -1 {
+		uriBytes = val[lbrack+1 : rbrack]
 	}
 	if uriBytes == nil {
 		uriBytes = val

--- a/src/sipparser/zerocopy_opts_test.go
+++ b/src/sipparser/zerocopy_opts_test.go
@@ -164,3 +164,23 @@ func TestParseMsgZeroCopy_XRTPStatPlusCustom(t *testing.T) {
 		t.Fatalf("CustomHeader: %#v", s.CustomHeader)
 	}
 }
+
+func TestParseMsgZeroCopy_FromDisplayNameWithBrackets(t *testing.T) {
+	raw := []byte("INVITE sip:a@b SIP/2.0\r\n" +
+		"Via: SIP/2.0/UDP 10.0.0.1;branch=z9hG4bK1\r\n" +
+		`From: "a <b@c>" <sip:foo@bar>;tag=ft` + "\r\n" +
+		"To: <sip:c@d>\r\n" +
+		"Call-ID: cid-one@host\r\n" +
+		"CSeq: 1 INVITE\r\n" +
+		"\r\n")
+	s := ParseMsgZeroCopy(raw, nil)
+	if s.Error != nil {
+		t.Fatalf("parse: %v", s.Error)
+	}
+	if s.FromUser != "foo" {
+		t.Fatalf("FromUser: want foo, got %q", s.FromUser)
+	}
+	if s.FromHost != "bar" {
+		t.Fatalf("FromHost: want bar, got %q", s.FromHost)
+	}
+}


### PR DESCRIPTION
## Summary
- Fix `getBracks` / `findURIBrackets` to ignore `<...>` inside a leading quoted display-name and to use the last URI `<...>` pair when unquoted.
- Apply the same logic in zero-copy `zcParseFromTo`, `zcParseContact`, and `zcParsePAIUser`.
- Add zero-copy regression test for `"a <b@c>" <sip:foo@bar>`.

Fixes #846. Completes the failing tests added in #845.

## Test plan
- [x] `go test -race ./sipparser/...`