### PR TITLE
chore(release): bump version to 11.0.298

### DIFF
--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.297"
+	VERSION_APPLICATION = "11.0.298"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Bump `VERSION_APPLICATION` to **11.0.298** for release after #883, #885, #886.

## Test plan
- [x] Confirm `src/version.go` shows `11.0.298`
- [ ] Publish GitHub release `11.0.298` after merge (Build-n-Release)