### PR TITLE
fix(storage): reclaim physical space on tiered volumes after TTL expire

### DIFF
--- a/docs/STORAGE_POLICIES.md
+++ b/docs/STORAGE_POLICIES.md
@@ -289,6 +289,17 @@ level=INFO msg="TieringService: Tiering cycle completed" partitions_moved=0 part
 
 Set `max_data_age_days: 0` on the final volume to keep data indefinitely (or rely on S3 lifecycle / writer `retention_days`).
 
+### Physical space reclaim
+
+DuckLake `DELETE` (both the move source delete and the final-volume expiry) only marks parquet files as deleted in the catalog — the objects initially stay on disk/S3. Every tiering cycle then runs per-volume maintenance (`ducklake_expire_snapshots` with the `compaction.snapshot_expire_interval_sec` window, `ducklake_cleanup_old_files`, `ducklake_delete_orphaned_files`) on each tiered lake, which physically deletes the obsolete objects from local storage and S3:
+
+```
+level=INFO msg="TieredStorageManager: Running volume maintenance" volume=cold lake=homer_lake_cold snapshot_older_than_sec=3600
+level=INFO msg="TieredStorageManager: Volume maintenance completed" volume=cold lake=homer_lake_cold
+```
+
+Expired data disappears from S3 after the snapshot window passes (default 1 hour), not instantly at the moment of the expire DELETE.
+
 ### Partition Movement Process
 
 Data is partitioned by date (`date` column). The tiering service copies entire date partitions to cold storage:

--- a/src/storage/ducklake/tiered_storage.go
+++ b/src/storage/ducklake/tiered_storage.go
@@ -480,6 +480,65 @@ func (tsm *TieredStorageManager) DeletePartition(tableName string, date string, 
 	return nil
 }
 
