### PR TITLE
feat(storage): per-table retention_days for DuckLake compaction (11.0.295)

### DIFF
--- a/docs/COMPACTION_SETUP.md
+++ b/docs/COMPACTION_SETUP.md
@@ -2,7 +2,7 @@
 
 !!! note "Homer 11 modular stack"
     This page describes the **legacy Homer Server** (`arrow_settings`) compaction model.
-    For **Homer 11** DuckLake retention, merge, and snapshot tuning, use
+    For **Homer 11** DuckLake retention (including per-table `retention_days_by_table`), merge, and snapshot tuning, use
     **[Data retention](RETENTION.md)** and [`storage.ducklake.compaction`](../examples/homer.json)
     in `homer.json` instead.
 

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -30,5 +30,5 @@ Field names follow the `mapstructure` tags on [`Config` in `src/config/config.go
 - High-PPS ingest / DuckLake / Prometheus batching: [INGEST_PERFORMANCE.md](INGEST_PERFORMANCE.md).
 - Tiered storage fields: [`docs/STORAGE_POLICIES.md`](STORAGE_POLICIES.md) (conceptual); same paths appear under `storage.ducklake.storage_policy` and `node.ducklake` in JSON — mirror them as `HOMER_*` as above.
 - Example with variables declared inline in Compose: [`examples/docker/docker-compose.yml`](../examples/docker/docker-compose.yml) (`homer.environment`).
-- **Data retention (TTL):** [`RETENTION.md`](RETENTION.md) — `HOMER_STORAGE_DUCKLAKE_COMPACTION_RETENTION_DAYS` and related compaction env vars.
+- **Data retention (TTL):** [`RETENTION.md`](RETENTION.md) — `HOMER_STORAGE_DUCKLAKE_COMPACTION_RETENTION_DAYS` and related compaction env vars. Per-table overrides (`retention_days_by_table`) are configured in JSON (map), not as a single env scalar.
 - **Search timeouts:** [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md) — `HOMER_COORDINATOR_QUERY_TIMEOUT_SEC`, `HOMER_COORDINATOR_HTTP_SERVER_READ_TIMEOUT`, `HOMER_COORDINATOR_HTTP_SERVER_WRITE_TIMEOUT`.

--- a/docs/RETENTION.md
+++ b/docs/RETENTION.md
@@ -7,6 +7,7 @@ Homer 11 has **several retention-related settings**. Only one of them actually *
 | What you want | Setting | Where |
 |---------------|---------|--------|
 | **Delete data older than N days** (TTL) | `storage.ducklake.compaction.retention_days` | JSON config, [wizard](WIZARD.md), env, CLI |
+| **Per-table TTL override** | `storage.ducklake.compaction.retention_days_by_table` | JSON config (bare table name → days) |
 | Move old partitions to cold / S3 (keep data) | `storage.ducklake.storage_policy.volumes[].max_data_age_days` | [Storage policies](STORAGE_POLICIES.md) |
 | DuckLake snapshot / file housekeeping | `storage.ducklake.compaction.snapshot_expire_interval_sec` | Compaction cycle (not the same as TTL) |
 | Mapping row `retention` in Settings UI | `mapping_schema.retention` | Legacy Homer 7 field — **does not run TTL in Homer 11** |
@@ -33,6 +34,9 @@ This runs **per DuckLake table** during the periodic compaction cycle (after tab
         "enable": true,
         "check_interval_sec": 1800,
         "retention_days": 30,
+        "retention_days_by_table": {
+          "hep_proto_1_registration": 14
+        },
         "snapshot_expire_interval_sec": 3600
       }
     }
@@ -42,7 +46,8 @@ This runs **per DuckLake table** during the periodic compaction cycle (after tab
 
 | Field | Default | Meaning |
 |-------|---------|---------|
-| `retention_days` | `0` | Delete data older than **N calendar days**. **`0` = disabled** (no TTL deletes). |
+| `retention_days` | `0` | Default TTL for every table. Delete data older than **N calendar days**. **`0` = disabled** (no TTL deletes) unless a positive per-table override is set. |
+| `retention_days_by_table` | _(empty)_ | Optional map of **bare table name → days**. Overrides `retention_days` for matching tables. An override of **`0` disables TTL** for that table. When `retention_days` is `0`, only tables with a positive override are trimmed. |
 | `check_interval_sec` | `3600` | How often the compaction worker runs (retention runs inside this cycle). |
 | `enable` | `true` | Compaction (merge + snapshot maintenance + optional retention) on the writer catalog. |
 
@@ -59,11 +64,13 @@ HOMER_STORAGE_DUCKLAKE_COMPACTION_CHECK_INTERVAL_SEC=1800
 HOMER_STORAGE_DUCKLAKE_COMPACTION_SNAPSHOT_EXPIRE_INTERVAL_SEC=3600
 ```
 
+`retention_days_by_table` is a map — set it in JSON config (or merge JSON over env). There is no single scalar env var for the whole override map.
+
 Example in Compose: [`examples/docker/docker-compose.yaml`](../examples/docker/docker-compose.yaml).
 
 ### Config wizard
 
-Step **Storage** asks for **Retention days** (default **30**, **`0` = unlimited**). It maps to `storage.ducklake.compaction.retention_days`. See [WIZARD.md](WIZARD.md).
+Step **Storage** asks for **Retention days** (default **30**, **`0` = unlimited**). It maps to `storage.ducklake.compaction.retention_days`. Per-table overrides (`retention_days_by_table`) are not prompted in the wizard — edit `homer.json` after generation. See [WIZARD.md](WIZARD.md).
 
 ### One-off CLI
 
@@ -77,17 +84,31 @@ Other compaction flags: `homer-core system --help` (`--compaction-force`, `--com
 
 ### Logs
 
-On each cycle when TTL is enabled:
+On each cycle when TTL is enabled for a table:
 
 ```
-CompactionService: Retention completed  table=hep_proto_1_call  rows_deleted=…
+CompactionService: Retention completed  table=hep_proto_1_call  retention_days=120  rows_deleted=…
 ```
 
 Failures are logged per table; missing Parquet files are skipped and cleaned up in a later orphan-file pass.
 
-### Applies to all lake tables
+### Applies to lake tables
 
-Retention runs on **every table** in the writer DuckLake catalog (HEP `hep_proto_*`, OTLP `otlp_*`, Line Protocol `lp_*`, etc.). There is no per-protocol TTL in config — use separate volumes/tiering or external lifecycle rules on object storage if you need different policies per dataset.
+Retention runs on **every HEP table** discovered in the writer DuckLake catalog (`hep_proto_*`). Use `retention_days_by_table` when different datasets need different windows — for example keep calls longer than REGISTERs:
+
+```json
+"compaction": {
+  "enable": true,
+  "retention_days": 120,
+  "retention_days_by_table": {
+    "hep_proto_1_registration": 30
+  }
+}
+```
+
+Keys must match the **bare** catalog table name (not a fully-qualified `lake.main.*` name). Unknown keys are ignored.
+
+For datasets that are not part of the HEP discovery set, use separate volumes/tiering or external lifecycle rules on object storage.
 
 OTLP and Line Protocol docs point here: [OTLP.md](OTLP.md), [LINE_PROTOCOL.md](LINE_PROTOCOL.md).
 
@@ -131,16 +152,16 @@ Manual maintenance (advanced): [STORAGE_LAYOUT.md](STORAGE_LAYOUT.md#maintenance
 
 The Coordinator stores a **`retention`** integer on each `mapping_schema` row (default **14** in seeds/UI). This value is **carried over from Homer 7** for compatibility and appears in the Mappings panel.
 
-**Homer 11 does not use this field to delete DuckLake rows.** Operational TTL is **`storage.ducklake.compaction.retention_days`** only.
+**Homer 11 does not use this field to delete DuckLake rows.** Operational TTL is **`storage.ducklake.compaction.retention_days`** (and optional **`retention_days_by_table`** overrides).
 
-When migrating from Homer 7/10, align **`retention_days`** in `homer.json` with your compliance window; treat mapping `retention` as documentation unless you have custom tooling that reads it.
+When migrating from Homer 7/10, align **`retention_days`** / **`retention_days_by_table`** in `homer.json` with your compliance window; treat mapping `retention` as documentation unless you have custom tooling that reads it.
 
 ---
 
 ## Recommended starting points
 
 1. **Single-node / all-in-one:** `retention_days: 30`, compaction enabled, `check_interval_sec: 1800`.
-2. **Hot + S3 tiering:** short `max_data_age_days` on hot (e.g. 2–7), longer or zero on cold, plus `retention_days` on the writer if cold must also be trimmed.
-3. **Compliance / legal hold:** set `retention_days: 0` (disabled) and manage expiry outside Homer (bucket lifecycle, offline archive).
-
+2. **Calls longer than REGISTERs:** keep a long default (e.g. `retention_days: 120`) and shorten high-volume tables via `retention_days_by_table` (e.g. `hep_proto_1_registration: 30`). Prefer this over different TTLs on LB backends that shard the same calls.
+3. **Hot + S3 tiering:** short `max_data_age_days` on hot (e.g. 2–7), longer or zero on cold, plus `retention_days` on the writer if cold must also be trimmed.
+4. **Compliance / legal hold:** set `retention_days: 0` (disabled) and manage expiry outside Homer (bucket lifecycle, offline archive). Use a per-table override of `0` only when you need to disable TTL for selected tables while keeping a global default.
 For OOM or runaway file counts, see [OOM.md](OOM.md) and [INGEST_PERFORMANCE.md](INGEST_PERFORMANCE.md).

--- a/docs/STORAGE_LAYOUT.md
+++ b/docs/STORAGE_LAYOUT.md
@@ -228,7 +228,8 @@ Recommended baseline for ~10k packets/sec on local disk:
 - `ducklake.flush_interval_sec`: 15-30 (controls latency and file size)
 - `ducklake.compaction.check_interval_sec`: 900-1800
 - `ducklake.compaction.snapshot_expire_interval_sec`: 3600-7200
-- `ducklake.compaction.retention_days`: set to policy (e.g. 7/30) — see [Data retention](RETENTION.md)
+- `ducklake.compaction.retention_days`: default TTL policy (e.g. 7/30)
+- `ducklake.compaction.retention_days_by_table`: optional per-table TTL overrides (e.g. shorter for `hep_proto_1_registration`) — see [Data retention](RETENTION.md)
 
 Goal: fewer small files, predictable compaction cycles, stable write latency.
 Adjust `batch_size` and `flush_interval_sec` together to hit desired file size.

--- a/docs/STORAGE_POLICIES.md
+++ b/docs/STORAGE_POLICIES.md
@@ -373,7 +373,7 @@ Simply enable `storage_policy` in your config and restart. The system handles th
 
 ## Best Practices
 
-1. **Start with longer retention on hot storage**: Begin with 30 days and reduce as needed — configure TTL via [`retention_days`](RETENTION.md#data-ttl-retention_days), not mapping schema alone.
+1. **Start with longer retention on hot storage**: Begin with 30 days and reduce as needed — configure TTL via [`retention_days`](RETENTION.md#data-ttl-retention_days) / optional [`retention_days_by_table`](RETENTION.md#data-ttl-retention_days), not mapping schema alone.
 2. **Use compaction before tiering**: Ensure compaction runs before tiering to minimize small files in cold storage
 3. **Monitor S3 costs**: Object storage egress can be expensive for frequently queried data
 4. **Test restore procedures**: Periodically verify you can query data from cold storage

--- a/docs/WIZARD.md
+++ b/docs/WIZARD.md
@@ -80,7 +80,8 @@ Choose a profile to pre-fill module settings. Selecting `all-in-one` enables all
 - DuckLake catalog — sqlite
 - Catalog path (default: `/data/homer/homer_catalog.sqlite`)
 - Data path for parquet files (default: `/data/homer/parquet`)
-- Retention days (default: 30, 0 = unlimited)
+- Retention days (default: 30, 0 = unlimited) → `storage.ducklake.compaction.retention_days`
+  - Optional per-table TTL overrides (`retention_days_by_table`) are not collected here; edit the generated JSON — see [RETENTION.md](RETENTION.md)
 - Batch size
 
 **Step 4 -- Node Module** (skipped if disabled)

--- a/examples/homer.json
+++ b/examples/homer.json
@@ -71,6 +71,9 @@
         "enable": true,
         "check_interval_sec": 1800,
         "retention_days": 30,
+        "retention_days_by_table": {
+          "hep_proto_1_registration": 14
+        },
         "snapshot_expire_interval_sec": 3600,
         "min_age_sec": 3600,
         "min_file_size_bytes": 0,

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -755,6 +755,11 @@ type CompactionConfig struct {
 	Enable           bool `json:"enable" mapstructure:"enable" default:"true"`
 	CheckIntervalSec int  `json:"check_interval_sec" mapstructure:"check_interval_sec" default:"3600"` // 1 hour
 	RetentionDays    int  `json:"retention_days" mapstructure:"retention_days" default:"0"`            // 0 = disabled
+	// RetentionDaysByTable overrides RetentionDays for specific DuckLake tables
+	// (keys are bare table names, e.g. "hep_proto_1_registration"). An override
+	// of 0 disables TTL for that table. When RetentionDays is 0, positive
+	// overrides still run retention for the listed tables only.
+	RetentionDaysByTable map[string]int `json:"retention_days_by_table" mapstructure:"retention_days_by_table"`
 	// SnapshotExpireIntervalSec controls how long to keep DuckLake snapshots (seconds).
 	SnapshotExpireIntervalSec int `json:"snapshot_expire_interval_sec" mapstructure:"snapshot_expire_interval_sec" default:"3600"`
 	// MinAgeSec controls how old data must be before compaction runs.

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.294"
+	VERSION_APPLICATION = "11.0.295"
 
 	// BuildDate is the build date
 	BuildDate = ""

--- a/src/writer/compaction.go
+++ b/src/writer/compaction.go
@@ -111,6 +111,9 @@ type CompactionConfig struct {
 	Enable           bool `json:"enable"`
 	CheckIntervalSec int  `json:"check_interval_sec"` // How often to run compaction (default: 3600 = 1 hour)
 	RetentionDays    int  `json:"retention_days"`     // Delete data older than N days (0 = disabled)
+	// RetentionDaysByTable overrides RetentionDays per bare table name
+	// (e.g. "hep_proto_1_registration"). Override 0 disables TTL for that table.
+	RetentionDaysByTable map[string]int `json:"retention_days_by_table"`
 	// SnapshotExpireIntervalSec controls how long to keep DuckLake snapshots (seconds).
 	SnapshotExpireIntervalSec int `json:"snapshot_expire_interval_sec"`
 	// MinAgeSec controls how old data must be before compaction runs.
@@ -249,6 +252,7 @@ func (c *CompactionService) Start() error {
 		"interval", fmt.Sprintf("%ds", c.config.CheckIntervalSec),
 		"min_age_sec", c.config.MinAgeSec,
 		"retention_days", c.config.RetentionDays,
+		"retention_days_by_table", len(c.config.RetentionDaysByTable),
 		"tables", len(c.tables))
 
 	// Always run compaction on startup after a short delay.
@@ -409,15 +413,20 @@ func (c *CompactionService) runCompaction() {
 
 	var totalRowsDeleted int64
 
-	// Run retention per table if configured — lock per table
-	if c.config.RetentionDays > 0 {
+	// Run retention per table when global TTL or any per-table override is set.
+	// Lock per table so flush is not blocked for the whole cycle.
+	if c.retentionEnabled() {
 		for _, table := range c.tables {
+			days := c.retentionDaysForTable(table)
+			if days <= 0 {
+				continue
+			}
 			c.withCatalogLock(func() {
-				deleted, err := c.runRetention(table)
+				deleted, err := c.runRetention(table, days)
 				if err != nil {
-					logger.Error("CompactionService: Retention failed", "table", table, "error", err)
+					logger.Error("CompactionService: Retention failed", "table", table, "retention_days", days, "error", err)
 				} else if deleted > 0 {
-					logger.Info("CompactionService: Retention completed", "table", table, "rows_deleted", deleted)
+					logger.Info("CompactionService: Retention completed", "table", table, "retention_days", days, "rows_deleted", deleted)
 					totalRowsDeleted += deleted
 				}
 			})
@@ -477,11 +486,42 @@ func (c *CompactionService) discoverTables() error {
 	return nil
 }
 
-// runRetention deletes data older than retention period.
+// retentionEnabled reports whether any retention TTL is configured (global or
+// a positive per-table override).
+func (c *CompactionService) retentionEnabled() bool {
+	if c.config.RetentionDays > 0 {
+		return true
+	}
+	for _, days := range c.config.RetentionDaysByTable {
+		if days > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// retentionDaysForTable returns the TTL in days for a catalog table.
+// Bare table names in RetentionDaysByTable win over the global RetentionDays.
+// An explicit override of 0 disables TTL for that table.
+func (c *CompactionService) retentionDaysForTable(table string) int {
+	name := tableNameFromFQN(table)
+	if name == "" {
+		name = table
+	}
+	if days, ok := c.config.RetentionDaysByTable[name]; ok {
+		return days
+	}
+	return c.config.RetentionDays
+}
+
+// runRetention deletes data older than retentionDays for one table.
 // Missing parquet files are silently skipped — they will be cleaned up
 // by ducklake_delete_orphaned_files in the maintenance phase.
-func (c *CompactionService) runRetention(table string) (int64, error) {
-	cutoff := time.Now().AddDate(0, 0, -c.config.RetentionDays)
+func (c *CompactionService) runRetention(table string, retentionDays int) (int64, error) {
+	if retentionDays <= 0 {
+		return 0, nil
+	}
+	cutoff := time.Now().AddDate(0, 0, -retentionDays)
 	cutoffStr := cutoff.UTC().Format("2006-01-02 15:04:05")
 
 	query := fmt.Sprintf(`DELETE FROM %s WHERE timestamp < TIMESTAMP '%s'`,
@@ -794,13 +834,14 @@ func (c *CompactionService) GetStats() map[string]interface{} {
 	defer c.mu.RUnlock()
 
 	return map[string]interface{}{
-		"enabled":              c.config.Enable,
-		"check_interval_sec":   c.config.CheckIntervalSec,
-		"retention_days":       c.config.RetentionDays,
-		"tables":               len(c.tables),
-		"last_compaction_time": c.lastCompactionTime,
-		"total_compactions":    c.totalCompactions,
-		"total_rows_deleted":   c.totalRowsDeleted,
+		"enabled":                c.config.Enable,
+		"check_interval_sec":     c.config.CheckIntervalSec,
+		"retention_days":         c.config.RetentionDays,
+		"retention_days_by_table": c.config.RetentionDaysByTable,
+		"tables":                 len(c.tables),
+		"last_compaction_time":   c.lastCompactionTime,
+		"total_compactions":      c.totalCompactions,
+		"total_rows_deleted":     c.totalRowsDeleted,
 	}
 }
 

--- a/src/writer/retention_days_test.go
+++ b/src/writer/retention_days_test.go
@@ -1,0 +1,64 @@
+package writer
+
+import (
+	"testing"
+)
+
+func TestRetentionDaysForTable(t *testing.T) {
+	svc := &CompactionService{
+		config: CompactionConfig{
+			RetentionDays: 120,
+			RetentionDaysByTable: map[string]int{
+				"hep_proto_1_registration": 30,
+				"hep_proto_1_call":         0, // explicit disable
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		table string
+		want  int
+	}{
+		{"global default", "homer_lake.main.hep_proto_1_default", 120},
+		{"override shorter", "homer_lake.main.hep_proto_1_registration", 30},
+		{"override disable", "homer_lake.main.hep_proto_1_call", 0},
+		{"bare table name", "hep_proto_1_registration", 30},
+		{"unknown bare uses global", "hep_proto_1_option", 120},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := svc.retentionDaysForTable(tt.table); got != tt.want {
+				t.Fatalf("retentionDaysForTable(%q)=%d, want %d", tt.table, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetentionEnabled(t *testing.T) {
+	tests := []struct {
+		name   string
+		config CompactionConfig
+		want   bool
+	}{
+		{"all zero", CompactionConfig{}, false},
+		{"global only", CompactionConfig{RetentionDays: 30}, true},
+		{"override only", CompactionConfig{RetentionDaysByTable: map[string]int{"hep_proto_1_registration": 14}}, true},
+		{"global zero with disable overrides", CompactionConfig{
+			RetentionDays:        0,
+			RetentionDaysByTable: map[string]int{"hep_proto_1_call": 0},
+		}, false},
+		{"global zero with positive override", CompactionConfig{
+			RetentionDays:        0,
+			RetentionDaysByTable: map[string]int{"hep_proto_1_registration": 7},
+		}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &CompactionService{config: tt.config}
+			if got := svc.retentionEnabled(); got != tt.want {
+				t.Fatalf("retentionEnabled()=%v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/src/writer/writer.go
+++ b/src/writer/writer.go
@@ -330,6 +330,7 @@ func (w *Writer) Start() error {
 			Enable:                    compactionEnable,
 			CheckIntervalSec:          w.storageConfig.DuckLake.Compaction.CheckIntervalSec,
 			RetentionDays:             w.storageConfig.DuckLake.Compaction.RetentionDays,
+			RetentionDaysByTable:      w.storageConfig.DuckLake.Compaction.RetentionDaysByTable,
 			SnapshotExpireIntervalSec: w.storageConfig.DuckLake.Compaction.SnapshotExpireIntervalSec,
 			MinAgeSec:                 w.storageConfig.DuckLake.Compaction.MinAgeSec,
 			MinFileSizeBytes:          w.storageConfig.DuckLake.Compaction.MinFileSizeBytes,


### PR DESCRIPTION
## Summary
- Add `storage.ducklake.compaction.retention_days_by_table` so individual HEP tables can override the global TTL (closes #873).
- Semantics: global `retention_days` is the default; matching bare table names win; override `0` disables TTL for that table; retention still runs when global is `0` but at least one override is positive.
- Docs + example updated; version bumped to **11.0.295**.

## Test plan
- [x] `go test ./writer/ -run TestRetention`
- [x] Configure e.g. `"retention_days": 120` + `"hep_proto_1_registration": 30` and confirm logs show different `retention_days` per table
- [x] Confirm override `0` skips DELETE for that table while others still trim
- [x] Confirm with `retention_days: 0` and a positive override, only listed tables are trimmed