### PR TITLE
chore(release): bump version to 11.0.297

### DIFF
--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.296"
+	VERSION_APPLICATION = "11.0.297"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Bump `VERSION_APPLICATION` to **11.0.297** (missed in #878 — merge happened before the version commit landed).

## Test plan
- [x] Confirm `src/version.go` shows `11.0.297` on `homer11` after merge