### PR TITLE
fix(coordinator): render SQL NULL alias fields as empty, not "<nil>"

### DIFF
--- a/src/coordinator/services/alias_service.go
+++ b/src/coordinator/services/alias_service.go
@@ -333,6 +333,11 @@ func rowGetStringCI(row map[string]interface{}, want string) (string, bool) {
 		return "", false
 	}
 	switch s := v.(type) {
+	case nil:
+		// A SQL NULL must read back as empty, not the literal "<nil>" that
+		// fmt.Sprint(nil) produces (which the UI then renders as a broken
+		// <img src="<nil>"> for alias custom_image, and as "<nil>" tag chips).
+		return "", true
 	case string:
 		return s, true
 	default:

--- a/src/coordinator/services/alias_service_test.go
+++ b/src/coordinator/services/alias_service_test.go
@@ -93,3 +93,53 @@ func TestMapRowToAlias_StatusFromInt32(t *testing.T) {
 		t.Fatalf("mapRowToAlias dropped fields: %+v", got)
 	}
 }
+
+// TestRowGetStringCI_NilSQLNull regresses the broken <img src="<nil>"> /
+// "<nil>" tag-chip bug: a present map key with a nil value (SQL NULL from
+// DuckDB) must return ("", true), never fmt.Sprint(nil) == "<nil>".
+func TestRowGetStringCI_NilSQLNull(t *testing.T) {
+	row := map[string]interface{}{
+		"custom_image": nil,
+		"tag1":         nil,
+		"alias":        "gw",
+	}
+	got, ok := rowGetStringCI(row, "custom_image")
+	if !ok || got != "" {
+		t.Fatalf("custom_image nil: got (%q, %v), want (\"\", true)", got, ok)
+	}
+	got, ok = rowGetStringCI(row, "tag1")
+	if !ok || got != "" {
+		t.Fatalf("tag1 nil: got (%q, %v), want (\"\", true)", got, ok)
+	}
+	got, ok = rowGetStringCI(row, "alias")
+	if !ok || got != "gw" {
+		t.Fatalf("alias string: got (%q, %v), want (\"gw\", true)", got, ok)
+	}
+	got, ok = rowGetStringCI(row, "missing")
+	if ok || got != "" {
+		t.Fatalf("missing key: got (%q, %v), want (\"\", false)", got, ok)
+	}
+}
+
+func TestMapRowToAlias_NullOptionalFields(t *testing.T) {
+	row := map[string]interface{}{
+		"guid":         "g1",
+		"alias":        "edge-1",
+		"ip":           "10.0.0.1",
+		"port":         int32(5060),
+		"mask":         int32(32),
+		"status":       int32(1),
+		"custom_image": nil,
+		"tag1":         nil,
+		"tag2":         nil,
+		"tag3":         nil,
+		"tag4":         nil,
+	}
+	got := mapRowToAlias(row)
+	if got.CustomImage != "" || got.Tag1 != "" || got.Tag2 != "" || got.Tag3 != "" || got.Tag4 != "" {
+		t.Fatalf("NULL optional fields must map to empty strings, got %+v", got)
+	}
+	if got.CustomImage == "<nil>" || got.Tag1 == "<nil>" {
+		t.Fatal("must not serialize SQL NULL as the literal \"<nil>\"")
+	}
+}


### PR DESCRIPTION
## Summary
Render SQL `NULL` alias fields as empty instead of the literal string `"<nil>"`.

## Problem
`rowGetStringCI` fell through to `default:` for a `nil` value and returned `fmt.Sprint(nil)`, which is the literal `"<nil>"`. For alias rows this reaches the UI as `custom_image = "<nil>"` (rendered as a broken `<img src="<nil>">`) and as `"<nil>"` tag chips. It affects any alias whose `custom_image`/`tag1..4` (or other nullable string field) is `NULL` — e.g. rows created without those optional fields.

## Fix
Add an explicit `case nil:` to `rowGetStringCI` that returns `""`, so `NULL`/absent fields render cleanly ("—" in the UI).

## Testing
Verified on a live 11.0.298 deployment: aliases with NULL `custom_image`/tags now return empty strings via `/api/v4/aliases` and render without the broken-image icon; no other field behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
