### PR TITLE
fix(node): make tiered hot+cold query rewrite reach cold DuckLake data

### DIFF
--- a/src/node/node.go
+++ b/src/node/node.go
@@ -350,6 +350,36 @@ var (
 
 const memorySplitThresholdMs = int64(time.Hour / time.Millisecond)
 
+// sqlIsAggregateShape reports whether the query carries aggregation, grouping
+// or DISTINCT anywhere. Such results cannot be merged row-wise across DuckDB
+// instances (uuid/timestamp dedup keys collapse aggregate rows), so they need
+// a single-SQL execution over a UNION of the underlying tables instead.
+func sqlIsAggregateShape(sql string) bool {
+	return sqlGroupByRegexp.MatchString(sql) ||
+		sqlDistinctRegexp.MatchString(sql) ||
+		sqlAggregateRegexp.MatchString(sql)
+}
+
+var sqlOrderByTimestampAscRegexp = regexp.MustCompile(`(?is)\bORDER\s+BY\s+timestamp\s+ASC\b`)
+
+// sortMergedRowsForQueryOrder restores the requested row order after
+// mergeSelectResults, which always sorts newest-first. Queries like the QoS
+// RTP/RTCP tabs ask for ORDER BY timestamp ASC and consume the rows as-is,
+// so an ASC request must be re-sorted oldest-first (with LIMIT keeping the
+// oldest N to match single-statement semantics).
+func sortMergedRowsForQueryOrder(rows []map[string]interface{}, originalSQL string, limit int) []map[string]interface{} {
+	if !sqlOrderByTimestampAscRegexp.MatchString(originalSQL) {
+		return rows
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return rowTimestampSortKey(rows[i]) < rowTimestampSortKey(rows[j])
+	})
+	if limit > 0 && len(rows) > limit {
+		rows = rows[:limit]
+	}
+	return rows
+}
+
 func extractSQLLimit(sql string) int {
 	m := sqlLimitRegexp.FindStringSubmatch(sql)
 	if len(m) < 2 {
@@ -738,8 +768,10 @@ func (n *Node) buildMemoryUnionQueries(sql string) memoryUnionQueries {
 	if n.sharedDB == nil {
 		return out
 	}
-	upper := strings.ToUpper(sql)
-	if !strings.HasPrefix(strings.TrimSpace(upper), "SELECT") {
+	upper := strings.ToUpper(strings.TrimSpace(sql))
+	isSelect := strings.HasPrefix(upper, "SELECT")
+	isCTE := strings.HasPrefix(upper, "WITH")
+	if !isSelect && !isCTE {
 		return out
 	}
 
@@ -771,6 +803,21 @@ func (n *Node) buildMemoryUnionQueries(sql string) memoryUnionQueries {
 	memTableA := "mem_hep_proto_" + tableSuffix + "_a"
 	memTableB := "mem_hep_proto_" + tableSuffix + "_b"
 	lakeTableFQN := sql[lakeStart:suffixEnd]
+
+	// Aggregate/GROUP BY/DISTINCT results cannot be unioned row-wise (each
+	// branch would emit its own aggregate row — e.g. three count(*) rows), and
+	// CTE queries cannot be wrapped as UNION operands. For both, substitute
+	// the table reference in place with a derived UNION of the lake table and
+	// the two memory buffers so the query runs once with correct semantics.
+	if isCTE || sqlIsAggregateShape(sql) {
+		tableName := "hep_proto_" + tableSuffix
+		derived := "(SELECT * FROM " + lakeTableFQN +
+			" UNION ALL SELECT * FROM " + memTableA +
+			" UNION ALL SELECT * FROM " + memTableB + ")"
+		out.combinedSQL = replaceTableWithDerived(sql, lakeTableFQN, derived, tableName)
+		out.ok = true
+		return out
+	}
 
 	orderByClause, limitClause, baseSQL := extractOrderLimit(sql)
 	memSQLA := strings.Replace(baseSQL, lakeTableFQN, memTableA, 1)
@@ -852,7 +899,9 @@ func (n *Node) runSharedSelectWithMemoryPolicy(ctx context.Context, db *sql.DB, 
 		return data, cols, plan, err
 	}
 	orderByClause, limitClause, baseSQL := extractOrderLimit(sql)
-	if shouldSplitLakeAndMem(sql, baseSQL, orderByClause, limitClause) {
+	// mq.memSQL is empty for the derived-table rewrite (CTE/aggregate
+	// queries); those must run as a single combined statement.
+	if mq.memSQL != "" && shouldSplitLakeAndMem(sql, baseSQL, orderByClause, limitClause) {
 		plan.mode = "split_lake_and_mem"
 		plan.lakeSQL = mq.lakeSQL
 		plan.memSQL = mq.memSQL
@@ -1020,8 +1069,25 @@ func (n *Node) handleQuery(w http.ResponseWriter, r *http.Request) {
 	if tieredOk && tieredDB != nil && n.sharedDB != nil {
 		tieredResults, tieredCols, terr := runSelectQuery(r.Context(), tieredDB, tieredUnion)
 		if terr == nil {
-			limit := extractSQLLimit(req.SQL)
-			results, columns = mergeSelectResults(results, tieredResults, columns, tieredCols, limit)
+			if sqlIsAggregateShape(req.SQL) {
+				// Aggregate rows cannot be merged across DuckDB instances (the
+				// uuid/timestamp dedup keys collapse them). The tiered union
+				// already spans hot+cold with correct aggregate semantics, and
+				// the hot tier shares the writer's catalog, so it covers all
+				// committed data; only unflushed memory-buffer rows are
+				// excluded from aggregates.
+				results, columns = tieredResults, tieredCols
+			} else {
+				limit := extractSQLLimit(req.SQL)
+				if sqlOrderByTimestampAscRegexp.MatchString(req.SQL) {
+					// Merge without the newest-first trim, then restore the
+					// requested ASC order (trim keeps the oldest N).
+					results, columns = mergeSelectResults(results, tieredResults, columns, tieredCols, 0)
+					results = sortMergedRowsForQueryOrder(results, req.SQL, limit)
+				} else {
+					results, columns = mergeSelectResults(results, tieredResults, columns, tieredCols, limit)
+				}
+			}
 			logger.Info("Node: handleQuery: returning merged results", "rows", len(results), "columns", fmt.Sprintf("%v", columns))
 			writeJSON(w, http.StatusOK, QueryResponse{
 				Success: true,
@@ -1141,33 +1207,33 @@ func tieredTableExists(db *sql.DB, lakeName, tableName string) bool {
 	return count > 0
 }
 
-// tryBuildVolumeUnionSQL builds SELECT ... UNION ALL ... across configured volumes
-// for execution on the TieredStorageManager DuckDB (hot + cold catalogs).
-// Volumes where the table is missing in that DuckDB instance are skipped so a cold
-// lake without a given hep_proto_* table does not break the whole UNION.
+// tryBuildVolumeUnionSQL rewrites a query referencing <baseLake>.main.<table>
+// so it reads from every configured volume: the table reference is replaced
+// in place with a derived table that UNION ALLs the per-volume catalogs,
+// aliased back to the table name so column references keep resolving.
+//
+// Unlike unioning whole queries, this substitution preserves the statement
+// shape: the result still starts with SELECT/WITH (passes the read-only SQL
+// validators), works inside CTEs, and keeps aggregate/GROUP BY/ORDER BY
+// semantics correct because they run once over the combined rows.
+//
+// Volumes where the table is missing in the target DuckDB instance are
+// skipped so a cold lake without a given hep_proto_* table does not break
+// the whole query.
 func (n *Node) tryBuildVolumeUnionSQL(sql string) (string, bool) {
 	if len(n.volumes) <= 1 {
 		return "", false
 	}
 
 	baseLakeName := n.config.DuckLake.LakeName
-	if !strings.Contains(sql, baseLakeName+".main.") {
-		return "", false
-	}
-
-	upperSQL := strings.ToUpper(sql)
-	if !strings.HasPrefix(strings.TrimSpace(upperSQL), "SELECT") {
-		return "", false
-	}
-
-	fromIdx := strings.Index(upperSQL, "FROM")
-	if fromIdx == -1 {
-		return "", false
-	}
-
 	tablePattern := baseLakeName + ".main."
 	tableStart := strings.Index(sql, tablePattern)
 	if tableStart == -1 {
+		return "", false
+	}
+
+	upperSQL := strings.ToUpper(strings.TrimSpace(sql))
+	if !strings.HasPrefix(upperSQL, "SELECT") && !strings.HasPrefix(upperSQL, "WITH") {
 		return "", false
 	}
 
@@ -1183,24 +1249,97 @@ func (n *Node) tryBuildVolumeUnionSQL(sql string) (string, bool) {
 	tableFQN := sql[tableStart:tableEnd]
 	tableName := tableFQN[len(tablePattern):]
 
+	// When the query already carries storage_* labels (a node-side rewrite ran
+	// before us), skip adding them in the branches to avoid duplicate columns.
+	addStorageCols := !strings.Contains(strings.ToLower(sql), "storage_lake")
+
 	presenceDB := n.duckDBForTieredTablePresence()
-	var unionParts []string
+	var branches []string
 	for _, vol := range n.volumes {
 		cat := n.duckLakeCatalogForQuery(vol)
 		if presenceDB != nil && !tieredTableExists(presenceDB, cat, tableName) {
 			continue
 		}
-		volTableFQN := cat + ".main." + tableName
-		rewrittenPart := strings.Replace(sql, tableFQN, volTableFQN, 1)
-		rewrittenPart = addStorageColumnsToQuery(rewrittenPart, cat, vol.Name)
-		unionParts = append(unionParts, "("+rewrittenPart+")")
+		branch := "SELECT *"
+		if addStorageCols {
+			branch += fmt.Sprintf(", %s AS storage_lake, %s AS storage_volume",
+				sqlStringLiteral(cat), sqlStringLiteral(vol.Name))
+		}
+		branch += " FROM " + cat + ".main." + tableName
+		branches = append(branches, branch)
 	}
 
-	if len(unionParts) == 0 {
+	if len(branches) == 0 {
 		return "", false
 	}
 
-	return strings.Join(unionParts, " UNION ALL "), true
+	derived := "(" + strings.Join(branches, " UNION ALL ") + ")"
+	return replaceTableWithDerived(sql, tableFQN, derived, tableName), true
+}
+
+// sqlKeywordsAfterTableRef are keywords that may legally follow a table
+// reference in a FROM clause; anything else there is an explicit alias.
+var sqlKeywordsAfterTableRef = map[string]bool{
+	"AS": false, // handled separately: AS always introduces an alias
+	"WHERE": true, "ORDER": true, "GROUP": true, "LIMIT": true, "OFFSET": true,
+	"UNION": true, "EXCEPT": true, "INTERSECT": true, "HAVING": true,
+	"JOIN": true, "LEFT": true, "RIGHT": true, "INNER": true, "OUTER": true,
+	"FULL": true, "CROSS": true, "NATURAL": true, "ON": true, "USING": true,
+	"QUALIFY": true, "WINDOW": true, "SEMI": true, "ANTI": true, "ASOF": true,
+}
+
+// sqlHasExplicitAliasAfter reports whether the text following a table
+// reference starts with an alias (either "AS name" or a bare identifier that
+// is not a clause keyword).
+func sqlHasExplicitAliasAfter(rest string) bool {
+	i := 0
+	for i < len(rest) && (rest[i] == ' ' || rest[i] == '\t' || rest[i] == '\n') {
+		i++
+	}
+	if i >= len(rest) {
+		return false
+	}
+	ch := rest[i]
+	isIdentStart := ch == '_' || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
+	if !isIdentStart {
+		return false
+	}
+	j := i
+	for j < len(rest) {
+		c := rest[j]
+		if c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+			j++
+			continue
+		}
+		break
+	}
+	word := strings.ToUpper(rest[i:j])
+	if word == "AS" {
+		return true
+	}
+	isClauseKeyword, known := sqlKeywordsAfterTableRef[word]
+	return !(known && isClauseKeyword)
+}
+
+// replaceTableWithDerived substitutes every occurrence of tableFQN with the
+// derived-table expression, appending "AS <alias>" only where the original
+// query does not already alias the table reference.
+func replaceTableWithDerived(sql, tableFQN, derived, alias string) string {
+	var b strings.Builder
+	rest := sql
+	for {
+		idx := strings.Index(rest, tableFQN)
+		if idx == -1 {
+			b.WriteString(rest)
+			return b.String()
+		}
+		b.WriteString(rest[:idx])
+		b.WriteString(derived)
+		rest = rest[idx+len(tableFQN):]
+		if !sqlHasExplicitAliasAfter(rest) {
+			b.WriteString(" AS " + alias)
+		}
+	}
 }
 
 // addMemoryUnion rewrites a SELECT query to include unflushed rows from the

--- a/src/node/rewrite_query_test.go
+++ b/src/node/rewrite_query_test.go
@@ -88,9 +88,9 @@ func TestDuckDBForTieredTablePresence(t *testing.T) {
 	}
 }
 
-func TestTryBuildVolumeUnionSQL_multiVolume(t *testing.T) {
+func multiVolumeNode() *Node {
 	cfg := &config.NodeConfig{DuckLake: config.DuckLakeConfig{LakeName: "homer_lake"}}
-	n := &Node{
+	return &Node{
 		config: cfg,
 		volumes: []VolumeInfo{
 			{Name: "hot", LakeName: "homer_lake_hot"},
@@ -98,13 +98,281 @@ func TestTryBuildVolumeUnionSQL_multiVolume(t *testing.T) {
 		},
 		sharedDB: new(sql.DB),
 	}
-	sql := "SELECT * FROM homer_lake.main.hep_proto_1_call WHERE 1=1"
-	out, ok := n.tryBuildVolumeUnionSQL(sql)
+}
+
+func TestTryBuildVolumeUnionSQL_multiVolume(t *testing.T) {
+	n := multiVolumeNode()
+	sqlIn := "SELECT * FROM homer_lake.main.hep_proto_1_call WHERE 1=1"
+	out, ok := n.tryBuildVolumeUnionSQL(sqlIn)
 	if !ok {
 		t.Fatal("expected ok")
 	}
-	if !strings.Contains(out, "homer_lake_hot") || !strings.Contains(out, "UNION ALL") || !strings.Contains(out, "homer_lake_cold") {
+	if !strings.Contains(out, "homer_lake_hot.main.hep_proto_1_call") ||
+		!strings.Contains(out, "UNION ALL") ||
+		!strings.Contains(out, "homer_lake_cold.main.hep_proto_1_call") {
 		t.Fatalf("expected union across hot+cold: %s", out)
+	}
+	// The derived table must be aliased back to the original table name so
+	// column references keep resolving.
+	if !strings.Contains(out, ") AS hep_proto_1_call") {
+		t.Fatalf("expected derived table aliased to table name: %s", out)
+	}
+	// Volume labels are exposed as columns for the UI.
+	if !strings.Contains(out, "'homer_lake_cold' AS storage_lake") || !strings.Contains(out, "'cold' AS storage_volume") {
+		t.Fatalf("expected storage_* labels in union branches: %s", out)
+	}
+	// The rewritten query must pass the node's own read-only SQL gates —
+	// the previous "(SELECT ...) UNION ALL (SELECT ...)" shape was rejected
+	// by validateUserSQL and never reached the cold catalog (issue #868).
+	if err := validateUserSQL(out); err != nil {
+		t.Fatalf("rewritten SQL rejected by validateUserSQL: %v\nsql: %s", err, out)
+	}
+	if err := ensureReadOnlySingleStatement(out); err != nil {
+		t.Fatalf("rewritten SQL rejected by ensureReadOnlySingleStatement: %v\nsql: %s", err, out)
+	}
+	if !shouldUseSQLQuery(out) {
+		t.Fatalf("rewritten SQL must be recognized as a query: %s", out)
+	}
+}
+
+func TestTryBuildVolumeUnionSQL_skipsStorageColsWhenPresent(t *testing.T) {
+	n := multiVolumeNode()
+	sqlIn := "SELECT *, 'homer_lake' AS storage_lake, 'default' AS storage_volume FROM homer_lake.main.hep_proto_1_call WHERE 1=1 ORDER BY timestamp DESC LIMIT 50"
+	out, ok := n.tryBuildVolumeUnionSQL(sqlIn)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if strings.Contains(out, "'hot' AS storage_volume") {
+		t.Fatalf("expected no duplicate storage_* columns in branches: %s", out)
+	}
+	if !strings.Contains(out, "UNION ALL SELECT * FROM homer_lake_cold.main.hep_proto_1_call) AS hep_proto_1_call") {
+		t.Fatalf("expected plain branches with alias: %s", out)
+	}
+}
+
+func TestTryBuildVolumeUnionSQL_cteQuery(t *testing.T) {
+	n := multiVolumeNode()
+	sqlIn := "WITH x AS ( SELECT * FROM homer_lake.main.hep_proto_1_default WHERE date = DATE '2026-07-12' ) SELECT count(*) FROM x"
+	out, ok := n.tryBuildVolumeUnionSQL(sqlIn)
+	if !ok {
+		t.Fatal("expected ok for CTE query")
+	}
+	if !strings.HasPrefix(strings.ToUpper(strings.TrimSpace(out)), "WITH") {
+		t.Fatalf("expected rewritten CTE to keep WITH prefix: %s", out)
+	}
+	if !strings.Contains(out, "homer_lake_hot.main.hep_proto_1_default") ||
+		!strings.Contains(out, "homer_lake_cold.main.hep_proto_1_default") {
+		t.Fatalf("expected hot+cold branches inside CTE: %s", out)
+	}
+	if err := validateUserSQL(out); err != nil {
+		t.Fatalf("rewritten CTE rejected by validateUserSQL: %v\nsql: %s", err, out)
+	}
+}
+
+func TestTryBuildVolumeUnionSQL_aggregateQuery(t *testing.T) {
+	n := multiVolumeNode()
+	sqlIn := "SELECT count(*) FROM homer_lake.main.hep_proto_1_default WHERE date = DATE '2026-07-12'"
+	out, ok := n.tryBuildVolumeUnionSQL(sqlIn)
+	if !ok {
+		t.Fatal("expected ok for aggregate query")
+	}
+	// The aggregate must run once over the combined rows: exactly one
+	// count(*) in the outer query, table replaced by the derived union.
+	if strings.Count(out, "count(*)") != 1 {
+		t.Fatalf("expected single outer aggregate: %s", out)
+	}
+	if !strings.Contains(out, "FROM (SELECT *") || !strings.Contains(out, ") AS hep_proto_1_default WHERE date") {
+		t.Fatalf("expected derived-table substitution before WHERE: %s", out)
+	}
+}
+
+func TestTryBuildVolumeUnionSQL_preservesExplicitAlias(t *testing.T) {
+	n := multiVolumeNode()
+	sqlIn := "SELECT t.sid FROM homer_lake.main.hep_proto_1_call t WHERE 1=1"
+	out, ok := n.tryBuildVolumeUnionSQL(sqlIn)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if strings.Contains(out, "AS hep_proto_1_call") {
+		t.Fatalf("expected original alias to be kept, no injected alias: %s", out)
+	}
+	if !strings.Contains(out, ") t WHERE 1=1") {
+		t.Fatalf("expected derived table followed by original alias: %s", out)
+	}
+}
+
+// TestTryBuildVolumeUnionSQL_executesOnDuckDB verifies the rewritten SQL
+// actually parses and runs on DuckDB across two attached catalogs, covering
+// the issue #868 shapes: plain SELECT, CTE and aggregate over hot+cold.
+func TestTryBuildVolumeUnionSQL_executesOnDuckDB(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+
+	setup := []string{
+		"ATTACH ':memory:' AS homer_lake_hot",
+		"ATTACH ':memory:' AS homer_lake_cold",
+		"CREATE TABLE homer_lake_hot.main.hep_proto_1_default (uuid VARCHAR, date DATE, timestamp TIMESTAMP, sid VARCHAR)",
+		"CREATE TABLE homer_lake_cold.main.hep_proto_1_default (uuid VARCHAR, date DATE, timestamp TIMESTAMP, sid VARCHAR)",
+		"INSERT INTO homer_lake_hot.main.hep_proto_1_default VALUES ('u1', DATE '2026-07-14', TIMESTAMP '2026-07-14 10:00:00', 'a')",
+		"INSERT INTO homer_lake_cold.main.hep_proto_1_default VALUES ('u2', DATE '2026-07-12', TIMESTAMP '2026-07-12 10:00:00', 'b'), ('u3', DATE '2026-07-12', TIMESTAMP '2026-07-12 11:00:00', 'c')",
+	}
+	for _, stmt := range setup {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("setup %q: %v", stmt, err)
+		}
+	}
+
+	n := multiVolumeNode()
+	n.tieredQueryDB = db
+
+	queryOne := func(t *testing.T, query string) int {
+		t.Helper()
+		var got int
+		if err := db.QueryRow(query).Scan(&got); err != nil {
+			t.Fatalf("query failed: %v\nsql: %s", err, query)
+		}
+		return got
+	}
+
+	t.Run("aggregate over cold date", func(t *testing.T) {
+		out, ok := n.tryBuildVolumeUnionSQL("SELECT count(*) FROM homer_lake.main.hep_proto_1_default WHERE date = DATE '2026-07-12'")
+		if !ok {
+			t.Fatal("expected rewrite")
+		}
+		if got := queryOne(t, out); got != 2 {
+			t.Fatalf("expected 2 cold rows, got %d\nsql: %s", got, out)
+		}
+	})
+
+	t.Run("CTE over cold timestamp range", func(t *testing.T) {
+		out, ok := n.tryBuildVolumeUnionSQL("WITH x AS ( SELECT * FROM homer_lake.main.hep_proto_1_default WHERE timestamp >= TIMESTAMP '2026-07-12 00:00:00' AND timestamp < TIMESTAMP '2026-07-13 00:00:00' ) SELECT count(*) FROM x")
+		if !ok {
+			t.Fatal("expected rewrite")
+		}
+		if got := queryOne(t, out); got != 2 {
+			t.Fatalf("expected 2 cold rows via CTE, got %d\nsql: %s", got, out)
+		}
+	})
+
+	t.Run("plain select spans hot and cold", func(t *testing.T) {
+		out, ok := n.tryBuildVolumeUnionSQL("SELECT * FROM homer_lake.main.hep_proto_1_default WHERE sid IS NOT NULL ORDER BY timestamp DESC LIMIT 50")
+		if !ok {
+			t.Fatal("expected rewrite")
+		}
+		rows, err := db.Query(out)
+		if err != nil {
+			t.Fatalf("query failed: %v\nsql: %s", err, out)
+		}
+		defer rows.Close()
+		data, cols, err := scanAllSQLRows(rows)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(data) != 3 {
+			t.Fatalf("expected 3 rows across hot+cold, got %d\nsql: %s", len(data), out)
+		}
+		hasCol := func(name string) bool {
+			for _, c := range cols {
+				if c == name {
+					return true
+				}
+			}
+			return false
+		}
+		if !hasCol("storage_lake") || !hasCol("storage_volume") {
+			t.Fatalf("expected storage_* columns in result, got %v", cols)
+		}
+	})
+
+	// Call Search flow: phase 1 finds uuids by callid (narrow projection),
+	// phase 2 hydrates full rows by uuid IN (...). Both must survive the
+	// derived-table rewrite and reach cold rows.
+	t.Run("callid search then hydrate by uuid", func(t *testing.T) {
+		narrow, ok := n.tryBuildVolumeUnionSQL("SELECT uuid, timestamp FROM homer_lake.main.hep_proto_1_default WHERE (sid = 'b' OR sid = 'c') ORDER BY timestamp DESC LIMIT 200")
+		if !ok {
+			t.Fatal("expected rewrite for narrow phase")
+		}
+		rows, err := db.Query(narrow)
+		if err != nil {
+			t.Fatalf("narrow query failed: %v\nsql: %s", err, narrow)
+		}
+		data, cols, err := scanAllSQLRows(rows)
+		rows.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(data) != 2 {
+			t.Fatalf("expected 2 narrow rows from cold, got %d\nsql: %s", len(data), narrow)
+		}
+		if len(cols) != 2 || cols[0] != "uuid" || cols[1] != "timestamp" {
+			t.Fatalf("narrow projection must stay uuid+timestamp, got %v", cols)
+		}
+
+		hydrate, ok := n.tryBuildVolumeUnionSQL("SELECT * FROM homer_lake.main.hep_proto_1_default WHERE uuid IN ('u2','u3') AND timestamp >= TIMESTAMP '2026-07-12 00:00:00'")
+		if !ok {
+			t.Fatal("expected rewrite for hydration phase")
+		}
+		rows, err = db.Query(hydrate)
+		if err != nil {
+			t.Fatalf("hydration query failed: %v\nsql: %s", err, hydrate)
+		}
+		data, _, err = scanAllSQLRows(rows)
+		rows.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(data) != 2 {
+			t.Fatalf("expected 2 hydrated rows from cold, got %d\nsql: %s", len(data), hydrate)
+		}
+	})
+
+	t.Run("missing table on cold is skipped", func(t *testing.T) {
+		if _, err := db.Exec("CREATE TABLE homer_lake_hot.main.hep_proto_1_call (uuid VARCHAR, date DATE, timestamp TIMESTAMP, sid VARCHAR)"); err != nil {
+			t.Fatal(err)
+		}
+		out, ok := n.tryBuildVolumeUnionSQL("SELECT count(*) FROM homer_lake.main.hep_proto_1_call WHERE 1=1")
+		if !ok {
+			t.Fatal("expected rewrite with hot-only branch")
+		}
+		if strings.Contains(out, "homer_lake_cold") {
+			t.Fatalf("expected cold volume skipped for missing table: %s", out)
+		}
+		if got := queryOne(t, out); got != 0 {
+			t.Fatalf("expected 0 rows, got %d", got)
+		}
+	})
+}
+
+func TestSortMergedRowsForQueryOrder(t *testing.T) {
+	ts := func(s string) map[string]interface{} {
+		return map[string]interface{}{"timestamp": []byte(s)}
+	}
+	rows := []map[string]interface{}{
+		ts("2026-07-12 12:00:00"),
+		ts("2026-07-12 10:00:00"),
+		ts("2026-07-12 11:00:00"),
+	}
+
+	descSQL := "SELECT * FROM t ORDER BY timestamp DESC LIMIT 50"
+	got := sortMergedRowsForQueryOrder(rows, descSQL, 50)
+	if len(got) != 3 || string(got[0]["timestamp"].([]byte)) != "2026-07-12 12:00:00" {
+		t.Fatalf("DESC query must be left untouched: %v", got)
+	}
+
+	ascSQL := "SELECT * FROM t WHERE sid = 'x' ORDER BY timestamp ASC"
+	got = sortMergedRowsForQueryOrder(rows, ascSQL, 0)
+	if string(got[0]["timestamp"].([]byte)) != "2026-07-12 10:00:00" ||
+		string(got[2]["timestamp"].([]byte)) != "2026-07-12 12:00:00" {
+		t.Fatalf("expected ascending order, got: %v", got)
+	}
+
+	got = sortMergedRowsForQueryOrder(rows, ascSQL, 2)
+	if len(got) != 2 || string(got[1]["timestamp"].([]byte)) != "2026-07-12 11:00:00" {
+		t.Fatalf("expected oldest 2 rows for ASC LIMIT, got: %v", got)
 	}
 }
 
@@ -148,6 +416,49 @@ func TestBuildMemoryUnionQueries(t *testing.T) {
 	}
 	if !strings.Contains(q.memSQL, "UNION ALL") {
 		t.Fatalf("expected mem SQL to union both buffers, got: %s", q.memSQL)
+	}
+}
+
+func TestBuildMemoryUnionQueries_aggregateSingleRow(t *testing.T) {
+	n := defaultMemoryUnionNode()
+	sqlIn := "SELECT count(*) FROM homer_lake.main.hep_proto_1_default WHERE date = DATE '2026-07-12'"
+	q := n.buildMemoryUnionQueries(sqlIn)
+	if !q.ok {
+		t.Fatal("expected memory union query plan")
+	}
+	// Unioning whole aggregate queries returned one count row per branch
+	// (issue #868 showed rows=3); the derived-table substitution must keep a
+	// single outer aggregate over lake + both memory buffers.
+	if strings.Count(q.combinedSQL, "count(*)") != 1 {
+		t.Fatalf("expected single outer aggregate, got: %s", q.combinedSQL)
+	}
+	if !strings.Contains(q.combinedSQL, "mem_hep_proto_1_default_a") ||
+		!strings.Contains(q.combinedSQL, "mem_hep_proto_1_default_b") {
+		t.Fatalf("expected both memory buffers in derived union: %s", q.combinedSQL)
+	}
+	if !strings.Contains(q.combinedSQL, ") AS hep_proto_1_default WHERE date") {
+		t.Fatalf("expected derived table aliased before WHERE: %s", q.combinedSQL)
+	}
+	if q.memSQL != "" {
+		t.Fatalf("derived rewrite must not produce a separate mem query: %s", q.memSQL)
+	}
+}
+
+func TestBuildMemoryUnionQueries_cteQuery(t *testing.T) {
+	n := defaultMemoryUnionNode()
+	sqlIn := "WITH x AS ( SELECT * FROM homer_lake.main.hep_proto_1_default WHERE date = DATE '2026-07-12' ) SELECT count(*) FROM x"
+	q := n.buildMemoryUnionQueries(sqlIn)
+	if !q.ok {
+		t.Fatal("expected memory union query plan for CTE")
+	}
+	if !strings.HasPrefix(strings.ToUpper(strings.TrimSpace(q.combinedSQL)), "WITH") {
+		t.Fatalf("expected combined SQL to keep WITH prefix: %s", q.combinedSQL)
+	}
+	if !strings.Contains(q.combinedSQL, "mem_hep_proto_1_default_a") {
+		t.Fatalf("expected memory buffer inside CTE: %s", q.combinedSQL)
+	}
+	if err := validateUserSQL(q.combinedSQL); err != nil {
+		t.Fatalf("combined CTE SQL rejected by validateUserSQL: %v\nsql: %s", err, q.combinedSQL)
 	}
 }
 

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.291"
+	VERSION_APPLICATION = "11.0.292"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary

Fixes #868 — queries against tiered DuckLake storage returned no cold data even though the cold catalog was attached and contained partitions.

Three defects in the node query path, all in `src/node/node.go`:

- **The tiered rewrite was rejected by the node's own validators.** `tryBuildVolumeUnionSQL` produced `(SELECT ...) UNION ALL (SELECT ...)` — a statement starting with a parenthesis, which `validateUserSQL` / `ensureReadOnlySingleStatement` reject with `only SELECT/CTE queries are allowed` (the exact warning from the issue: `merged writer+tiered query failed, falling back to writer-only`). The merged hot+cold path therefore never returned cold rows. In standalone multi-volume mode the same string failed `shouldUseSQLQuery` and went to `ExecContext`, returning empty data.
- **CTE queries never reached the cold catalog.** `tryBuildVolumeUnionSQL` and `buildMemoryUnionQueries` only accepted a `SELECT` prefix, so `WITH x AS (...)` queries from Web SQL silently skipped the tiered union (`mode=no_mem_union`, result 0).
- **Aggregates broke on row-wise merging.** The memory union returned one `count(*)` row per branch (`rows=3` in the issue log), and the Go-side merge dedups rows by uuid/timestamp, collapsing hot/cold aggregate rows into one arbitrary value.

## Fix

- Rewrite `tryBuildVolumeUnionSQL` as an in-place **derived-table substitution**: `FROM <lake>.main.<table>` becomes `FROM (SELECT ... FROM hot.main.<table> UNION ALL SELECT ... FROM cold.main.<table>) AS <table>`, with `storage_lake` / `storage_volume` labels in the branches (skipped when the query already carries them) and explicit aliases preserved. The result keeps its `SELECT`/`WITH` prefix, passes the validators, works inside CTEs, and keeps aggregate/GROUP BY/ORDER BY/LIMIT semantics. Volumes missing the table are still skipped.
- `handleQuery`: aggregate/GROUP BY/DISTINCT queries return the tiered result (one SQL over hot+cold) instead of the uuid-dedup merge; non-aggregate merging is unchanged. Queries ordered `ORDER BY timestamp ASC` (QoS RTP/RTCP tabs) are re-sorted ascending after the merge, since `mergeSelectResults` always sorts newest-first.
- `buildMemoryUnionQueries`: aggregate and CTE queries substitute the table with a derived union of the lake table and both memory buffers, so `SELECT count(*)` returns a single correct row on the writer DB.
- Bump version to 11.0.292.

## Test plan

- [x] `go vet ./node/... ./writer/... ./storage/...` clean
- [x] `go test -race ./node/` passes
- [x] New unit tests: rewritten SQL passes `validateUserSQL` / `shouldUseSQLQuery`; CTE rewrite; aggregate keeps a single outer aggregate; explicit alias preserved; storage columns not duplicated; ASC merge ordering
- [x] Live DuckDB test with two attached catalogs executing the issue #868 shapes end-to-end: `count(*)` by date, CTE over a timestamp range, `SELECT *` with ORDER BY/LIMIT spanning hot+cold, callid search + hydration by `uuid IN (...)`, and cold-volume skip for a missing table
- [ ] Verify on a tiered RustFS deployment that Web SQL / Call Search return rows for cold-only dates

## Notes

- Not addressed here (pre-existing, documented gaps): the FlightSQL/Grafana path does not do the tiered merge when sharing the writer DB; aggregate results exclude not-yet-flushed memory-buffer rows.
- The missing `hep_proto_1_call` table in the reporter's cold catalog is a separate concern: tiering moves tables lazily per partition, so it may simply mean no call partitions aged out yet (or a runtime move failure worth checking in `TieringService` logs).