+// volumeMaintenanceSQL returns the DuckLake maintenance calls that physically
+// reclaim storage on a volume's lake: expire snapshots referencing deleted
+// files, then delete the superseded/orphaned parquet objects (local or S3).
+func volumeMaintenanceSQL(lakeName string, snapshotOlderThanSec int) []string {
+	if snapshotOlderThanSec <= 0 {
+		snapshotOlderThanSec = 3600
+	}
+	return []string{
+		fmt.Sprintf(
+			"CALL ducklake_expire_snapshots('%s', older_than => CAST(NOW() - INTERVAL '%d seconds' AS TIMESTAMPTZ))",
+			lakeName, snapshotOlderThanSec,
+		),
+		fmt.Sprintf("CALL ducklake_cleanup_old_files('%s', cleanup_all => true)", lakeName),
+		fmt.Sprintf("CALL ducklake_delete_orphaned_files('%s', cleanup_all => true)", lakeName),
+	}
+}
+
+// RunVolumeMaintenance expires old snapshots and deletes obsolete parquet
+// files on the given volume's lake. Without this, DELETEs performed by
+// tiering (move source delete, final-volume TTL expire) only mark files
+// obsolete in the DuckLake catalog while the objects stay on disk/S3
+// (issue #882 follow-up: cold physical space was never reclaimed because
+// the writer CompactionService only maintains the writer lake).
+func (tsm *TieredStorageManager) RunVolumeMaintenance(vol *Volume, snapshotOlderThanSec int) error {
+	locker := tsm.hotCatalogLocker(vol)
+
+	logger.Info("TieredStorageManager: Running volume maintenance",
+		"volume", vol.Name,
+		"lake", vol.LakeName,
+		"snapshot_older_than_sec", snapshotOlderThanSec)
+
+	var firstErr error
+	for _, stmt := range volumeMaintenanceSQL(vol.LakeName, snapshotOlderThanSec) {
+		if _, err := execWithRetry(
+			tsm.db,
+			tieringMaxRetries,
+			tieringBaseBackoff,
+			locker,
+			stmt,
+		); err != nil {
+			logger.Warn("TieredStorageManager: Volume maintenance step failed",
+				"volume", vol.Name,
+				"lake", vol.LakeName,
+				"sql", stmt,
+				"error", err)
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+
+	if firstErr == nil {
+		logger.Info("TieredStorageManager: Volume maintenance completed",
+			"volume", vol.Name,
+			"lake", vol.LakeName)
+	}
+	return firstErr
+}
+
 func (tsm *TieredStorageManager) hotCatalogLocker(srcVol *Volume) CatalogLocker {
 	if tsm.primaryVolume != nil && srcVol.LakeName == tsm.primaryVolume.LakeName {
 		return tsm.catalogLocker

--- a/src/storage/ducklake/volume_maintenance_test.go
+++ b/src/storage/ducklake/volume_maintenance_test.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package ducklake
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVolumeMaintenanceSQL(t *testing.T) {
+	stmts := volumeMaintenanceSQL("homer_lake_cold", 1800)
+	if len(stmts) != 3 {
+		t.Fatalf("expected 3 maintenance statements, got %d", len(stmts))
+	}
+	if !strings.Contains(stmts[0], "ducklake_expire_snapshots('homer_lake_cold'") {
+		t.Errorf("first statement must expire snapshots, got: %s", stmts[0])
+	}
+	if !strings.Contains(stmts[0], "INTERVAL '1800 seconds'") {
+		t.Errorf("expire must use configured window, got: %s", stmts[0])
+	}
+	if !strings.Contains(stmts[1], "ducklake_cleanup_old_files('homer_lake_cold', cleanup_all => true)") {
+		t.Errorf("second statement must cleanup old files, got: %s", stmts[1])
+	}
+	if !strings.Contains(stmts[2], "ducklake_delete_orphaned_files('homer_lake_cold', cleanup_all => true)") {
+		t.Errorf("third statement must delete orphaned files, got: %s", stmts[2])
+	}
+}
+
+func TestVolumeMaintenanceSQLDefaultWindow(t *testing.T) {
+	stmts := volumeMaintenanceSQL("homer_lake_hot", 0)
+	if !strings.Contains(stmts[0], "INTERVAL '3600 seconds'") {
+		t.Errorf("zero window must default to 3600s, got: %s", stmts[0])
+	}
+}

--- a/src/writer/tiering.go
+++ b/src/writer/tiering.go
@@ -28,6 +28,10 @@ type TieringConfig struct {
 	ConcurrentMoves  int
 	MoveOnStartup    bool
 	MoveFactor       float64 // Move data when volume fill ratio exceeds this value (0.0-1.0)
+	// SnapshotExpireSec is the snapshot retention window used when running
+	// DuckLake maintenance on tiered volumes after moves/expires (mirrors
+	// compaction.snapshot_expire_interval_sec; 0 = default 3600).
+	SnapshotExpireSec int
 }
 
 // TieringService manages automatic data tiering between storage volumes
@@ -187,12 +191,24 @@ func (ts *TieringService) runTieringCycle() {
 		}
 	}
 
-	// Cleanup empty partition directories after moving/expiring data
-	if totalMoved > 0 || totalExpired > 0 {
-		for _, vol := range volumes {
-			if vol.Type == ducklake.VolumeTypeLocal {
-				ts.cleanupEmptyPartitions(vol.Path)
-			}
+	// Tiering DELETEs (move source delete, final-volume TTL expire) only mark
+	// parquet files as deleted in the DuckLake catalog — the objects stay on
+	// disk/S3 until snapshots are expired and cleanup runs on that lake. The
+	// writer CompactionService only maintains the writer lake, so run
+	// per-volume maintenance every cycle: this also drains obsolete backlog
+	// from earlier cycles even when nothing moved this time (#882).
+	for _, vol := range volumes {
+		if err := ts.tieredStorage.RunVolumeMaintenance(vol, ts.config.SnapshotExpireSec); err != nil {
+			logger.Error("TieringService: Volume maintenance failed",
+				"volume", vol.Name,
+				"error", err)
+		}
+	}
+
+	// Cleanup empty partition directories after maintenance removed files
+	for _, vol := range volumes {
+		if vol.Type == ducklake.VolumeTypeLocal {
+			ts.cleanupEmptyPartitions(vol.Path)
 		}
 	}
 

--- a/src/writer/writer.go
+++ b/src/writer/writer.go
@@ -970,11 +970,12 @@ func (w *Writer) startTieringService() error {
 
 	// Create tiering service
 	tieringCfg := TieringConfig{
-		Enable:           policy.Enable,
-		CheckIntervalSec: policy.TTLMoveIntervalSec,
-		ConcurrentMoves:  policy.ConcurrentMoves,
-		MoveOnStartup:    policy.MoveOnStartup,
-		MoveFactor:       policy.MoveFactor,
+		Enable:            policy.Enable,
+		CheckIntervalSec:  policy.TTLMoveIntervalSec,
+		ConcurrentMoves:   policy.ConcurrentMoves,
+		MoveOnStartup:     policy.MoveOnStartup,
+		MoveFactor:        policy.MoveFactor,
+		SnapshotExpireSec: w.storageConfig.DuckLake.Compaction.SnapshotExpireIntervalSec,
 	}
 	if tieringCfg.CheckIntervalSec <= 0 {
 		tieringCfg.CheckIntervalSec = 3600 // default 1 hour


### PR DESCRIPTION
## Summary
Follow-up to #885 / [#882 comment](https://github.com/sipcapture/homer/issues/882#issuecomment-5056880763): cold partitions were expired logically, but obsolete parquet objects stayed in S3/RustFS and disk space was never reclaimed.

- Add `TieredStorageManager.RunVolumeMaintenance`: `ducklake_expire_snapshots` (window = `compaction.snapshot_expire_interval_sec`, default 3600s) + `ducklake_cleanup_old_files` + `ducklake_delete_orphaned_files` per tiered lake, on the shared tiered connection that already holds per-volume S3 secrets.
- `TieringService` runs maintenance for every volume each cycle — also drains pre-existing obsolete backlog when no new moves/expires happen (the reporter's current state).
- Wire `SnapshotExpireSec` from `compaction.snapshot_expire_interval_sec`.
- Docs: physical reclaim section in `STORAGE_POLICIES.md`.

Fixes #882

## Test plan
- [x] `go vet` / `go test ./writer/ ./storage/ducklake/`
- [ ] On the reporter setup: after next tiering cycle, `ducklake_data_file` obsolete rows are removed and RustFS usage drops to ~active size
- [ ] Logs show `TieredStorageManager: Running volume maintenance ... lake=homer_lake_cold`