### PR TITLE
fix(storage): expire final volume by max_data_age_days

### DIFF
--- a/docs/RETENTION.md
+++ b/docs/RETENTION.md
@@ -1,14 +1,15 @@
 # Data retention
 
-Homer 11 has **several retention-related settings**. Only one of them actually **deletes** captured data from DuckLake. The others control tiering, snapshot housekeeping, or legacy mapping metadata.
+Homer 11 has **several retention-related settings**. Data can be deleted by writer compaction TTL and/or by final-volume storage-policy age expiry. Other settings control tiering moves, snapshot housekeeping, or legacy mapping metadata.
 
 ## Quick reference
 
 | What you want | Setting | Where |
 |---------------|---------|--------|
-| **Delete data older than N days** (TTL) | `storage.ducklake.compaction.retention_days` | JSON config, [wizard](WIZARD.md), env, CLI |
+| **Delete data older than N days** (timestamp TTL on writer lake) | `storage.ducklake.compaction.retention_days` | JSON config, [wizard](WIZARD.md), env, CLI |
 | **Per-table TTL override** | `storage.ducklake.compaction.retention_days_by_table` | JSON config (bare table name → days) |
-| Move old partitions to cold / S3 (keep data) | `storage.ducklake.storage_policy.volumes[].max_data_age_days` | [Storage policies](STORAGE_POLICIES.md) |
+| Move old partitions to the next volume | `storage.ducklake.storage_policy.volumes[].max_data_age_days` on intermediate volumes | [Storage policies](STORAGE_POLICIES.md) |
+| **Expire partitions on the final volume** | `storage.ducklake.storage_policy.volumes[].max_data_age_days` on the last volume (`> 0`) | [Storage policies](STORAGE_POLICIES.md) |
 | DuckLake snapshot / file housekeeping | `storage.ducklake.compaction.snapshot_expire_interval_sec` | Compaction cycle (not the same as TTL) |
 | Mapping row `retention` in Settings UI | `mapping_schema.retention` | Legacy Homer 7 field — **does not run TTL in Homer 11** |
 
