### PR TITLE
feat: support configurable S3 URL style for DuckLake

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -19,6 +19,9 @@ Field names follow the `mapstructure` tags on [`Config` in `src/config/config.go
 
 - `storage.ducklake.storage_policy.volumes[1].s3_endpoint`  
   → `HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_1_S3_ENDPOINT`
+- `storage.ducklake.s3.url_style` → `HOMER_STORAGE_DUCKLAKE_S3_URL_STYLE` (`path` by default; set `vhost` for S3 virtual-hosted-style endpoints)
+- `node.ducklake.volumes[0].s3_url_style` → `HOMER_NODE_DUCKLAKE_VOLUMES_0_S3_URL_STYLE`
+- `storage.ducklake.storage_policy.volumes[1].s3_url_style` → `HOMER_STORAGE_DUCKLAKE_STORAGE_POLICY_VOLUMES_1_S3_URL_STYLE`
 
 ## References
 

--- a/docs/NODE.md
+++ b/docs/NODE.md
@@ -148,6 +148,7 @@ See [FLIGHTSQL.md](FLIGHTSQL.md) for Grafana setup and coordinator proxy (`coord
 | `s3_secret_access_key` | string | - | AWS Secret Access Key |
 | `s3_endpoint` | string | - | Custom S3 endpoint (MinIO, R2) |
 | `s3_use_ssl` | bool | true | Use SSL for S3 connections |
+| `s3_url_style` | string | path | DuckDB S3 URL style for custom endpoints (`path` or `vhost`) |
 | `override_data_path` | bool | false | If true, DuckLake `ATTACH` uses `OVERRIDE_DATA_PATH TRUE` so `path` may differ from the `DATA_PATH` already stored in the catalog (e.g. bucket rename). Prefer keeping `path` identical to the writer volume that created the catalog. |
 
 ### Volume `name` and the DuckDB catalog

--- a/docs/STORAGE_POLICIES.md
+++ b/docs/STORAGE_POLICIES.md
@@ -122,6 +122,7 @@ The `move_factor` parameter works similar to ClickHouse storage policies. It con
 | `s3_secret_access_key` | string | "" | Secret key |
 | `s3_endpoint` | string | "" | Custom endpoint for S3-compatible services (R2, MinIO, RustFS) |
 | `s3_use_ssl` | bool | true | Use HTTPS for S3 connections |
+| `s3_url_style` | string | "path" | DuckDB S3 URL style for custom endpoints (`path` or `vhost`) |
 
 ## Examples
 

--- a/src/cli/cli_cmd.go
+++ b/src/cli/cli_cmd.go
@@ -110,6 +110,7 @@ func duckLakeConfigFromModular(cfg *config.Config) ducklake.Config {
 		base.S3SecretAccessKey = source.S3.SecretAccessKey
 		base.S3Endpoint = source.S3.Endpoint
 		base.S3UseSSL = source.S3.UseSSL
+		base.S3URLStyle = source.S3.URLStyle
 	}
 
 	return base
@@ -124,14 +125,14 @@ func openDuckLakeReadOnly(cfg ducklake.Config) (*sql.DB, error) {
 	}
 
 	if err := ducklake.ApplyDuckDBS3ClientSettings(db,
-		cfg.S3Region, cfg.S3AccessKeyID, cfg.S3SecretAccessKey, cfg.S3Endpoint, cfg.S3UseSSL,
+		cfg.S3Region, cfg.S3AccessKeyID, cfg.S3SecretAccessKey, cfg.S3Endpoint, cfg.S3UseSSL, cfg.S3URLStyle,
 	); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("failed to configure S3: %w", err)
 	}
 	if ducklake.IsRemoteLakeDataPath(cfg.DataPath) {
 		if err := ducklake.EnsureWriterS3Secret(db,
-			cfg.S3Region, cfg.S3AccessKeyID, cfg.S3SecretAccessKey, cfg.S3Endpoint, cfg.S3UseSSL,
+			cfg.S3Region, cfg.S3AccessKeyID, cfg.S3SecretAccessKey, cfg.S3Endpoint, cfg.S3UseSSL, cfg.S3URLStyle,
 		); err != nil {
 			db.Close()
 			return nil, fmt.Errorf("failed to configure S3 secret: %w", err)

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -737,6 +737,7 @@ type VolumeConfig struct {
 	S3SecretKey    string `json:"s3_secret_access_key" mapstructure:"s3_secret_access_key" default:""`
 	S3Endpoint     string `json:"s3_endpoint" mapstructure:"s3_endpoint" default:""` // For S3-compatible (R2, MinIO)
 	S3UseSSL       bool   `json:"s3_use_ssl" mapstructure:"s3_use_ssl" default:"true"`
+	S3URLStyle     string `json:"s3_url_style" mapstructure:"s3_url_style" default:""` // Empty = path, set "vhost" for virtual-hosted-style
 	// OverrideDataPath passes OVERRIDE_DATA_PATH TRUE to DuckLake ATTACH when the path
 	// in config intentionally differs from DATA_PATH stored in an existing catalog
 	// (e.g. bucket rename, or node path typo vs writer). Prefer matching paths first.
@@ -792,6 +793,7 @@ type S3Config struct {
 	SecretAccessKey string `json:"secret_access_key" mapstructure:"secret_access_key" default:""`
 	Endpoint        string `json:"endpoint" mapstructure:"endpoint" default:""`
 	UseSSL          bool   `json:"use_ssl" mapstructure:"use_ssl" default:"true"`
+	URLStyle        string `json:"url_style" mapstructure:"url_style" default:""` // Empty = path, set "vhost" for virtual-hosted-style
 }
 
 // HEPConfig configures HEP protocol processing

--- a/src/homerconfig/dataconfig.go
+++ b/src/homerconfig/dataconfig.go
@@ -275,6 +275,7 @@ type HomerServerSettings struct {
 			SecretAccessKey string `json:"secret_access_key" mapstructure:"secret_access_key" default:""`
 			Endpoint        string `json:"endpoint" mapstructure:"endpoint" default:""`
 			UseSSL          bool   `json:"use_ssl" mapstructure:"use_ssl" default:"true"`
+			URLStyle        string `json:"url_style" mapstructure:"url_style" default:""`
 		} `json:"s3" mapstructure:"s3"`
 	} `json:"ducklake_settings" mapstructure:"ducklake_settings"`
 }

--- a/src/main.go
+++ b/src/main.go
@@ -353,6 +353,7 @@ func ducklakeConfigFromModular(cfg *config.Config) ducklake.Config {
 		base.S3SecretAccessKey = source.S3.SecretAccessKey
 		base.S3Endpoint = source.S3.Endpoint
 		base.S3UseSSL = source.S3.UseSSL
+		base.S3URLStyle = source.S3.URLStyle
 	}
 
 	return base

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -1507,6 +1507,7 @@ func configureDuckLake(db *sql.DB, cfg *config.NodeConfig) ([]VolumeInfo, error)
 		cfg.DuckLake.S3.SecretAccessKey,
 		cfg.DuckLake.S3.Endpoint,
 		cfg.DuckLake.S3.UseSSL,
+		cfg.DuckLake.S3.URLStyle,
 	); err != nil {
 		return nil, fmt.Errorf("failed to configure S3: %w", err)
 	}
