### PR TITLE
chore(deps): fix open npm Dependabot security alerts in UI

### DIFF
--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -1258,12 +1258,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -6791,9 +6791,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.26",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
-      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -7180,9 +7180,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -66,8 +66,10 @@
   "overrides": {
     "express-rate-limit": "8.5.1",
     "ip-address": "10.2.0",
-    "hono": "4.12.26",
-    "js-yaml": "4.2.0",
+    "hono": "4.12.31",
+    "js-yaml": "4.3.0",
+    "@hono/node-server": "2.0.11",
+    "fast-uri": "3.1.4",
     "@babel/core": "7.29.6",
     "ws": "8.21.0"
   }


### PR DESCRIPTION
## Summary
- Bump `package.json` overrides in `src/ui` to patched npm versions:
  - `hono` 4.12.26 → 4.12.31
  - `js-yaml` 4.2.0 → 4.3.0
  - `@hono/node-server` → 2.0.11
  - `fast-uri` → 3.1.4
- Refresh `package-lock.json` accordingly.

Addresses open Dependabot alerts [#50](https://github.com/sipcapture/homer/security/dependabot/50)–[#56](https://github.com/sipcapture/homer/security/dependabot/56).

## Test plan
- [x] `npm audit` in `src/ui` → 0 vulnerabilities
- [x] `npm run build` in `src/ui`
- [x] `npm test` in `src/ui` (150 tests)