### PR TITLE
fix(search): registration Call-ID without cid column

### DIFF
--- a/src/coordinator/handlers/search.go
+++ b/src/coordinator/handlers/search.go
@@ -211,7 +211,8 @@ func (h *SearchHandler) buildSimpleSearchSQL(req *SimpleSearchRequest) (string, 
 
 	// Field filters
 	if req.CallID != "" {
-		conditions = append(conditions, sqlFormMatchClauseOr("session_id", "cid", req.CallID))
+		txType := normalizeSIPTransactionType(req.ProtoType, req.TransactionType)
+		conditions = append(conditions, sipCallIDMatchClause(txType, req.CallID))
 	}
 	if req.FromUser != "" {
 		conditions = append(conditions, sqlFormMatchClause("caller", req.FromUser))

--- a/src/coordinator/handlers/transactions_sql_test.go
+++ b/src/coordinator/handlers/transactions_sql_test.go
@@ -73,6 +73,62 @@ func TestBuildSearchSQLV4_UserAgentRegistrationColumn(t *testing.T) {
 	}
 }
 
+func TestBuildSearchSQLV4_RegistrationCallIDUsesSessionIDOnly(t *testing.T) {
+	// hep_proto_1_registration has session_id but no cid (#884).
+	req := SearchObjectV4{}
+	req.Filter.ProtoType = 1
+	req.Filter.EventType = "registration"
+	req.Filter.CallID = "bb2d844e-ba46-4dac-86b3-c0afce431376"
+
+	sql, err := buildSearchSQLV4("homer_lake", &req, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(sql, "FROM homer_lake.main.hep_proto_1_registration") {
+		t.Fatalf("expected registration table, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "session_id = 'bb2d844e-ba46-4dac-86b3-c0afce431376'") {
+		t.Fatalf("expected session_id = Call-ID, got:\n%s", sql)
+	}
+	if strings.Contains(sql, "cid") {
+		t.Fatalf("registration Call-ID filter must not reference cid, got:\n%s", sql)
+	}
+}
+
+func TestBuildSearchSQLV4_RegistrationCIDAliasToSessionID(t *testing.T) {
+	req := SearchObjectV4{}
+	req.Filter.ProtoType = 1
+	req.Filter.EventType = "registration"
+	req.Filter.CID = "reg-cid-1"
+
+	sql, err := buildSearchSQLV4("homer_lake", &req, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(sql, "session_id = 'reg-cid-1'") {
+		t.Fatalf("expected cid filter aliased to session_id, got:\n%s", sql)
+	}
+	if strings.Contains(sql, "cid =") {
+		t.Fatalf("registration must not filter on cid column, got:\n%s", sql)
+	}
+}
+
+func TestBuildSearchSQLV4_CallStillMatchesSessionOrCID(t *testing.T) {
+	req := SearchObjectV4{}
+	req.Filter.ProtoType = 1
+	req.Filter.EventType = "call"
+	req.Filter.CallID = "call-1"
+
+	sql, err := buildSearchSQLV4("homer_lake", &req, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "(session_id = 'call-1' OR cid = 'call-1')"
+	if !strings.Contains(sql, want) {
+		t.Fatalf("expected %q in call search SQL, got:\n%s", want, sql)
+	}
+}
+
 func TestBuildSearchSQLV4_SIPMethodAndResponseMultiFilter(t *testing.T) {
 	req := SearchObjectV4{}
 	req.Filter.ProtoType = 1

--- a/src/coordinator/handlers/transactions_v4.go
+++ b/src/coordinator/handlers/transactions_v4.go
@@ -58,6 +58,24 @@ func sqlFormMatchClauseOr(leftExpr, rightExpr, rawValue string) string {
 	return fmt.Sprintf("(%s = '%s' OR %s = '%s')", leftExpr, esc, rightExpr, esc)
 }
 
+// sipCallIDMatchClause builds a Call-ID / session_id filter for a SIP profile.
+// hep_proto_1_registration stores Call-ID in session_id and has no cid column (#884).
+func sipCallIDMatchClause(txType, rawValue string) string {
+	if strings.EqualFold(strings.TrimSpace(txType), "registration") {
+		return sqlFormMatchClause("session_id", rawValue)
+	}
+	return sqlFormMatchClauseOr("session_id", "cid", rawValue)
+}
+
+// sipCIDMatchClause builds a dedicated cid filter for a SIP profile.
+// On registration tables, cid is aliased to session_id (#884).
+func sipCIDMatchClause(txType, rawValue string) string {
+	if strings.EqualFold(strings.TrimSpace(txType), "registration") {
+		return sqlFormMatchClause("session_id", rawValue)
+	}
+	return sqlFormMatchClause("cid", rawValue)
+}
+
 // sqlFormMatchClauseAny ORs the same value across multiple column expressions.
 func sqlFormMatchClauseAny(columnExprs []string, rawValue string) string {
 	esc := sqlvalidator.SafeString(rawValue)
@@ -2782,7 +2800,7 @@ func buildSearchSQLV4WithOpts(lakeName string, req *SearchObjectV4, virtualRules
 		case 100:
 			conditions = append(conditions, sqlFormMatchClause("session_id", sessionFilter))
 		default:
-			conditions = append(conditions, sqlFormMatchClauseOr("session_id", "cid", sessionFilter))
+			conditions = append(conditions, sipCallIDMatchClause(txType, sessionFilter))
 		}
 	} else if req.Filter.CID != "" {
 		switch protoType {
@@ -2791,7 +2809,7 @@ func buildSearchSQLV4WithOpts(lakeName string, req *SearchObjectV4, virtualRules
 		case 100:
 			conditions = append(conditions, sqlFormMatchClause("session_id", req.Filter.CID))
 		default:
-			conditions = append(conditions, sqlFormMatchClause("cid", req.Filter.CID))
+			conditions = append(conditions, sipCIDMatchClause(txType, req.Filter.CID))
 		}
 	}
 	// Party / identity filters — column layout depends on SIP profile (ducklake.TableSchema).


### PR DESCRIPTION
## Summary
- `hep_proto_1_registration` has `session_id` but no `cid`; Call-ID Form/API search built `(session_id OR cid)` and failed with Binder Error.
- Registration (and registration `cid` filter) now match `session_id` only; call/default keep `session_id OR cid`.
- Covers v4 transaction search SQL and the simple search builder.

Closes #884

## Test plan
- [x] `go test ./coordinator/handlers/ -run 'TestBuildSearchSQLV4_Registration|TestBuildSearchSQLV4_CallStill'`
- [x] `go vet ./coordinator/handlers/`
- [ ] UI: Form search event_type=registration by Call-ID succeeds (no Query failed)
- [ ] UI: Form search event_type=call by Call-ID still works