### PR TITLE
feat(coordinator): surface data_extra.custom_headers as Results columns

### DIFF
--- a/src/coordinator/handlers/ip_alias_enrich.go
+++ b/src/coordinator/handlers/ip_alias_enrich.go
@@ -11,10 +11,20 @@ import (
 	logger "github.com/sipcapture/homer-core/src/utils/logging"
 )
 
-// enrichRowsWithIPAliases resolves src_ip/dst_ip into aliasSrc/aliasDst on each row.
-// Safe when aliasService is nil or the query fails (rows unchanged except skipped enrich).
+// enrichRowsWithIPAliases enriches each result row in place: it flattens
+// data_extra.custom_headers onto the row as top-level keys (so configured custom
+// SIP headers surface as selectable Results columns) and resolves src_ip/dst_ip
+// into aliasSrc/aliasDst. Safe when aliasService is nil or the query fails.
 func (h *SearchHandler) enrichRowsWithIPAliases(ctx context.Context, rows []map[string]interface{}) {
-	if h == nil || h.aliasService == nil || len(rows) == 0 {
+	if h == nil || len(rows) == 0 {
+		return
+	}
+	// Custom-header flattening is independent of the IP-alias service, so it runs
+	// for every search result regardless of alias configuration.
+	for i := range rows {
+		flattenRowCustomHeaders(rows[i])
+	}
+	if h.aliasService == nil {
 		return
 	}
 	m, err := h.aliasService.CachedIPAliasMap(ctx)
@@ -24,5 +34,32 @@ func (h *SearchHandler) enrichRowsWithIPAliases(ctx context.Context, rows []map[
 	}
 	for i := range rows {
 		services.EnrichRowIPAliases(m, rows[i])
+	}
+}
+
+// flattenRowCustomHeaders copies data_extra.custom_headers.<Name> onto the row as a
+// top-level "<Name>" key (without overwriting existing columns) so extracted custom
+// SIP headers (e.g. X-Call-Trace, X-Session-Id) become selectable Results-table columns via the
+// same row-key mechanism used for aliasSrc/aliasDst.
+func flattenRowCustomHeaders(row map[string]interface{}) {
+	if row == nil {
+		return
+	}
+	extra := parseDataExtraMap(row["data_extra"])
+	if extra == nil {
+		return
+	}
+	ch, ok := extra["custom_headers"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	for name, val := range ch {
+		if name == "" {
+			continue
+		}
+		if _, exists := row[name]; exists {
+			continue
+		}
+		row[name] = val
 	}
 }

--- a/src/coordinator/handlers/ip_alias_enrich_test.go
+++ b/src/coordinator/handlers/ip_alias_enrich_test.go
@@ -1,0 +1,153 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package handlers
+
+import (
+	"context"
+	"testing"
+)
+
+func TestFlattenRowCustomHeaders_stringDataExtra(t *testing.T) {
+	row := map[string]interface{}{
+		"method":     "INVITE",
+		"data_extra": `{"user_agent":"UA","custom_headers":{"X-Call-Trace":"trace-1","X-Session-Id":"sess-9"}}`,
+	}
+	flattenRowCustomHeaders(row)
+	if row["X-Call-Trace"] != "trace-1" {
+		t.Fatalf("X-Call-Trace: got %#v", row["X-Call-Trace"])
+	}
+	if row["X-Session-Id"] != "sess-9" {
+		t.Fatalf("X-Session-Id: got %#v", row["X-Session-Id"])
+	}
+	if row["method"] != "INVITE" {
+		t.Fatalf("built-in method must stay unchanged: %#v", row["method"])
+	}
+}
+
+func TestFlattenRowCustomHeaders_mapDataExtra(t *testing.T) {
+	row := map[string]interface{}{
+		"src_ip": "10.0.0.1",
+		"data_extra": map[string]interface{}{
+			"custom_headers": map[string]interface{}{
+				"P-Charging-Vector": "icid-value=abc",
+			},
+		},
+	}
+	flattenRowCustomHeaders(row)
+	if row["P-Charging-Vector"] != "icid-value=abc" {
+		t.Fatalf("P-Charging-Vector: got %#v", row["P-Charging-Vector"])
+	}
+}
+
+func TestFlattenRowCustomHeaders_doesNotOverwriteExisting(t *testing.T) {
+	row := map[string]interface{}{
+		"method": "INVITE",
+		"data_extra": map[string]interface{}{
+			"custom_headers": map[string]interface{}{
+				"method":        "should-not-win",
+				"X-Custom-Only": "ok",
+			},
+		},
+	}
+	flattenRowCustomHeaders(row)
+	if row["method"] != "INVITE" {
+		t.Fatalf("existing top-level key must not be overwritten: %#v", row["method"])
+	}
+	if row["X-Custom-Only"] != "ok" {
+		t.Fatalf("non-colliding header should flatten: %#v", row["X-Custom-Only"])
+	}
+}
+
+func TestFlattenRowCustomHeaders_skipsEmptyName(t *testing.T) {
+	row := map[string]interface{}{
+		"data_extra": map[string]interface{}{
+			"custom_headers": map[string]interface{}{
+				"":        "nope",
+				"X-Valid": "yes",
+			},
+		},
+	}
+	flattenRowCustomHeaders(row)
+	if _, has := row[""]; has {
+		t.Fatal("empty header name must not create a top-level key")
+	}
+	if row["X-Valid"] != "yes" {
+		t.Fatalf("X-Valid: got %#v", row["X-Valid"])
+	}
+}
+
+func TestFlattenRowCustomHeaders_noopCases(t *testing.T) {
+	flattenRowCustomHeaders(nil) // must not panic
+
+	row := map[string]interface{}{"method": "BYE"}
+	flattenRowCustomHeaders(row)
+	if len(row) != 1 || row["method"] != "BYE" {
+		t.Fatalf("missing data_extra must leave row unchanged: %#v", row)
+	}
+
+	row = map[string]interface{}{
+		"data_extra": `{"user_agent":"UA"}`,
+	}
+	flattenRowCustomHeaders(row)
+	if _, has := row["user_agent"]; has {
+		t.Fatal("non-custom_headers fields must not be flattened")
+	}
+
+	row = map[string]interface{}{
+		"data_extra": map[string]interface{}{
+			"custom_headers": "not-a-map",
+		},
+	}
+	flattenRowCustomHeaders(row)
+	if len(row) != 1 {
+		t.Fatalf("invalid custom_headers type must be ignored: %#v", row)
+	}
+}
+
+func TestEnrichRowsWithIPAliases_flattensWithoutAliasService(t *testing.T) {
+	h := &SearchHandler{} // aliasService nil
+	rows := []map[string]interface{}{
+		{
+			"uuid":       "1",
+			"data_extra": `{"custom_headers":{"X-icc_uuid":"icc-42"}}`,
+		},
+	}
+	h.enrichRowsWithIPAliases(context.Background(), rows)
+	if rows[0]["X-icc_uuid"] != "icc-42" {
+		t.Fatalf("custom header flatten must run without alias service: %#v", rows[0]["X-icc_uuid"])
+	}
+}
+
+func TestGetColumns_unionsKeysAcrossRows(t *testing.T) {
+	if got := getColumns(nil); got != nil {
+		t.Fatalf("empty input: got %#v", got)
+	}
+	if got := getColumns([]map[string]interface{}{}); got != nil {
+		t.Fatalf("zero rows: got %#v", got)
+	}
+
+	results := []map[string]interface{}{
+		{"uuid": "1", "method": "INVITE"},
+		{"uuid": "2", "method": "200", "aliasSrc": "gw", "X-Call-Trace": "t1"},
+		{"uuid": "3", "aliasDst": "peer"},
+	}
+	cols := getColumns(results)
+	want := map[string]bool{
+		"uuid": true, "method": true, "aliasSrc": true, "aliasDst": true, "X-Call-Trace": true,
+	}
+	if len(cols) != len(want) {
+		t.Fatalf("column count: got %d (%v), want %d", len(cols), cols, len(want))
+	}
+	seen := make(map[string]bool, len(cols))
+	for _, c := range cols {
+		if !want[c] {
+			t.Fatalf("unexpected column %q in %v", c, cols)
+		}
+		if seen[c] {
+			t.Fatalf("duplicate column %q in %v", c, cols)
+		}
+		seen[c] = true
+	}
+}

--- a/src/coordinator/handlers/search.go
+++ b/src/coordinator/handlers/search.go
@@ -533,9 +533,19 @@ func getColumns(results []map[string]interface{}) []string {
 	if len(results) == 0 {
 		return nil
 	}
+	// Union of keys across all rows (not just results[0]) so columns present on
+	// only some rows — enriched custom headers, aliasSrc/aliasDst — are not dropped
+	// just because the first row happens to lack them.
+	seen := make(map[string]struct{}, len(results[0]))
 	columns := make([]string, 0, len(results[0]))
-	for k := range results[0] {
-		columns = append(columns, k)
+	for _, row := range results {
+		for k := range row {
+			if _, ok := seen[k]; ok {
+				continue
+			}
+			seen[k] = struct{}{}
+			columns = append(columns, k)
+		}
 	}
 	return columns
 }


### PR DESCRIPTION
## Summary
Make configured `data_extra.custom_headers` selectable as **Results-table columns**.

Homer extracts custom SIP headers into `data_extra.custom_headers` and exposes them as search fields, but the Results grid only offers a fixed set of built-in columns, so the extracted values can't be shown as columns.

## Changes
- **`ip_alias_enrich.go`** — during result enrichment, flatten `data_extra.custom_headers.<Name>` onto each row as a top-level `<Name>` key (without overwriting existing keys), using the same row-key mechanism already used for `aliasSrc`/`aliasDst`. Runs independently of the IP-alias service.
- **`search.go`** — `getColumns` now unions keys across **all** rows instead of reading only `results[0]`, so columns present on only some rows (the flattened headers, and `aliasSrc`/`aliasDst`) aren't dropped when the first row happens to lack them.

## Behavior / compatibility
- Purely additive: no built-in columns change; existing responses gain extra keys only when `custom_headers` are present. Existing top-level keys are never overwritten.

## Testing
Verified on a live 11.0.298 deployment: extracted headers appear as selectable Results columns and populate correctly. Happy to add unit tests for `flattenRowCustomHeaders` and the `getColumns` union if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