@@ -1576,6 +1577,7 @@ func attachVolume(db *sql.DB, baseLakeName string, vol config.VolumeConfig) (Vol
 		if region == "" && endpoint != "" {
 			region = "us-east-1"
 		}
+		urlStyle := strings.ReplaceAll(ducklake.NormalizeS3URLStyle(vol.S3URLStyle), "'", "''")
 
 		// Create secret
 		var createSecret string
@@ -1587,10 +1589,10 @@ func attachVolume(db *sql.DB, baseLakeName string, vol config.VolumeConfig) (Vol
 					SECRET '%s',
 					REGION '%s',
 					ENDPOINT '%s',
-					URL_STYLE 'path',
+					URL_STYLE '%s',
 					USE_SSL %t
 				);
-			`, secretName, vol.S3AccessKeyID, vol.S3SecretKey, region, endpoint, vol.S3UseSSL)
+			`, secretName, vol.S3AccessKeyID, vol.S3SecretKey, region, endpoint, urlStyle, vol.S3UseSSL)
 		} else {
 			createSecret = fmt.Sprintf(`
 				CREATE SECRET %s (

--- a/src/storage/ducklake/ducklake.go
+++ b/src/storage/ducklake/ducklake.go
@@ -86,6 +86,7 @@ type Config struct {
 	S3SecretAccessKey string
 	S3Endpoint        string
 	S3UseSSL          bool
+	S3URLStyle        string
 
 	// DuckDB engine tuning. Empty / zero values mean "leave DuckDB's
 	// own default" — these knobs are opt-in. See ApplyDuckDBTuning
@@ -345,6 +346,7 @@ func (mtw *MultiTableWriter) connect() error {
 		mtw.config.S3SecretAccessKey,
 		mtw.config.S3Endpoint,
 		mtw.config.S3UseSSL,
+		mtw.config.S3URLStyle,
 	)
 	connector, err := duckdb.NewConnector("", func(execer driver.ExecerContext) error {
 		for _, stmt := range s3Stmts {
@@ -482,6 +484,7 @@ func (mtw *MultiTableWriter) connect() error {
 			mtw.config.S3SecretAccessKey,
 			mtw.config.S3Endpoint,
 			mtw.config.S3UseSSL,
+			mtw.config.S3URLStyle,
 		); err != nil {
 			return fmt.Errorf("failed to configure S3 secret for DuckLake: %w", err)
 		}

--- a/src/storage/ducklake/manager.go
+++ b/src/storage/ducklake/manager.go
@@ -72,6 +72,7 @@ func NewManagerFromConfig() (*Manager, error) {
 		config.S3SecretAccessKey = settings.S3.SecretAccessKey
 		config.S3Endpoint = settings.S3.Endpoint
 		config.S3UseSSL = settings.S3.UseSSL
+		config.S3URLStyle = settings.S3.URLStyle
 	}
 
 	// Apply defaults

--- a/src/storage/ducklake/tiered_storage.go
+++ b/src/storage/ducklake/tiered_storage.go
@@ -45,6 +45,7 @@ type Volume struct {
 	S3SecretKey string
 	S3Endpoint  string
 	S3UseSSL    bool
+	S3URLStyle  string
 
 	// OverrideDataPath passes OVERRIDE_DATA_PATH TRUE to DuckLake ATTACH; see config.VolumeConfig.
 	OverrideDataPath bool
@@ -182,7 +183,7 @@ func (tsm *TieredStorageManager) attachVolume(vol *Volume) error {
 			region = "us-east-1"
 		}
 
-		createSecret := buildS3SecretSQL(secretName, vol.S3AccessKey, vol.S3SecretKey, region, endpoint, vol.S3UseSSL)
+		createSecret := buildS3SecretSQL(secretName, vol.S3AccessKey, vol.S3SecretKey, region, endpoint, vol.S3UseSSL, vol.S3URLStyle)
 
 		logger.Info("TieredStorageManager: Creating S3 secret",
 			"volume", vol.Name,
@@ -575,7 +576,7 @@ func sortResultsByTimestamp(results []map[string]interface{}) {
 // uses PROVIDER credential_chain so DuckDB resolves credentials through the
 // AWS SDK default chain (env, container/Pod Identity, instance profile).
 // Static keys and custom endpoints (MinIO / R2) use explicit KEY_ID/SECRET.
-func buildS3SecretSQL(secretName, accessKey, secretKey, region, endpoint string, useSSL bool) string {
+func buildS3SecretSQL(secretName, accessKey, secretKey, region, endpoint string, useSSL bool, urlStyle string) string {
 	switch {
 	case strings.TrimSpace(accessKey) == "" && endpoint == "":
 		// Default region for native AWS S3 so the secret signs correctly even
@@ -599,10 +600,10 @@ func buildS3SecretSQL(secretName, accessKey, secretKey, region, endpoint string,
 				SECRET '%s',
 				REGION '%s',
 				ENDPOINT '%s',
-				URL_STYLE 'path',
+				URL_STYLE '%s',
 				USE_SSL %t
 			);
-		`, secretName, accessKey, secretKey, region, endpoint, useSSL)
+		`, secretName, accessKey, secretKey, region, endpoint, strings.ReplaceAll(NormalizeS3URLStyle(urlStyle), "'", "''"), useSSL)
 	default:
 		return fmt.Sprintf(`
 			CREATE SECRET %s (

--- a/src/storage/ducklake/tiered_storage_test.go
+++ b/src/storage/ducklake/tiered_storage_test.go
@@ -41,7 +41,7 @@ func secretProvider(t *testing.T, accessKey, secretKey, region, endpoint string,
 		}
 	}
 
-	if _, err := db.Exec(buildS3SecretSQL("s3_secret_test", accessKey, secretKey, region, endpoint, useSSL)); err != nil {
+	if _, err := db.Exec(buildS3SecretSQL("s3_secret_test", accessKey, secretKey, region, endpoint, useSSL, "")); err != nil {
 		t.Skipf("CREATE SECRET unavailable (extension/version): %v", err)
 	}
 
@@ -143,7 +143,7 @@ func TestBuildS3SecretSQL_Branches(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			sql := buildS3SecretSQL("test_secret", tc.accessKey, "secret", tc.region, tc.endpoint, true)
+			sql := buildS3SecretSQL("test_secret", tc.accessKey, "secret", tc.region, tc.endpoint, true, "")
 			if !strings.Contains(sql, tc.wantSubstr) {
 				t.Errorf("SQL should contain %q:\n%s", tc.wantSubstr, sql)
 			}
@@ -151,5 +151,12 @@ func TestBuildS3SecretSQL_Branches(t *testing.T) {
 				t.Errorf("SQL should not contain %q:\n%s", tc.denySubstr, sql)
 			}
 		})
+	}
+}
+
+func TestBuildS3SecretSQL_CustomEndpointURLStyle(t *testing.T) {
+	sql := buildS3SecretSQL("test_secret", "AKIA...", "secret", "cn-hangzhou", "oss-cn-hangzhou.aliyuncs.com", true, "vhost")
+	if !strings.Contains(sql, "URL_STYLE 'vhost'") {
+		t.Fatalf("SQL should contain vhost URL_STYLE:\n%s", sql)
 	}
 }