@@ -116,20 +117,25 @@ OTLP and Line Protocol docs point here: [OTLP.md](OTLP.md), [LINE_PROTOCOL.md](L
 
 ## Tiering vs deletion (`max_data_age_days`)
 
-**Storage policy** moves date partitions from hot → cold volume based on age. It **does not delete** data by itself.
+**Storage policy** uses `max_data_age_days` in two ways:
+
+- **Intermediate volumes** (hot → cold, warm → archive, …): move date partitions whose DuckLake **`date`** is on or before `calendar(today) − N` to the next volume.
+- **Final volume**: there is no next tier. When `max_data_age_days > 0`, matching partitions are **deleted** (expired) from that volume. `0` disables age-based expiry on the final volume.
 
 ```json
 "storage_policy": {
   "volumes": [
-    { "name": "hot", "type": "local", "max_data_age_days": 7 },
-    { "name": "cold", "type": "s3", "max_data_age_days": 0 }
+    { "name": "hot", "type": "local", "max_data_age_days": 2 },
+    { "name": "cold", "type": "s3", "max_data_age_days": 5 }
   ]
 }
 ```
 
-Use this for cost/latency tiering. Combine with:
+Example on `2026-07-22`: hot keeps partitions after `2026-07-20`; cold keeps partitions after `2026-07-17` and expires older cold partitions.
 
-- **`retention_days`** on the writer to drop old data entirely, and/or
+Also available:
+
+- **`retention_days`** on the writer compaction service (timestamp-based TTL on the writer DuckLake catalog), and/or
 - **S3 lifecycle rules** on the cold bucket (Glacier, expire after 1y, …).
 
 Details: [STORAGE_POLICIES.md](STORAGE_POLICIES.md).
@@ -162,6 +168,6 @@ When migrating from Homer 7/10, align **`retention_days`** / **`retention_days_b
 
 1. **Single-node / all-in-one:** `retention_days: 30`, compaction enabled, `check_interval_sec: 1800`.
 2. **Calls longer than REGISTERs:** keep a long default (e.g. `retention_days: 120`) and shorten high-volume tables via `retention_days_by_table` (e.g. `hep_proto_1_registration: 30`). Prefer this over different TTLs on LB backends that shard the same calls.
-3. **Hot + S3 tiering:** short `max_data_age_days` on hot (e.g. 2–7), longer or zero on cold, plus `retention_days` on the writer if cold must also be trimmed.
+3. **Hot + S3 tiering:** short `max_data_age_days` on hot (e.g. 2–7); set a positive `max_data_age_days` on cold to expire final-tier partitions, or `0` to keep cold forever (optionally trim with bucket lifecycle / writer `retention_days`).
 4. **Compliance / legal hold:** set `retention_days: 0` (disabled) and manage expiry outside Homer (bucket lifecycle, offline archive). Use a per-table override of `0` only when you need to disable TTL for selected tables while keeping a global default.
 For OOM or runaway file counts, see [OOM.md](OOM.md) and [INGEST_PERFORMANCE.md](INGEST_PERFORMANCE.md).

--- a/docs/STORAGE_POLICIES.md
+++ b/docs/STORAGE_POLICIES.md
@@ -110,7 +110,7 @@ The `move_factor` parameter works similar to ClickHouse storage policies. It con
 | `type` | string | "local" | Storage type: "local" or "s3" |
 | `path` | string | required | Local path or S3 URL |
 | `priority` | int | 0 | Lower = higher priority. Writes go to lowest priority |
-| `max_data_age_days` | int | 0 | Tiering moves rows in partitions whose DuckLake **`date`** is **on or before** `calendar(today) − N days` (inclusive). Example: `N=1` on May 12 includes partition `date=2026-05-11`. `0` disables TTL-based moves. |
+| `max_data_age_days` | int | 0 | On intermediate volumes: move partitions whose DuckLake **`date`** is **on or before** `calendar(today) − N days` (inclusive) to the next volume. On the **final** volume: delete (expire) those partitions instead. Example: `N=1` on May 12 includes partition `date=2026-05-11`. `0` disables TTL for that volume. |
 | `max_size_gb` | int | 0 | Max volume size in GB (0 = no limit) |
 
 ### S3-specific Settings (for `type: "s3"`)
@@ -271,10 +271,23 @@ The `move_factor` parameter works similar to ClickHouse storage policies. It con
 
 1. **Write**: All new data is written to the primary (hot) volume (lowest priority number)
 2. **Tiering**: The TieringService periodically checks for old partitions
-3. **Copy**: Data older than `max_data_age_days` is copied to cold storage (new parquet files created)
-4. **Delete**: After successful copy, data is deleted from hot storage
-5. **Cleanup**: Empty partition directories are automatically removed
-6. **Query**: Queries automatically search across all volumes using UNION ALL
+3. **Copy**: On intermediate volumes, data older than `max_data_age_days` is copied to the next volume (new parquet files created)
+4. **Delete from source**: After successful copy, data is deleted from the source volume
+5. **Final-volume expiry**: On the last volume, `max_data_age_days > 0` deletes matching partitions (no next tier)
+6. **Cleanup**: Empty partition directories are automatically removed
+7. **Query**: Queries automatically search across all volumes using UNION ALL
+
+### Final volume expiry
+
+When the last volume has `max_data_age_days: N` (for example cold S3 with `N=5`), the tiering cycle expires partitions with `date <= calendar(today) − N`. Logs look like:
+
+```
+level=INFO msg="TieringService: TTL partition expire scan" source=cold max_data_age_days=5 partition_date_cutoff=2026-07-17
+level=INFO msg="TieredStorageManager: Partition expired" table=hep_proto_1_call date=2026-07-14 volume=cold rows=...
+level=INFO msg="TieringService: Tiering cycle completed" partitions_moved=0 partitions_expired=4
+```
+
+Set `max_data_age_days: 0` on the final volume to keep data indefinitely (or rely on S3 lifecycle / writer `retention_days`).
 
 ### Partition Movement Process
 

--- a/src/storage/ducklake/tiered_storage.go
+++ b/src/storage/ducklake/tiered_storage.go
@@ -437,6 +437,49 @@ func (tsm *TieredStorageManager) MovePartition(tableName string, date string, sr
 	return nil
 }
 
+// DeletePartition permanently removes a date partition from the given volume.
+// Used to enforce max_data_age_days on the final storage-policy volume (no next tier).
+func (tsm *TieredStorageManager) DeletePartition(tableName string, date string, vol *Volume) error {
+	tableFQN := fmt.Sprintf("%s.main.%s", vol.LakeName, tableName)
+
+	count, err := tsm.partitionRowCount(tableFQN, date)
+	if err != nil {
+		return fmt.Errorf("failed to count partition rows: %w", err)
+	}
+	if count == 0 {
+		logger.Debug("TieredStorageManager: Partition already empty, skip expire",
+			"table", tableName,
+			"date", date,
+			"volume", vol.Name)
+		return nil
+	}
+
+	logger.Info("TieredStorageManager: Expiring partition",
+		"table", tableName,
+		"date", date,
+		"volume", vol.Name,
+		"rows", count)
+
+	deleteSQL := fmt.Sprintf("DELETE FROM %s WHERE date = ?", tableFQN)
+	if _, err := execWithRetry(
+		tsm.db,
+		tieringMaxRetries,
+		tieringBaseBackoff,
+		tsm.hotCatalogLocker(vol),
+		deleteSQL,
+		date,
+	); err != nil {
+		return fmt.Errorf("failed to delete partition: %w", err)
+	}
+
+	logger.Info("TieredStorageManager: Partition expired",
+		"table", tableName,
+		"date", date,
+		"volume", vol.Name,
+		"rows", count)
+	return nil
+}
+
 func (tsm *TieredStorageManager) hotCatalogLocker(srcVol *Volume) CatalogLocker {
 	if tsm.primaryVolume != nil && srcVol.LakeName == tsm.primaryVolume.LakeName {
 		return tsm.catalogLocker

--- a/src/writer/tiering.go
+++ b/src/writer/tiering.go
@@ -127,6 +127,7 @@ func (ts *TieringService) runTieringCycle() {
 
 	volumes := ts.tieredStorage.GetVolumes()
 	var totalMoved int64
+	var totalExpired int64
 
 	// Process each volume pair (hot -> next volume based on priority)
 	for i := 0; i < len(volumes)-1; i++ {
@@ -174,8 +175,20 @@ func (ts *TieringService) runTieringCycle() {
 		}
 	}
 
-	// Cleanup empty partition directories after moving data
-	if totalMoved > 0 {
+	// Final volume: max_data_age_days expires partitions (no next tier to move to).
+	if last := finalVolumeForExpire(volumes); last != nil {
+		expired, err := ts.expireOldPartitions(last)
+		if err != nil {
+			logger.Error("TieringService: Failed to expire partitions on final volume",
+				"source", last.Name,
+				"error", err)
+		} else {
+			totalExpired += expired
+		}
+	}
+
+	// Cleanup empty partition directories after moving/expiring data
+	if totalMoved > 0 || totalExpired > 0 {
 		for _, vol := range volumes {
 			if vol.Type == ducklake.VolumeTypeLocal {
 				ts.cleanupEmptyPartitions(vol.Path)
@@ -186,7 +199,8 @@ func (ts *TieringService) runTieringCycle() {
 	duration := time.Since(startTime)
 	logger.Info("TieringService: Tiering cycle completed",
 		"duration", duration.String(),
-		"partitions_moved", totalMoved)
+		"partitions_moved", totalMoved,
+		"partitions_expired", totalExpired)
 }
 
 // checkVolumeSizeThreshold checks if volume size exceeds move_factor threshold
@@ -370,6 +384,99 @@ func (ts *TieringService) moveOldPartitions(srcVol, dstVol *ducklake.Volume) (in
 			"hint", "No partition dates on or before cutoff; increase max_data_age_days or wait for older calendar partitions.")
 	}
 	return totalMoved, nil
+}
+
+// finalVolumeForExpire returns the last storage-policy volume when it has a
+// positive max_data_age_days (TTL expire). Intermediate volumes only move data;
+// the final volume has no destination, so age TTL deletes partitions instead.
+func finalVolumeForExpire(volumes []*ducklake.Volume) *ducklake.Volume {
+	if len(volumes) == 0 {
+		return nil
+	}
+	last := volumes[len(volumes)-1]
+	if last == nil || last.MaxDataAgeDays <= 0 {
+		return nil
+	}
+	return last
+}
+
+// expireOldPartitions deletes partitions older than max_data_age_days from the
+// final storage-policy volume (there is no next tier to move into).
+func (ts *TieringService) expireOldPartitions(vol *ducklake.Volume) (int64, error) {
+	cutoffDate := time.Now().AddDate(0, 0, -vol.MaxDataAgeDays).Format("2006-01-02")
+
+	logger.Info("TieringService: TTL partition expire scan",
+		"source", vol.Name,
+		"max_data_age_days", vol.MaxDataAgeDays,
+		"partition_date_cutoff", cutoffDate,
+		"rule", "partition date <= cutoff (inclusive); cutoff is calendar today minus max_data_age_days; final volume expires instead of moving")
+
+	tables, err := ts.tieredStorage.GetTableNames(vol)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get table names: %w", err)
+	}
+	if len(tables) == 0 {
+		logger.Info("TieringService: No hep_proto* tables on final volume — nothing to expire by age",
+			"source", vol.Name,
+			"lake", vol.LakeName)
+		return 0, nil
+	}
+
+	var totalExpired int64
+	semaphore := make(chan struct{}, ts.config.ConcurrentMoves)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+
+	for _, tableName := range tables {
+		partitions, err := ts.tieredStorage.GetPartitionsOlderThan(vol, tableName, cutoffDate)
+		if err != nil {
+			logger.Warn("TieringService: Failed to get partitions for expire",
+				"table", tableName,
+				"error", err)
+			continue
+		}
+		if len(partitions) == 0 {
+			continue
+		}
+
+		logger.Info("TieringService: Found expired partitions",
+			"table", tableName,
+			"count", len(partitions),
+			"dates", partitions)
+
+		for _, partition := range partitions {
+			wg.Add(1)
+			semaphore <- struct{}{}
+
+			go func(table, date string) {
+				defer wg.Done()
+				defer func() { <-semaphore }()
+
+				if err := ts.tieredStorage.DeletePartition(table, date, vol); err != nil {
+					logger.Error("TieringService: Failed to expire partition",
+						"table", table,
+						"date", date,
+						"volume", vol.Name,
+						"error", err)
+					return
+				}
+
+				mu.Lock()
+				totalExpired++
+				mu.Unlock()
+			}(tableName, partition)
+		}
+	}
+
+	wg.Wait()
+	if totalExpired == 0 {
+		logger.Info("TieringService: TTL expire pass completed with no deletes",
+			"source", vol.Name,
+			"tables_checked", len(tables),
+			"partition_date_cutoff", cutoffDate,
+			"hint", "No partition dates on or before cutoff on the final volume.")
+	}
+	return totalExpired, nil
 }
 
 // ensureTableExists ensures the destination table exists with the same schema and partitioning as source

--- a/src/writer/tiering_expire_test.go
+++ b/src/writer/tiering_expire_test.go
@@ -1,0 +1,70 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package writer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sipcapture/homer-core/src/storage/ducklake"
+)
+
+func TestFinalVolumeForExpire(t *testing.T) {
+	hot := &ducklake.Volume{Name: "hot", MaxDataAgeDays: 2}
+	coldDisabled := &ducklake.Volume{Name: "cold", MaxDataAgeDays: 0}
+	coldEnabled := &ducklake.Volume{Name: "cold", MaxDataAgeDays: 5}
+	archive := &ducklake.Volume{Name: "archive", MaxDataAgeDays: 30}
+
+	tests := []struct {
+		name    string
+		volumes []*ducklake.Volume
+		want    string // volume name, or "" if nil
+	}{
+		{name: "empty", volumes: nil, want: ""},
+		{name: "hot only with TTL", volumes: []*ducklake.Volume{hot}, want: "hot"},
+		{name: "hot only zero TTL", volumes: []*ducklake.Volume{coldDisabled}, want: ""},
+		{name: "two volumes cold disabled", volumes: []*ducklake.Volume{hot, coldDisabled}, want: ""},
+		{name: "two volumes cold enabled", volumes: []*ducklake.Volume{hot, coldEnabled}, want: "cold"},
+		{name: "three volumes last enabled", volumes: []*ducklake.Volume{hot, coldDisabled, archive}, want: "archive"},
+		{name: "intermediate TTL ignored for expire", volumes: []*ducklake.Volume{
+			{Name: "hot", MaxDataAgeDays: 2},
+			{Name: "warm", MaxDataAgeDays: 7},
+			{Name: "cold", MaxDataAgeDays: 0},
+		}, want: ""},
+		{name: "nil last entry", volumes: []*ducklake.Volume{hot, nil}, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := finalVolumeForExpire(tt.volumes)
+			if tt.want == "" {
+				if got != nil {
+					t.Fatalf("expected nil, got %q", got.Name)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected volume %q, got nil", tt.want)
+			}
+			if got.Name != tt.want {
+				t.Fatalf("got %q, want %q", got.Name, tt.want)
+			}
+		})
+	}
+}
+
+func TestPartitionDateCutoffInclusive(t *testing.T) {
+	// Mirrors expireOldPartitions / moveOldPartitions cutoff:
+	// calendar(today) - N days, inclusive selection via GetPartitionsOlderThan.
+	now := time.Date(2026, 7, 22, 15, 0, 0, 0, time.Local)
+	got := now.AddDate(0, 0, -5).Format("2006-01-02")
+	want := "2026-07-17"
+	if got != want {
+		t.Fatalf("cutoff = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Enforce `max_data_age_days` on the **final** storage-policy volume by deleting (expiring) date partitions on or before the inclusive calendar cutoff.
- Intermediate volumes keep move-only tiering (`hot → cold`); `0` on the last volume still disables age expiry.
- Docs updated in `RETENTION.md` / `STORAGE_POLICIES.md`; unit coverage for final-volume selection and cutoff.

Closes #882

## Test plan
- [x] `go vet ./writer/ ./storage/ducklake/`
- [x] `go test ./writer/ ./storage/ducklake/ -count=1`
- [ ] Deploy/config with hot `max_data_age_days=2` and cold `max_data_age_days=5`, wait for a tiering cycle
- [ ] Confirm logs include `TTL partition expire scan source=cold` and `partitions_expired > 0` for dates `<= today-5`
- [ ] Confirm cold catalog no longer lists expired active partitions (`end_snapshot IS NULL`)