### PR TITLE
fix(ui): restore Form search default event_type to call (#870)

### DIFF
--- a/src/ui/src/dashboard/stores/search-store.ts
+++ b/src/ui/src/dashboard/stores/search-store.ts
@@ -41,7 +41,7 @@ const DEFAULT_FORM: SearchFormFields = {
   src_ip: '',
   dst_ip: '',
   proto_type: '1',
-  event_type: 'all',
+  event_type: 'call',
   node: '',
   src_port: '',
   dst_port: '',

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.295"
+	VERSION_APPLICATION = "11.0.296"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary

Restores the Form search **Event type** default from `all` back to `call`.

- `#871` / `3d2371b` set `DEFAULT_FORM.event_type = 'all'` so a fresh Form search merged `call` + `registration` + `default`.
- Product default for SIP Form search is **Call**.
- Backend merge for an explicit `event_type=all` is unchanged — users can still select **All** / **Default** / **Registration** in the dropdown.

Version: `11.0.295` → `11.0.296`.

## Context (#870)

On Pavel's dataset the July 12 cold window has traffic in `hep_proto_1_default` / `hep_proto_1_registration`, not in `hep_proto_1_call`. Form with Event=Call correctly returns 0; SQL finds data because it targets `_default` explicitly. Cold merge and the Form-style timestamp predicate are fine (`(A) ≈ (B) ≈ 29.8M`).

## Test plan

- [ ] Fresh Form widget (or Clear) shows Event = **Call**
- [ ] Selecting **All** still merges call/registration/default
- [ ] Selecting **Default** / **Registration** hits the matching table
- [ ] Persisted localStorage form keeps the user's last Event selection

Refs #870