### PR TITLE
fix(ui): default event_type to "all" across search and lookup paths (#870)

### DIFF
--- a/src/ui/src/dashboard/MessageModal.tsx
+++ b/src/ui/src/dashboard/MessageModal.tsx
@@ -213,7 +213,7 @@ export default function MessageModal({ modal, onClose, timeZone }) {
       const body = {
         uuid,
         proto_type: messageContext?.proto_type ?? 1,
-        event_type: messageContext?.event_type ?? 'call',
+        event_type: messageContext?.event_type ?? 'all',
       }
       if (messageContext?.timestamp?.from != null && messageContext?.timestamp?.to != null) {
         body.timestamp = messageContext.timestamp

--- a/src/ui/src/dashboard/TransactionModal.tsx
+++ b/src/ui/src/dashboard/TransactionModal.tsx
@@ -693,7 +693,7 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
     try {
       const body = buildTransactionTabBody(sessionIdsForApi, items, timeRange, timeZone, {
         proto_type: modal?.protoType || 1,
-        event_type: modal?.eventType || 'call',
+        event_type: modal?.eventType || 'all',
       })
       const data = await apiPost('/transactions/callinfo', body)
       setCallInfoData(data?.data || {})
@@ -750,7 +750,7 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
     const uuid = raw.uuid || raw.id || flowItem.id
     const messageContext = {
       proto_type: 1,
-      event_type: 'call',
+      event_type: 'all',
       timestamp: (() => {
         const ts = resolveTimeRange(timeRange, timeZone)
         return ts ? { from: ts.from, to: ts.to } : undefined
@@ -766,7 +766,7 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
     }
     setMessageModals(prev => [...prev, { modalKey: nestedKey, uuid, loading: true, data: null, error: null, messageContext }])
     try {
-      const body = { uuid, proto_type: 1, event_type: 'call' }
+      const body = { uuid, proto_type: 1, event_type: 'all' }
       if (messageContext.timestamp) body.timestamp = messageContext.timestamp
       const result = await apiPost('/messages', body)
       update({ modalKey: nestedKey, uuid, loading: false, data: result?.data || raw, error: null, messageContext })
@@ -969,7 +969,7 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
                   items={items}
                   timeRange={timeRange}
                   protoType={modal?.protoType || 1}
-                  eventType={modal?.eventType || 'call'}
+                  eventType={modal?.eventType || 'all'}
                 />
               </TabsContent>
             </Tabs>

--- a/src/ui/src/dashboard/searchDeepLink.ts
+++ b/src/ui/src/dashboard/searchDeepLink.ts
@@ -207,7 +207,9 @@ export function buildSearchPayload(
 ): SearchPayload {
   const filter: Record<string, unknown> = {
     proto_type: spec.proto_type ?? 1,
-    event_type: spec.event_type ?? 'call',
+    // Default to "all" so deep-linked/shared searches span call, registration
+    // and default SIP tables (backend merges them). See issue #870.
+    event_type: spec.event_type ?? 'all',
   }
   if (spec.from_user) filter.from_user = spec.from_user
   if (spec.to_user) filter.to_user = spec.to_user

--- a/src/ui/src/dashboard/widgets/ResultsPanel.tsx
+++ b/src/ui/src/dashboard/widgets/ResultsPanel.tsx
@@ -346,7 +346,7 @@ export default function ResultsPanel({ widgetId, config: _config }) {
     setSelectedKeys(new Set())
     lastSearchDataRef.current = sd
     const proto = String(sd.filter?.proto_type ?? sd.filter?.proto ?? '1')
-    const event = String(sd.filter?.event_type ?? sd.filter?.event ?? 'call')
+    const event = String(sd.filter?.event_type ?? sd.filter?.event ?? 'all')
     setCurrentProto(proto)
     setCurrentEvent(event)
     setHiddenColumns(loadLS(LS_KEY_HIDDEN(widgetId, proto, event), []))
@@ -657,7 +657,7 @@ export default function ResultsPanel({ widgetId, config: _config }) {
     const modalKey = genModalKey()
     const lastSearch = lastSearchDataRef.current
     const protoType = lastSearch?.filter?.proto_type ?? 1
-    const eventType = lastSearch?.filter?.event_type ?? 'call'
+    const eventType = lastSearch?.filter?.event_type ?? 'all'
     const rowMs = pickRowTimestampMs(row)
     const WIN_MS = 300 * 1000
     const messageContext = { proto_type: protoType, event_type: eventType }
@@ -698,7 +698,7 @@ export default function ResultsPanel({ widgetId, config: _config }) {
     const modalKey = genModalKey()
     const lastSearch = lastSearchDataRef.current
     const protoType = Number(lastSearch?.filter?.proto_type ?? lastSearch?.filter?.proto ?? 1) || 1
-    const eventType = String(lastSearch?.filter?.event_type ?? lastSearch?.filter?.event ?? 'call')
+    const eventType = String(lastSearch?.filter?.event_type ?? lastSearch?.filter?.event ?? 'all')
     const WIN_MS = 300 * 1000
 
     let sessionIds = []

--- a/src/ui/src/dashboard/widgets/SmartInputPanel.tsx
+++ b/src/ui/src/dashboard/widgets/SmartInputPanel.tsx
@@ -64,7 +64,7 @@ export default function SmartInputPanel({ config, onConfigChange }) {
       useSqlEndpoint: true,
       param: { limit },
       timestamp: timeRange,
-      filter: { proto_type: 1, event_type: 'call' },
+      filter: { proto_type: 1, event_type: 'all' },
     }
     if (targetId) {
       publishSearch(targetId, payload)

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.295"
+	VERSION_APPLICATION = "11.0.296"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary

Follow-up to #870 / #872. Form search already defaults to `event_type=all`, but several other UI entry points still fell back to `"call"`, so **deep links and row-open actions could silently miss rows stored in the `registration` / `default` SIP tables**.

This defaults those fallbacks to `"all"`, matching the Form default and letting the backend merge/resolve across `call`, `registration` and `default` tables (the message/transaction-by-uuid endpoints already support `all`).

## Changes

- `searchDeepLink.ts` — `buildSearchPayload` default `call` → `all` (deep-linked / shared / bootstrapped searches). **Primary fix.**
- `ResultsPanel.tsx` — search-context + message/transaction hydration fallbacks → `all`.
- `MessageModal.tsx` — decode fallback → `all`.
- `TransactionModal.tsx` — callinfo, flow-message open, and export fallbacks → `all`.
- `SmartInputPanel.tsx` — SQL-panel filter metadata → `all` (consistency; inert for table selection on the SQL path).
- `version.go` — 11.0.295 → 11.0.296.

No behavior change on the happy path (an explicit `event_type` is still honored); only the *unknown/fallback* case changes from `call` to `all`.

## Test plan

- [ ] Rebuild UI + backend from this branch (version ≥ 11.0.296).
- [ ] Form search with default selector returns rows across call/registration/default.
- [ ] Open a shared/deep-link search URL without `event_type` → results span all tables.
- [ ] Open a registration/default row from results → message & transaction modals hydrate correctly.

Refs #870