### PR TITLE
fix(ui): PCAP uploader Authorization undefined (#862)

### DIFF
--- a/src/ui/src/dashboard/widgets/PcapUploaderPanel.tsx
+++ b/src/ui/src/dashboard/widgets/PcapUploaderPanel.tsx
@@ -3,6 +3,7 @@ import { Upload } from 'lucide-react'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Label } from '@/components/ui/label'
 import { cn } from '@/lib/utils'
+import { handleUnauthorized } from '@/api'
 import { useDashboard } from '../context/DashboardContext'
 
 export default function PcapUploaderPanel() {
@@ -31,9 +32,14 @@ export default function PcapUploaderPanel() {
       }
       const res = await fetch(`${apiBase}/imports/pcap`, {
         method: 'POST',
-        headers: { Authorization: authHeader.Authorization },
+        headers: { ...authHeader },
+        credentials: 'include',
         body: formData,
       })
+      if (res.status === 401) {
+        handleUnauthorized()
+        throw new Error('Unauthorized')
+      }
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
         throw new Error(err?.error?.detail || `Upload failed (${res.status})`)

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.289"
+	VERSION_APPLICATION = "11.0.290"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary

- Fix PCAP Uploader sending `Authorization: undefined` when authenticated via HttpOnly cookie session (default login without "Remember me").
- Use `{ ...authHeader }` and `credentials: 'include'` like other dashboard widgets; handle `401` via `handleUnauthorized()`.
- Bump `VERSION_APPLICATION` to `11.0.290`.

Fixes https://github.com/sipcapture/homer/issues/862

## Test plan

- [x] Sign in without "Remember me" (cookie session)
- [x] Open PCAP Uploader widget and upload a `.pcap` file
- [x] Confirm request has no `Authorization: undefined` header; upload succeeds
- [x] Sign in with "Remember me" and confirm Bearer token upload still works