### PR TITLE
chore: bump version to 11.0.300

### DIFF
--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.299"
+	VERSION_APPLICATION = "11.0.300"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Bump `VERSION_APPLICATION` to **11.0.300** after merging custom-header Results columns (#892) and SQL NULL alias field render fix (#893).

## Test plan
- [x] Confirm `src/version.go` shows `11.0.300`
- [x] CI Compile Check passes