### PR TITLE
chore: bump version to 11.0.299

### DIFF
--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.298"
+	VERSION_APPLICATION = "11.0.299"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
Version bump for release 11.0.299: ships #890 (physical space reclaim on tiered volumes, follow-up to #882).