### PR TITLE
fix: use json_extract_string() for data_extra comparisons (follow-up to #859)

### DIFF
--- a/src/coordinator/handlers/transactions_sql_test.go
+++ b/src/coordinator/handlers/transactions_sql_test.go
@@ -20,8 +20,8 @@ func TestBuildSearchSQLV4_CaptureID(t *testing.T) {
 	if !strings.Contains(sql, "node_id") || !strings.Contains(sql, "42") {
 		t.Fatalf("expected node_id and capture value in SQL, got:\n%s", sql)
 	}
-	if !strings.Contains(sql, "data_extra ->> '$.capture_id'") {
-		t.Fatalf("expected data_extra ->> for capture_id, got:\n%s", sql)
+	if !strings.Contains(sql, "json_extract_string(data_extra, '$.capture_id')") {
+		t.Fatalf("expected json_extract_string for capture_id, got:\n%s", sql)
 	}
 }
 
@@ -380,7 +380,7 @@ func TestBuildSearchSQLV4_VirtualDataExtra(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(sql, "data_extra ->> '$.to_tag'") {
+	if !strings.Contains(sql, "json_extract_string(data_extra, '$.to_tag')") {
 		t.Fatalf("expected virtual to_tag extract, got:\n%s", sql)
 	}
 	if !strings.Contains(sql, "= 'abc7'") {
@@ -436,7 +436,7 @@ func TestBuildSearchSQLV4_VirtualDataExtraEquals(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(sql, "data_extra ->> '$.branch'") {
+	if !strings.Contains(sql, "json_extract_string(data_extra, '$.branch')") {
 		t.Fatalf("expected branch extract, got:\n%s", sql)
 	}
 	if !strings.Contains(sql, "= 'z9hG4bK1'") {
@@ -462,12 +462,46 @@ func TestBuildSearchSQLV4_VirtualDataExtraCustomHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := `data_extra ->> '$.custom_headers."X-icc_uuid"'`
+	want := `json_extract_string(data_extra, '$.custom_headers."X-icc_uuid"')`
 	if !strings.Contains(sql, want) {
 		t.Fatalf("expected %q in SQL, got:\n%s", want, sql)
 	}
 	if !strings.Contains(sql, "= 'uuid-123'") {
 		t.Fatalf("expected filter value in SQL, got:\n%s", sql)
+	}
+}
+
+// Regression: data_extra value comparisons must use json_extract_string(), not the
+// `->>` operator. `data_extra ->> '$.path'` combined with a timestamp-range filter
+// (which the search UI always sends) triggers a DuckDB planner error at runtime —
+// "Conversion Error: Failed to cast value to numerical" — and 500s the search
+// endpoint. json_extract_string() returns the same unquoted value without the issue.
+// See PR #859 (which introduced `->>`).
+func TestBuildSearchSQLV4_VirtualEqualsUsesJsonExtractStringNotArrowOp(t *testing.T) {
+	req := SearchObjectV4{}
+	req.Filter.ProtoType = 1
+	req.Filter.EventType = "call"
+	req.Filter.Virtual = map[string]string{"x_grp": "GRP-1"}
+	req.Timestamp.From = 1700000000000
+	req.Timestamp.To = 1700003600000
+
+	rules := map[string]services.VirtualFieldRule{
+		"x_grp": {
+			Kind:  services.VirtualKindDataExtraJSON,
+			Path:  "custom_headers.X-Group-Id",
+			Match: services.VirtualMatchEquals,
+		},
+	}
+
+	sql, err := buildSearchSQLV4("homer_lake", &req, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(sql, `json_extract_string(data_extra, '$.custom_headers."X-Group-Id"')`) {
+		t.Fatalf("virtual equals must use json_extract_string, got:\n%s", sql)
+	}
+	if strings.Contains(sql, "data_extra ->>") {
+		t.Fatalf("virtual field must NOT use the ->> operator (breaks combined with a timestamp filter), got:\n%s", sql)
 	}
 }
 
@@ -493,7 +527,7 @@ func TestBuildSearchSQLV4_VirtualAbsentToTag(t *testing.T) {
 	if !strings.Contains(sql, "method IN ('INVITE')") {
 		t.Fatalf("expected INVITE filter, got:\n%s", sql)
 	}
-	if !strings.Contains(sql, "data_extra ->> '$.to_tag'") {
+	if !strings.Contains(sql, "json_extract_string(data_extra, '$.to_tag')") {
 		t.Fatalf("expected to_tag extract for absent, got:\n%s", sql)
 	}
 	if !strings.Contains(sql, "IS NULL") {

--- a/src/coordinator/handlers/transactions_v4.go
+++ b/src/coordinator/handlers/transactions_v4.go
@@ -2403,7 +2403,7 @@ func buildMCPRawSQL(lakeName string, req *SearchObjectV4) string {
 	if req.Filter.CaptureID > 0 {
 		capStr := sqlvalidator.SafeString(strconv.Itoa(req.Filter.CaptureID))
 		conditions = append(conditions, fmt.Sprintf(
-			"(CAST(node_id AS VARCHAR) = '%s' OR data_extra ->> '$.capture_id' = '%s' OR data_extra ->> '$.captureId' = '%s')",
+			"(CAST(node_id AS VARCHAR) = '%s' OR json_extract_string(data_extra, '$.capture_id') = '%s' OR json_extract_string(data_extra, '$.captureId') = '%s')",
 			capStr, capStr, capStr))
 	}
 	if req.Filter.Payload != "" {
@@ -2453,7 +2453,7 @@ func appendVirtualValueConditions(conditions []string, values map[string]string,
 			continue
 		}
 		jp := services.DuckJSONPath(rule.Path)
-		clause := sqlFormMatchClause(fmt.Sprintf("data_extra ->> '%s'", jp), raw)
+		clause := sqlFormMatchClause(fmt.Sprintf("json_extract_string(data_extra, '%s')", jp), raw)
 		conditions = append(conditions, clause)
 	}
 	return conditions
@@ -2483,8 +2483,8 @@ func appendVirtualAbsentPresentConditions(conditions []string, absentIDs, presen
 			continue
 		}
 		jp := services.DuckJSONPath(rule.Path)
-		inner := fmt.Sprintf("trim(data_extra ->> '%s')", jp)
-		clause := fmt.Sprintf("(data_extra ->> '%s' IS NULL OR %s = '' OR lower(%s) = 'null')", jp, inner, inner)
+		inner := fmt.Sprintf("trim(json_extract_string(data_extra, '%s'))", jp)
+		clause := fmt.Sprintf("(json_extract_string(data_extra, '%s') IS NULL OR %s = '' OR lower(%s) = 'null')", jp, inner, inner)
 		conditions = append(conditions, clause)
 	}
 	for _, id := range normalizeIDs(presentIDs) {
@@ -2493,8 +2493,8 @@ func appendVirtualAbsentPresentConditions(conditions []string, absentIDs, presen
 			continue
 		}
 		jp := services.DuckJSONPath(rule.Path)
-		inner := fmt.Sprintf("trim(data_extra ->> '%s')", jp)
-		clause := fmt.Sprintf("(data_extra ->> '%s' IS NOT NULL AND %s <> '' AND lower(%s) <> 'null')", jp, inner, inner)
+		inner := fmt.Sprintf("trim(json_extract_string(data_extra, '%s'))", jp)
+		clause := fmt.Sprintf("(json_extract_string(data_extra, '%s') IS NOT NULL AND %s <> '' AND lower(%s) <> 'null')", jp, inner, inner)
 		conditions = append(conditions, clause)
 	}
 	return conditions
@@ -2660,10 +2660,10 @@ func buildSearchSQLV4WithOpts(lakeName string, req *SearchObjectV4, virtualRules
 			}
 		case "default":
 			if callerFilter != "" {
-				conditions = append(conditions, sqlFormMatchClause("data_extra ->> '$.from_host'", callerFilter))
+				conditions = append(conditions, sqlFormMatchClause("json_extract_string(data_extra, '$.from_host')", callerFilter))
 			}
 			if calleeFilter != "" {
-				conditions = append(conditions, sqlFormMatchClause("data_extra ->> '$.to_host'", calleeFilter))
+				conditions = append(conditions, sqlFormMatchClause("json_extract_string(data_extra, '$.to_host')", calleeFilter))
 			}
 		}
 	}
@@ -2705,7 +2705,7 @@ func buildSearchSQLV4WithOpts(lakeName string, req *SearchObjectV4, virtualRules
 		// Classic Homer captureId corresponds to HEP chunk 0x000c (capture agent); we persist it as node_id.
 		// Also match capture_id embedded in data_extra when present (custom ingest).
 		conditions = append(conditions, fmt.Sprintf(
-			"(CAST(node_id AS VARCHAR) = '%s' OR data_extra ->> '$.capture_id' = '%s' OR data_extra ->> '$.captureId' = '%s')",
+			"(CAST(node_id AS VARCHAR) = '%s' OR json_extract_string(data_extra, '$.capture_id') = '%s' OR json_extract_string(data_extra, '$.captureId') = '%s')",
 			capStr, capStr, capStr))
 	}
 	// node / node_id
@@ -2717,11 +2717,11 @@ func buildSearchSQLV4WithOpts(lakeName string, req *SearchObjectV4, virtualRules
 		if protoType == 1 && txType == "registration" {
 			conditions = append(conditions, sqlFormMatchClause("user_agent", ua))
 		} else {
-			conditions = append(conditions, sqlFormMatchClause("data_extra ->> '$.user_agent'", ua))
+			conditions = append(conditions, sqlFormMatchClause("json_extract_string(data_extra, '$.user_agent')", ua))
 		}
 	}
 	if ru := strings.TrimSpace(req.Filter.RuriUser); ru != "" {
-		conditions = append(conditions, sqlFormMatchClause("data_extra ->> '$.request_uri'", ru))
+		conditions = append(conditions, sqlFormMatchClause("json_extract_string(data_extra, '$.request_uri')", ru))
 	}
 	if req.Filter.Payload != "" {
 		conditions = append(conditions, sqlFormMatchClause("payload", req.Filter.Payload))


### PR DESCRIPTION
Follow-up / regression fix to #859.

## Problem

#859 (released in v11.0.288) switched `data_extra` string comparisons from `json_extract()` to the `->>` operator to fix quote-wrapping. However, `data_extra ->> '$.path'` **combined with a timestamp-range filter** — which Protocol Search always sends — triggers a DuckDB planner error at runtime and **500s the entire search endpoint**:

```
Conversion Error: Failed to cast value to numerical: {...} when casting from source column data_extra
```

This breaks exact-match search on **every** `data_extra`-backed field: virtual fields (custom SIP headers) as well as the built-in `from_host`, `to_host`, `user_agent`, `request_uri`, and `capture_id` filters.

## Minimal repro (DuckDB)

```sql
WHERE data_extra ->> '$.custom_headers."X-Foo"' = 'v'                  -- OK
WHERE timestamp >= .. AND timestamp <= ..                             -- OK
WHERE timestamp .. AND data_extra ->> '$...' = 'v'                     -- ERROR (cast to numerical)
WHERE timestamp .. AND json_extract_string(data_extra, '$...') = 'v'   -- OK
```

`->>` alone works and the timestamp filter alone works, but combined they fail. `json_extract_string()` returns the same unquoted value without the planner issue.

## Fix

Replace `data_extra ->> '$.path'` with `json_extract_string(data_extra, '$.path')` in the value / absent / present clauses (virtual fields + `from_host`, `to_host`, `user_agent`, `request_uri`, `capture_id`).

## Tests

- Updated the SQL-shape unit tests to expect `json_extract_string`.
- Added a regression test asserting the virtual-`equals` clause uses `json_extract_string` (not `->>`). The coverage gap — the SQL-shape tests never execute a real `equals` match — is what let both this and the original quote-wrap bug through.
- Manually verified against a running build: virtual-field `equals`, `LIKE`, `absent`/`present`, `request_uri`, `user_agent`, and `capture_id` searches all return correct results with a timestamp filter applied (previously 500).

## AI Disclaimer

This change was drafted with AI assistance. I've reviewed the diff and verified the fix (and the existing search filters) in my own test environment.