### PR TITLE
fix(ingest): route REFER to hep_proto_1_call (#850)

### DIFF
--- a/docs/STORAGE_LAYOUT.md
+++ b/docs/STORAGE_LAYOUT.md
@@ -77,9 +77,9 @@ SIP messages are split into three tables by transaction type:
 
 | Table | Methods | Description |
 |-------|---------|-------------|
-| `hep_proto_1_call` | INVITE, ACK, PRACK, UPDATE, BYE, CANCEL, INFO | Call messages |
+| `hep_proto_1_call` | INVITE, ACK, PRACK, UPDATE, BYE, CANCEL, INFO, REFER | Call messages |
 | `hep_proto_1_registration` | REGISTER | Registrations |
-| `hep_proto_1_default` | OPTIONS, NOTIFY, SUBSCRIBE, PUBLISH, MESSAGE, REFER | Other |
+| `hep_proto_1_default` | OPTIONS, NOTIFY, SUBSCRIBE, PUBLISH, MESSAGE | Other |
 | `hep_proto_1_siprec` | SIPREC SRS signaling (in-process receiver) | Recording metadata + SIP |
 
 **Important**: SIP responses (200 OK, 180 Ringing) are routed by the method from `CSeq` header.

--- a/src/storage/ducklake/README.md
+++ b/src/storage/ducklake/README.md
@@ -33,9 +33,9 @@ SIP messages are further split by method type:
 
 | Table Name | Methods | Description |
 |------------|---------|-------------|
-| `hep_proto_1_call` | INVITE, ACK, PRACK, UPDATE, BYE, CANCEL, INFO | Call-related messages |
+| `hep_proto_1_call` | INVITE, ACK, PRACK, UPDATE, BYE, CANCEL, INFO, REFER | Call-related messages |
 | `hep_proto_1_registration` | REGISTER | Registration messages |
-| `hep_proto_1_default` | OPTIONS, NOTIFY, SUBSCRIBE, PUBLISH, MESSAGE, REFER | Other SIP messages |
+| `hep_proto_1_default` | OPTIONS, NOTIFY, SUBSCRIBE, PUBLISH, MESSAGE | Other SIP messages |
 
 **Important**: For SIP responses (e.g., "200 OK"), routing is based on `CSeq` method, not the response line.
 

--- a/src/storage/ducklake/tables.go
+++ b/src/storage/ducklake/tables.go
@@ -39,9 +39,9 @@ const (
 
 // SIPType constants for SIP message categories
 const (
-	SIPTypeCall         = "call"         // INVITE, ACK, PRACK, UPDATE, BYE, CANCEL, INFO
+	SIPTypeCall         = "call"         // INVITE, ACK, PRACK, UPDATE, BYE, CANCEL, INFO, REFER
 	SIPTypeRegistration = "registration" // REGISTER
-	SIPTypeDefault      = "default"      // OPTIONS, NOTIFY, SUBSCRIBE, PUBLISH, MESSAGE, REFER
+	SIPTypeDefault      = "default"      // OPTIONS, NOTIFY, SUBSCRIBE, PUBLISH, MESSAGE
 	SIPTypeSiprec       = "siprec"       // SIPREC SRS signaling captured in Homer
 )
 
@@ -84,12 +84,12 @@ func GetSIPMethod(firstMethod, cseqMethod, firstResp string) string {
 // GetSIPType returns the SIP sub-type based on method
 func GetSIPType(method string) string {
 	switch method {
-	case "INVITE", "ACK", "PRACK", "UPDATE", "BYE", "CANCEL", "INFO":
+	case "INVITE", "ACK", "PRACK", "UPDATE", "BYE", "CANCEL", "INFO", "REFER":
 		return SIPTypeCall
 	case "REGISTER":
 		return SIPTypeRegistration
 	default:
-		// OPTIONS, NOTIFY, SUBSCRIBE, PUBLISH, MESSAGE, REFER, etc.
+		// OPTIONS, NOTIFY, SUBSCRIBE, PUBLISH, MESSAGE, etc.
 		return SIPTypeDefault
 	}
 }
@@ -97,7 +97,7 @@ func GetSIPType(method string) string {
 // GetTableSchemas returns schemas for all supported table types
 func GetTableSchemas() map[TableKey]*TableSchema {
 	return map[TableKey]*TableSchema{
-		// SIP Call - INVITE, ACK, PRACK, UPDATE, BYE, CANCEL, INFO
+		// SIP Call - INVITE, ACK, PRACK, UPDATE, BYE, CANCEL, INFO, REFER
 		{ProtoType: ProtoTypeSIP, SubType: SIPTypeCall}: {
 			ProtoType:   ProtoTypeSIP,
 			SubType:     SIPTypeCall,
@@ -209,7 +209,7 @@ func GetTableSchemas() map[TableKey]*TableSchema {
 				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::JSON)`,
 		},
 
-		// SIP Default - OPTIONS, NOTIFY, SUBSCRIBE, PUBLISH, MESSAGE, REFER
+		// SIP Default - OPTIONS, NOTIFY, SUBSCRIBE, PUBLISH, MESSAGE
 		{ProtoType: ProtoTypeSIP, SubType: SIPTypeDefault}: {
 			ProtoType:   ProtoTypeSIP,
 			SubType:     SIPTypeDefault,

--- a/src/storage/ducklake/tables_sip_test.go
+++ b/src/storage/ducklake/tables_sip_test.go
@@ -1,0 +1,25 @@
+package ducklake
+
+import "testing"
+
+func TestGetSIPType_REFERGoesToCall(t *testing.T) {
+	if got := GetSIPType("REFER"); got != SIPTypeCall {
+		t.Fatalf("GetSIPType(REFER) = %q, want %q", got, SIPTypeCall)
+	}
+}
+
+func TestGetSIPType_CallMethods(t *testing.T) {
+	for _, m := range []string{"INVITE", "ACK", "BYE", "CANCEL", "UPDATE", "PRACK", "INFO", "REFER"} {
+		if got := GetSIPType(m); got != SIPTypeCall {
+			t.Errorf("GetSIPType(%q) = %q, want call", m, got)
+		}
+	}
+}
+
+func TestGetSIPType_DefaultMethods(t *testing.T) {
+	for _, m := range []string{"OPTIONS", "NOTIFY", "SUBSCRIBE", "PUBLISH", "MESSAGE"} {
+		if got := GetSIPType(m); got != SIPTypeDefault {
+			t.Errorf("GetSIPType(%q) = %q, want default", m, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Route `REFER` (requests and CSeq-matched responses) to `hep_proto_1_call`, matching Homer 7 / hepic-server and the existing `decoder/sip.go` call profile.
- Update storage docs and add `GetSIPType` tests.

Closes #850.

## Background
In Homer 11, `GetSIPType()` sent `REFER` to `hep_proto_1_default` while Homer 7 stored it in the call messages table. The dashboard default search uses profile `call`, so REFER was invisible in the calls table and call-flow transaction view even when captured correctly.

**Note:** Already-ingested REFER rows remain in `hep_proto_1_default` until re-ingested or migrated. New traffic after this fix lands in `hep_proto_1_call`.

**Workaround before upgrade:** search profile `default` with method `REFER`, or SQL against `hep_proto_1_default`.

## Test plan
- [x] `go test ./storage/ducklake/... -run TestGetSIPType`
- [x] Capture or replay a REFER on a live call-id; confirm row in `hep_proto_1_call`
- [x] Open transaction / call flow for that Call-ID; REFER appears alongside INVITE/BYE