--- a/src/storage/ducklake/tuning.go
+++ b/src/storage/ducklake/tuning.go
@@ -26,11 +26,11 @@ import (
 // If accessKeyID is empty, returns nil (nothing to apply).
 //
 // When endpoint is non-empty, the scheme is stripped (DuckDB expects host:port)
-// and s3_url_style is set to path — required for most S3-compatible stores
+// and s3_url_style defaults to path — required for most S3-compatible stores
 // (MinIO, RustFS) and aligned with per-volume CREATE SECRET in attachVolume.
 // If region is empty but a custom endpoint is set, region defaults to us-east-1
 // (signing requires a non-empty region for many S3-compatible backends).
-func S3ClientSettingsSQL(region, accessKeyID, secretAccessKey, endpoint string, useSSL bool) []string {
+func S3ClientSettingsSQL(region, accessKeyID, secretAccessKey, endpoint string, useSSL bool, urlStyle string) []string {
 	if strings.TrimSpace(accessKeyID) == "" {
 		return nil
 	}
@@ -51,13 +51,23 @@ func S3ClientSettingsSQL(region, accessKeyID, secretAccessKey, endpoint string, 
 		ep := strings.TrimPrefix(strings.TrimPrefix(epRaw, "http://"), "https://")
 		stmts = append(stmts,
 			fmt.Sprintf("SET s3_endpoint = '%s';", quote(ep)),
-			"SET s3_url_style = 'path';",
+			fmt.Sprintf("SET s3_url_style = '%s';", quote(NormalizeS3URLStyle(urlStyle))),
 		)
 	}
 	if !useSSL {
 		stmts = append(stmts, "SET s3_use_ssl = false;")
 	}
 	return stmts
+}
+
+// NormalizeS3URLStyle returns the DuckDB S3 URL style used for custom
+// endpoints. Empty keeps the historical Homer behaviour: path-style URLs.
+func NormalizeS3URLStyle(urlStyle string) string {
+	style := strings.ToLower(strings.TrimSpace(urlStyle))
+	if style == "" {
+		return "path"
+	}
+	return style
 }
 
 // s3SettingName extracts the setting identifier from a "SET name = ..."
@@ -75,11 +85,11 @@ func s3SettingName(stmt string) string {
 // writer MultiTableWriter, node global prefix (configureDuckLake), CLI helpers.
 // Note: SET s3_* is session-scoped — this only reliably covers pools with
 // MaxOpenConns(1); pooled writers replay S3ClientSettingsSQL per connection.
-func ApplyDuckDBS3ClientSettings(db *sql.DB, region, accessKeyID, secretAccessKey, endpoint string, useSSL bool) error {
+func ApplyDuckDBS3ClientSettings(db *sql.DB, region, accessKeyID, secretAccessKey, endpoint string, useSSL bool, urlStyle string) error {
 	if db == nil {
 		return nil
 	}
-	for _, stmt := range S3ClientSettingsSQL(region, accessKeyID, secretAccessKey, endpoint, useSSL) {
+	for _, stmt := range S3ClientSettingsSQL(region, accessKeyID, secretAccessKey, endpoint, useSSL, urlStyle) {
 		if _, err := db.Exec(stmt); err != nil {
 			return fmt.Errorf("duckdb SET %s: %w", s3SettingName(stmt), err)
 		}
@@ -96,7 +106,7 @@ const writerLakeS3Secret = "homer_writer_s3"
 // EnsureWriterS3Secret creates a session-scoped DuckDB TYPE S3 secret so DuckLake
 // internals hit the same endpoint as ApplyDuckDBS3ClientSettings. Call after
 // ApplyDuckDBS3ClientSettings and before ATTACH ducklake. No-op if accessKeyID is empty.
-func EnsureWriterS3Secret(db *sql.DB, region, accessKeyID, secretAccessKey, endpoint string, useSSL bool) error {
+func EnsureWriterS3Secret(db *sql.DB, region, accessKeyID, secretAccessKey, endpoint string, useSSL bool, urlStyle string) error {
 	if db == nil || strings.TrimSpace(accessKeyID) == "" {
 		return nil
 	}
@@ -107,6 +117,7 @@ func EnsureWriterS3Secret(db *sql.DB, region, accessKeyID, secretAccessKey, endp
 	}
 	sqlQuote := func(s string) string { return strings.ReplaceAll(s, "'", "''") }
 	epHost := strings.TrimPrefix(strings.TrimPrefix(epRaw, "http://"), "https://")
+	style := NormalizeS3URLStyle(urlStyle)
 
 	drop := fmt.Sprintf("DROP SECRET IF EXISTS %s;", writerLakeS3Secret)
 	if _, err := db.Exec(drop); err != nil {
@@ -121,9 +132,9 @@ CREATE SECRET %s (
 	SECRET '%s',
 	REGION '%s',
 	ENDPOINT '%s',
-	URL_STYLE 'path',
+	URL_STYLE '%s',
 	USE_SSL %t
-);`, writerLakeS3Secret, sqlQuote(accessKeyID), sqlQuote(secretAccessKey), sqlQuote(reg), sqlQuote(epHost), useSSL)
+);`, writerLakeS3Secret, sqlQuote(accessKeyID), sqlQuote(secretAccessKey), sqlQuote(reg), sqlQuote(epHost), sqlQuote(style), useSSL)
 	} else {
 		create = fmt.Sprintf(`
 CREATE SECRET %s (

--- a/src/storage/ducklake/tuning_test.go
+++ b/src/storage/ducklake/tuning_test.go
@@ -132,7 +132,7 @@ func TestEnsureWriterS3Secret_MinIOStyle(t *testing.T) {
 	}
 	defer db.Close()
 
-	if err := EnsureWriterS3Secret(db, "us-east-1", "k", "s", "http://127.0.0.1:9000", false); err != nil {
+	if err := EnsureWriterS3Secret(db, "us-east-1", "k", "s", "http://127.0.0.1:9000", false, ""); err != nil {
 		t.Fatalf("EnsureWriterS3Secret: %v", err)
 	}
 	if _, err := db.Exec("SELECT 1"); err != nil {
@@ -147,11 +147,19 @@ func TestApplyDuckDBS3ClientSettings_MinIOStyleEndpoint(t *testing.T) {
 	}
 	defer db.Close()
 
-	if err := ApplyDuckDBS3ClientSettings(db, "us-east-1", "testkey", "testsecret", "http://127.0.0.1:9000", false); err != nil {
+	if err := ApplyDuckDBS3ClientSettings(db, "us-east-1", "testkey", "testsecret", "http://127.0.0.1:9000", false, ""); err != nil {
 		t.Fatalf("ApplyDuckDBS3ClientSettings: %v", err)
 	}
 	if got := getSetting(t, db, "s3_url_style"); got != "path" {
 		t.Fatalf("s3_url_style = %q, want path", got)
+	}
+}
+
+func TestS3ClientSettingsSQL_CustomURLStyle(t *testing.T) {
+	stmts := S3ClientSettingsSQL("cn-hangzhou", "testkey", "testsecret", "https://oss-cn-hangzhou.aliyuncs.com", true, "vhost")
+	joined := strings.Join(stmts, "\n")
+	if !strings.Contains(joined, "SET s3_url_style = 'vhost';") {
+		t.Fatalf("S3ClientSettingsSQL should set vhost URL style:\n%s", joined)
 	}
 }
 

--- a/src/writer/compaction.go
+++ b/src/writer/compaction.go
@@ -157,6 +157,7 @@ type CatalogRefresher interface {
 type CompactionS3Client struct {
 	Region, AccessKeyID, SecretAccessKey, Endpoint string
 	UseSSL                                           bool
+	URLStyle                                         string
 }
 
 // CompactionService handles periodic compaction and retention
@@ -207,7 +208,7 @@ func (c *CompactionService) ensureS3ClientSettings() {
 		return
 	}
 	s := c.s3Client
-	if err := ducklake.ApplyDuckDBS3ClientSettings(c.db, s.Region, s.AccessKeyID, s.SecretAccessKey, s.Endpoint, s.UseSSL); err != nil {
+	if err := ducklake.ApplyDuckDBS3ClientSettings(c.db, s.Region, s.AccessKeyID, s.SecretAccessKey, s.Endpoint, s.UseSSL, s.URLStyle); err != nil {
 		logger.Warn("CompactionService: ApplyDuckDBS3ClientSettings failed", "error", err)
 	}
 }

--- a/src/writer/writer.go
+++ b/src/writer/writer.go
@@ -274,6 +274,7 @@ func New(ingestCfg *config.IngestConfig, storageCfg *config.StorageConfig, promC
 		duckCfg.S3SecretAccessKey = storageCfg.DuckLake.S3.SecretAccessKey
 		duckCfg.S3Endpoint = storageCfg.DuckLake.S3.Endpoint
 		duckCfg.S3UseSSL = storageCfg.DuckLake.S3.UseSSL
+		duckCfg.S3URLStyle = storageCfg.DuckLake.S3.URLStyle
 	}
 
 	duckMgr, err := ducklake.NewManager(duckCfg)
@@ -368,6 +369,7 @@ func (w *Writer) Start() error {
 					SecretAccessKey: s.SecretAccessKey,
 					Endpoint:        s.Endpoint,
 					UseSSL:          s.UseSSL,
+					URLStyle:        s.URLStyle,
 				}
 			}
 		}
@@ -937,6 +939,7 @@ func (w *Writer) startTieringService() error {
 			S3SecretKey:      vol.S3SecretKey,
 			S3Endpoint:       vol.S3Endpoint,
 			S3UseSSL:         vol.S3UseSSL,
+			S3URLStyle:       vol.S3URLStyle,
 			OverrideDataPath: vol.OverrideDataPath,
 		}
 	}


### PR DESCRIPTION
## Summary

Add support for configuring DuckDB S3 URL style across DuckLake storage paths. This allows custom S3-compatible endpoints to use either the existing path-style behavior or virtual-hosted-style access when required by providers such as Aliyun OSS.

## Changes

- Added `s3_url_style` / `url_style` configuration fields for DuckLake S3 settings.
- Propagated the S3 URL style through writer, node, CLI, tiered storage, compaction, and DuckLake manager setup.
- Updated DuckDB S3 client settings and DuckLake S3 secret creation to use the configured URL style.
- Preserved the existing default behavior by normalizing empty URL style values to `path`.
- Added test coverage for custom `vhost` URL style handling.
- Updated documentation for environment variables, node volume config, and storage policy volume config.

## Validation

- `go test ./storage/ducklake`