### PR TITLE
fix(correlation): expand call legs transitively

### DIFF
--- a/examples/lua/correlation/sip_call.lua
+++ b/examples/lua/correlation/sip_call.lua
@@ -6,7 +6,19 @@
 --   Given the base session_ids the user clicked on in the UI, find every
 --   other session_id that shares the same "correlation id" (aka x_call_id
 --   / X-CID / B2B peer call-id) and return it so the transaction view can
---   merge both legs of a B2B call.
+--   merge every leg of a B2B call.
+--
+--   Expansion is TRANSITIVE. Chained B2BUAs produce a chain of legs, where
+--   each leg's x_call_id names its parent:
+--
+--       leg_a <- leg_b <- leg_c
+--             <- leg_d <- leg_e
+--
+--   A single expansion pass only reaches the immediate neighbours of the
+--   rows it was handed, so the set of legs returned would depend on which
+--   leg the user happened to open (opening leg_a finds 4 of the 5 above,
+--   opening leg_e finds 2). Expanding to a fixed point means every leg
+--   resolves the whole call, no matter where the user entered it.
 --
 -- INPUTS
 --   data  — table<row>  rows returned by the base SELECT on
@@ -48,6 +60,11 @@
 --   HashTable(op, key, val)  op   = "get" | "set" | "del"  (small KV cache)
 -- ============================================================================
 
+-- Hard cap on expansion rounds. Each round costs exactly one executeSQL
+-- call, so this stays well inside the engine's MaxSQLCalls budget (default
+-- 16). Chains deeper than this degrade to a partial merge, never an error.
+local MAX_ROUNDS = 5
+
 -- strip_b2b removes the "_b2b-NNN" suffix some B2BUAs append to Call-ID
 -- so that A-leg and B-leg ids compare equal.
 local function strip_b2b(id)
@@ -57,14 +74,6 @@ end
 
 local function is_non_empty(s)
   return type(s) == "string" and #s > 0
-end
-
--- add inserts s into out/seen if it is a new, non-empty string.
-local function add(out, seen, s)
-  if not is_non_empty(s) then return end
-  if seen[s] then return end
-  seen[s] = true
-  out[#out + 1] = s
 end
 
 -- quote_list SQL-quotes and joins a Lua array of strings into
@@ -77,10 +86,10 @@ local function quote_list(arr)
   return table.concat(parts, ",")
 end
 
--- collect_correlation_ids reads the "correlation id" from a row. In
--- homer-core the historical ClickHouse column "correlation_id" lives
--- inside the data_extra JSON as x_call_id (see hep_adapter.go). We try a
--- handful of common keys so user-customised schemas keep working.
+-- row_correlation_id reads the "correlation id" from a row. In homer-core
+-- the historical ClickHouse column "correlation_id" lives inside the
+-- data_extra JSON as x_call_id (see hep_adapter.go). We try a handful of
+-- common keys so user-customised schemas keep working.
 local function row_correlation_id(row)
   if type(row) ~= "table" then return nil end
   local v = row["correlation_id"]
@@ -110,7 +119,7 @@ end
 
 function correlate(data, nodes, ctx)
   local extras = {}
-  local seen   = {}
+  local seen   = {}   -- every id already emitted, so extras stay unique
 
   if type(data) ~= "table" or #data == 0 then
     return extras
@@ -122,94 +131,96 @@ function correlate(data, nodes, ctx)
   local from_ms = (type(ctx) == "table" and tonumber(ctx.time_from)) or 0
   local to_ms   = (type(ctx) == "table" and tonumber(ctx.time_to))   or 0
 
-  -- 1. Gather the two sets we want to correlate on:
-  --      base_sids = session_ids the user asked for (via row.session_id)
-  --      corr_ids  = correlation ids seen inside those base rows
-  local base_sids = {}
-  local seen_sid  = {}
-  local corr_ids  = {}
-  local seen_cid  = {}
+  -- known    = every id discovered so far.
+  -- frontier = the ids still to be expanded in the next round.
+  --
+  -- session_ids and correlation ids share one namespace: in a B2B chain a
+  -- leg's x_call_id IS another leg's session_id. So both go into the same
+  -- set and the graph is walked undirected, which is what lets any leg
+  -- reach the whole call.
+  local known    = {}
+  local frontier = {}
 
-  for i = 1, #data do
-    local row = data[i]
-    if type(row) == "table" then
-      local sid = row["session_id"] or row["call_id"]
-      if is_non_empty(sid) and not seen_sid[sid] then
-        seen_sid[sid] = true
-        base_sids[#base_sids + 1] = sid
-      end
-
-      local cid = row_correlation_id(row)
-      local stripped = strip_b2b(cid)
-      if is_non_empty(stripped) and not seen_cid[stripped] then
-        seen_cid[stripped] = true
-        corr_ids[#corr_ids + 1] = stripped
-        -- A common layout is: A-leg Call-ID equals B-leg correlation_id
-        -- and vice-versa. Emit the stripped id immediately so even a
-        -- trivial dataset (no DB) returns something useful.
-        add(extras, seen, stripped)
-      end
+  local function discover(id)
+    local s = strip_b2b(id)
+    if not is_non_empty(s) then return end
+    if known[s] then return end
+    known[s] = true
+    frontier[#frontier + 1] = s
+    if not seen[s] then
+      seen[s] = true
+      extras[#extras + 1] = s
     end
   end
 
-  -- 2. Ask the DB for every other session_id that references any of our
-  --    base session_ids OR any of the collected correlation_ids.
-  --    executeSQL is the most explicit variant; getDataByField is the
-  --    safer typed shortcut (see the commented-out version below).
-  if #base_sids == 0 and #corr_ids == 0 then
+  -- Round 0: seed from the rows the base SELECT already returned. Emitting
+  -- the correlation ids immediately means even a trivial dataset (no DB)
+  -- returns something useful.
+  for i = 1, #data do
+    local row = data[i]
+    if type(row) == "table" then
+      discover(row["session_id"] or row["call_id"])
+      discover(row_correlation_id(row))
+    end
+  end
+
+  if #frontier == 0 then
     return extras
   end
-
-  local filters = {}
-  if #base_sids > 0 then
-    -- Other dialogs whose correlation_id points at one of our sids.
-    filters[#filters + 1] =
-      "json_extract_string(data_extra, '$.x_call_id') IN (" ..
-      quote_list(base_sids) .. ")"
-  end
-  if #corr_ids > 0 then
-    -- Dialogs whose own session_id is one of our correlation_ids.
-    filters[#filters + 1] = "session_id IN (" .. quote_list(corr_ids) .. ")"
-    -- Or dialogs that share the same correlation_id (chained B2BUAs).
-    filters[#filters + 1] =
-      "json_extract_string(data_extra, '$.x_call_id') IN (" ..
-      quote_list(corr_ids) .. ")"
-  end
-
-  local sql = "SELECT DISTINCT session_id FROM homer_lake.hep_proto_1_call" ..
-              " WHERE (" .. table.concat(filters, " OR ") .. ")"
 
   -- Bound the search to the user's visible timerange when available.
   -- Without this bound a busy DuckLake would scan every historical
   -- partition, which is almost never what the UI wants.
+  local time_clause = ""
   if from_ms > 0 and to_ms > 0 and from_ms < to_ms then
-    sql = sql ..
+    time_clause =
       " AND timestamp >= (to_timestamp(" .. tostring(from_ms) .. " / 1000.0) AT TIME ZONE 'UTC')" ..
       " AND timestamp <= (to_timestamp(" .. tostring(to_ms)   .. " / 1000.0) AT TIME ZONE 'UTC')"
   end
 
-  local rows = executeSQL(sql)
-  if rows == nil or #rows == 0 then
-    return extras
-  end
+  -- Walk outwards until a round adds nothing new (fixed point) or the
+  -- round cap is reached.
+  for _ = 1, MAX_ROUNDS do
+    local ids = quote_list(frontier)
+    frontier = {}
 
-  for i = 1, #rows do
-    add(extras, seen, rows[i].session_id)
+    -- Both directions of the relation in one query:
+    --   session_id IN (...)  -> legs whose own Call-ID we already know of
+    --   x_call_id  IN (...)  -> legs pointing AT something we know
+    --
+    -- x_call_id is selected as well as filtered on: that is what makes
+    -- iteration possible, since a newly found leg's parent has to be known
+    -- before the next round can expand it.
+    local sql =
+      "SELECT DISTINCT session_id," ..
+      " json_extract_string(data_extra, '$.x_call_id') AS x_call_id" ..
+      " FROM homer_lake.hep_proto_1_call" ..
+      " WHERE (session_id IN (" .. ids .. ")" ..
+      " OR json_extract_string(data_extra, '$.x_call_id') IN (" .. ids .. "))" ..
+      time_clause
+
+    local rows = executeSQL(sql)
+    if rows == nil or #rows == 0 then
+      break
+    end
+
+    for i = 1, #rows do
+      discover(rows[i].session_id)
+      discover(rows[i].x_call_id)
+    end
+
+    if #frontier == 0 then
+      break
+    end
   end
 
   -- -------------------------------------------------------------------------
-  -- ALTERNATIVE 1: use the typed helper (safer, no hand-written SQL).
-  --   -- from_ms/to_ms are already read from ctx at the top of the script.
-  --   local rows = getDataByField(1, "call", "session_id", corr_ids, from_ms, to_ms)
-  --   for i = 1, #(rows or {}) do
-  --     add(extras, seen, rows[i].session_id)
-  --   end
-  --
-  -- ALTERNATIVE 2: correlate by a top-level column if your deployment
-  -- maps X-CID to a real column named "correlation_id":
-  --   local sql = "SELECT DISTINCT session_id FROM homer_lake.hep_proto_1_call" ..
-  --               " WHERE correlation_id IN (" .. quote_list(base_sids) .. ")"
-  --   local rows = executeSQL(sql)
+  -- ALTERNATIVE: correlate by a top-level column if your deployment maps
+  -- X-CID to a real column named "correlation_id":
+  --   local sql = "SELECT DISTINCT session_id, correlation_id" ..
+  --               " FROM homer_lake.hep_proto_1_call" ..
+  --               " WHERE correlation_id IN (" .. ids .. ")" ..
+  --               " OR session_id IN (" .. ids .. ")"
   -- -------------------------------------------------------------------------
 
   return extras

--- a/src/coordinator/correlation_seed.go
+++ b/src/coordinator/correlation_seed.go
@@ -53,7 +53,14 @@ var legacySeedSHA256 = map[string][]string{
 	// sip_call.lua before 11.0.242: row_correlation_id only looked at
 	// top-level columns, so B-leg -> A-leg correlation never found the
 	// x_call_id stored inside the data_extra JSON.
-	"call": {"d22553459a7bd3e7ad05d68d56e9cd0fbf0343d430003995c0e356104e8559a3"},
+	"call": {
+		"d22553459a7bd3e7ad05d68d56e9cd0fbf0343d430003995c0e356104e8559a3",
+		// sip_call.lua before 11.0.301: correlate() expanded exactly one
+		// hop, so a chain of B2B legs only partially merged and the result
+		// depended on which leg the user opened. Now expands to a fixed
+		// point.
+		"4b4d1007faa5067da4ba18f682defa09be4b840ff2e3292ef9c75c59d29831f2",
+	},
 }
 
 // seedDefaultCorrelationScript inserts the bundled correlation templates

--- a/src/coordinator/correlation_seed_lua/sip_call.lua
+++ b/src/coordinator/correlation_seed_lua/sip_call.lua
@@ -6,7 +6,19 @@
 --   Given the base session_ids the user clicked on in the UI, find every
 --   other session_id that shares the same "correlation id" (aka x_call_id
 --   / X-CID / B2B peer call-id) and return it so the transaction view can
---   merge both legs of a B2B call.
+--   merge every leg of a B2B call.
+--
+--   Expansion is TRANSITIVE. Chained B2BUAs produce a chain of legs, where
+--   each leg's x_call_id names its parent:
+--
+--       leg_a <- leg_b <- leg_c
+--             <- leg_d <- leg_e
+--
+--   A single expansion pass only reaches the immediate neighbours of the
+--   rows it was handed, so the set of legs returned would depend on which
+--   leg the user happened to open (opening leg_a finds 4 of the 5 above,
+--   opening leg_e finds 2). Expanding to a fixed point means every leg
+--   resolves the whole call, no matter where the user entered it.
 --
 -- INPUTS
 --   data  — table<row>  rows returned by the base SELECT on
@@ -48,6 +60,11 @@
 --   HashTable(op, key, val)  op   = "get" | "set" | "del"  (small KV cache)
 -- ============================================================================
 
+-- Hard cap on expansion rounds. Each round costs exactly one executeSQL
+-- call, so this stays well inside the engine's MaxSQLCalls budget (default
+-- 16). Chains deeper than this degrade to a partial merge, never an error.
+local MAX_ROUNDS = 5
+
 -- strip_b2b removes the "_b2b-NNN" suffix some B2BUAs append to Call-ID
 -- so that A-leg and B-leg ids compare equal.
 local function strip_b2b(id)
@@ -57,14 +74,6 @@ end
 
 local function is_non_empty(s)
   return type(s) == "string" and #s > 0
-end
-
--- add inserts s into out/seen if it is a new, non-empty string.
-local function add(out, seen, s)
-  if not is_non_empty(s) then return end
-  if seen[s] then return end
-  seen[s] = true
-  out[#out + 1] = s
 end
 
 -- quote_list SQL-quotes and joins a Lua array of strings into
@@ -77,10 +86,10 @@ local function quote_list(arr)
   return table.concat(parts, ",")
 end
 
--- collect_correlation_ids reads the "correlation id" from a row. In
--- homer-core the historical ClickHouse column "correlation_id" lives
--- inside the data_extra JSON as x_call_id (see hep_adapter.go). We try a
--- handful of common keys so user-customised schemas keep working.
+-- row_correlation_id reads the "correlation id" from a row. In homer-core
+-- the historical ClickHouse column "correlation_id" lives inside the
+-- data_extra JSON as x_call_id (see hep_adapter.go). We try a handful of
+-- common keys so user-customised schemas keep working.
 local function row_correlation_id(row)
   if type(row) ~= "table" then return nil end
   local v = row["correlation_id"]
@@ -110,7 +119,7 @@ end
 
 function correlate(data, nodes, ctx)
   local extras = {}
-  local seen   = {}
+  local seen   = {}   -- every id already emitted, so extras stay unique
 
   if type(data) ~= "table" or #data == 0 then
     return extras
@@ -122,94 +131,96 @@ function correlate(data, nodes, ctx)
   local from_ms = (type(ctx) == "table" and tonumber(ctx.time_from)) or 0
   local to_ms   = (type(ctx) == "table" and tonumber(ctx.time_to))   or 0
 
-  -- 1. Gather the two sets we want to correlate on:
-  --      base_sids = session_ids the user asked for (via row.session_id)
-  --      corr_ids  = correlation ids seen inside those base rows
-  local base_sids = {}
-  local seen_sid  = {}
-  local corr_ids  = {}
-  local seen_cid  = {}
+  -- known    = every id discovered so far.
+  -- frontier = the ids still to be expanded in the next round.
+  --
+  -- session_ids and correlation ids share one namespace: in a B2B chain a
+  -- leg's x_call_id IS another leg's session_id. So both go into the same
+  -- set and the graph is walked undirected, which is what lets any leg
+  -- reach the whole call.
+  local known    = {}
+  local frontier = {}
 
-  for i = 1, #data do
-    local row = data[i]
-    if type(row) == "table" then
-      local sid = row["session_id"] or row["call_id"]
-      if is_non_empty(sid) and not seen_sid[sid] then
-        seen_sid[sid] = true
-        base_sids[#base_sids + 1] = sid
-      end
-
-      local cid = row_correlation_id(row)
-      local stripped = strip_b2b(cid)
-      if is_non_empty(stripped) and not seen_cid[stripped] then
-        seen_cid[stripped] = true
-        corr_ids[#corr_ids + 1] = stripped
-        -- A common layout is: A-leg Call-ID equals B-leg correlation_id
-        -- and vice-versa. Emit the stripped id immediately so even a
-        -- trivial dataset (no DB) returns something useful.
-        add(extras, seen, stripped)
-      end
+  local function discover(id)
+    local s = strip_b2b(id)
+    if not is_non_empty(s) then return end
+    if known[s] then return end
+    known[s] = true
+    frontier[#frontier + 1] = s
+    if not seen[s] then
+      seen[s] = true
+      extras[#extras + 1] = s
     end
   end
 
-  -- 2. Ask the DB for every other session_id that references any of our
-  --    base session_ids OR any of the collected correlation_ids.
-  --    executeSQL is the most explicit variant; getDataByField is the
-  --    safer typed shortcut (see the commented-out version below).
-  if #base_sids == 0 and #corr_ids == 0 then
+  -- Round 0: seed from the rows the base SELECT already returned. Emitting
+  -- the correlation ids immediately means even a trivial dataset (no DB)
+  -- returns something useful.
+  for i = 1, #data do
+    local row = data[i]
+    if type(row) == "table" then
+      discover(row["session_id"] or row["call_id"])
+      discover(row_correlation_id(row))
+    end
+  end
+
+  if #frontier == 0 then
     return extras
   end
-
-  local filters = {}
-  if #base_sids > 0 then
-    -- Other dialogs whose correlation_id points at one of our sids.
-    filters[#filters + 1] =
-      "json_extract_string(data_extra, '$.x_call_id') IN (" ..
-      quote_list(base_sids) .. ")"
-  end
-  if #corr_ids > 0 then
-    -- Dialogs whose own session_id is one of our correlation_ids.
-    filters[#filters + 1] = "session_id IN (" .. quote_list(corr_ids) .. ")"
-    -- Or dialogs that share the same correlation_id (chained B2BUAs).
-    filters[#filters + 1] =
-      "json_extract_string(data_extra, '$.x_call_id') IN (" ..
-      quote_list(corr_ids) .. ")"
-  end
-
-  local sql = "SELECT DISTINCT session_id FROM homer_lake.hep_proto_1_call" ..
-              " WHERE (" .. table.concat(filters, " OR ") .. ")"
 
   -- Bound the search to the user's visible timerange when available.
   -- Without this bound a busy DuckLake would scan every historical
   -- partition, which is almost never what the UI wants.
+  local time_clause = ""
   if from_ms > 0 and to_ms > 0 and from_ms < to_ms then
-    sql = sql ..
+    time_clause =
       " AND timestamp >= (to_timestamp(" .. tostring(from_ms) .. " / 1000.0) AT TIME ZONE 'UTC')" ..
       " AND timestamp <= (to_timestamp(" .. tostring(to_ms)   .. " / 1000.0) AT TIME ZONE 'UTC')"
   end
 
-  local rows = executeSQL(sql)
-  if rows == nil or #rows == 0 then
-    return extras
-  end
+  -- Walk outwards until a round adds nothing new (fixed point) or the
+  -- round cap is reached.
+  for _ = 1, MAX_ROUNDS do
+    local ids = quote_list(frontier)
+    frontier = {}
 
-  for i = 1, #rows do
-    add(extras, seen, rows[i].session_id)
+    -- Both directions of the relation in one query:
+    --   session_id IN (...)  -> legs whose own Call-ID we already know of
+    --   x_call_id  IN (...)  -> legs pointing AT something we know
+    --
+    -- x_call_id is selected as well as filtered on: that is what makes
+    -- iteration possible, since a newly found leg's parent has to be known
+    -- before the next round can expand it.
+    local sql =
+      "SELECT DISTINCT session_id," ..
+      " json_extract_string(data_extra, '$.x_call_id') AS x_call_id" ..
+      " FROM homer_lake.hep_proto_1_call" ..
+      " WHERE (session_id IN (" .. ids .. ")" ..
+      " OR json_extract_string(data_extra, '$.x_call_id') IN (" .. ids .. "))" ..
+      time_clause
+
+    local rows = executeSQL(sql)
+    if rows == nil or #rows == 0 then
+      break
+    end
+
+    for i = 1, #rows do
+      discover(rows[i].session_id)
+      discover(rows[i].x_call_id)
+    end
+
+    if #frontier == 0 then
+      break
+    end
   end
 
   -- -------------------------------------------------------------------------
-  -- ALTERNATIVE 1: use the typed helper (safer, no hand-written SQL).
-  --   -- from_ms/to_ms are already read from ctx at the top of the script.
-  --   local rows = getDataByField(1, "call", "session_id", corr_ids, from_ms, to_ms)
-  --   for i = 1, #(rows or {}) do
-  --     add(extras, seen, rows[i].session_id)
-  --   end
-  --
-  -- ALTERNATIVE 2: correlate by a top-level column if your deployment
-  -- maps X-CID to a real column named "correlation_id":
-  --   local sql = "SELECT DISTINCT session_id FROM homer_lake.hep_proto_1_call" ..
-  --               " WHERE correlation_id IN (" .. quote_list(base_sids) .. ")"
-  --   local rows = executeSQL(sql)
+  -- ALTERNATIVE: correlate by a top-level column if your deployment maps
+  -- X-CID to a real column named "correlation_id":
+  --   local sql = "SELECT DISTINCT session_id, correlation_id" ..
+  --               " FROM homer_lake.hep_proto_1_call" ..
+  --               " WHERE correlation_id IN (" .. ids .. ")" ..
+  --               " OR session_id IN (" .. ids .. ")"
   -- -------------------------------------------------------------------------
 
   return extras

--- a/src/coordinator/correlation_seed_test.go
+++ b/src/coordinator/correlation_seed_test.go
@@ -14,11 +14,16 @@ import (
 	"encoding/hex"
 	"fmt"
 	"path/filepath"
+	"reflect"
+	"regexp"
+	"sort"
 	"strings"
 	"testing"
 
 	_ "github.com/duckdb/duckdb-go/v2"
+	"github.com/sipcapture/homer-core/src/config"
 	"github.com/sipcapture/homer-core/src/coordinator/services"
+	"github.com/sipcapture/homer-core/src/scripting/correlation"
 )
 
 // openTestSettingsDB opens a fresh file-backed DuckDB (file-backed so the
@@ -306,4 +311,105 @@ func safeSlice(s string, lo, hi int) string {
 		return ""
 	}
 	return s[lo:hi]
+}
+
+// seedChainGraph models a multi-hop B2B call as leg -> x_call_id (its parent).
+// leg_a is the first leg and has no parent:
+//
+//	leg_a <- leg_b <- leg_c
+//	      <- leg_d <- leg_e
+var seedChainGraph = map[string]string{
+	"leg_a": "",
+	"leg_b": "leg_a",
+	"leg_c": "leg_b",
+	"leg_d": "leg_a",
+	"leg_e": "leg_d",
+}
+
+var seedQuotedID = regexp.MustCompile(`'([^']*)'`)
+
+// chainExecutor answers the bundled script's SELECT out of seedChainGraph:
+// every leg whose own id, or whose parent id, appears in the query's IN list.
+type chainExecutor struct{ calls int }
+
+func (c *chainExecutor) Query(_ context.Context, sql string) ([]map[string]interface{}, error) {
+	c.calls++
+	wanted := map[string]bool{}
+	for _, m := range seedQuotedID.FindAllStringSubmatch(sql, -1) {
+		if m[1] != "" {
+			wanted[m[1]] = true
+		}
+	}
+	var out []map[string]interface{}
+	for leg, parent := range seedChainGraph {
+		if wanted[leg] || (parent != "" && wanted[parent]) {
+			out = append(out, map[string]interface{}{"session_id": leg, "x_call_id": parent})
+		}
+	}
+	return out, nil
+}
+
+type staticScriptLoader struct{ items []correlation.LoadedScript }
+
+func (s *staticScriptLoader) LoadActiveCorrelation(context.Context) ([]correlation.LoadedScript, error) {
+	return s.items, nil
+}
+
+// TestDefaultCallSeedExpandsWholeChain runs the bundled sip_call.lua and asserts
+// that every leg of a multi-hop B2B chain resolves the whole call. A single-pass
+// expansion only reaches the immediate neighbours (opening leg_e would return
+// just leg_e and leg_d), so this is what pins the transitive behaviour.
+func TestDefaultCallSeedExpandsWholeChain(t *testing.T) {
+	cfg := config.CorrelationScriptingConfig{
+		Enable:          true,
+		SQLTimeoutMS:    500,
+		ScriptTimeoutMS: 3000,
+		MaxSQLCalls:     16,
+		MaxSQLRows:      64,
+		SyncIntervalSec: 0,
+	}
+	loader := &staticScriptLoader{items: []correlation.LoadedScript{
+		{GUID: "seed", HepID: 1, Profile: "call", Script: defaultCallCorrelationLua},
+	}}
+	want := []string{"leg_a", "leg_b", "leg_c", "leg_d", "leg_e"}
+
+	for leg, parent := range seedChainGraph {
+		exec := &chainExecutor{}
+		e := correlation.NewEngine(cfg, loader, exec, "homer_lake")
+		if e == nil {
+			t.Fatal("NewEngine returned nil despite Enable=true")
+		}
+		if err := e.ReloadFromDB(context.Background()); err != nil {
+			t.Fatalf("ReloadFromDB: %v", err)
+		}
+
+		dataExtra := "{}"
+		if parent != "" {
+			dataExtra = fmt.Sprintf(`{"x_call_id":%q}`, parent)
+		}
+		res := e.Correlate(context.Background(), correlation.CorrelationInput{
+			HepID:      1,
+			Profile:    "call",
+			ProtoType:  1,
+			EventType:  "call",
+			SessionIDs: []string{leg},
+			BaseRows: []map[string]interface{}{
+				{"session_id": leg, "data_extra": dataExtra},
+			},
+			TimeFrom: 1,
+			TimeTo:   2,
+		})
+		if res == nil {
+			t.Fatalf("start %s: nil correlation result", leg)
+		}
+
+		got := append([]string(nil), res.ExtraSessionIDs...)
+		sort.Strings(got)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("start %s: extras = %v, want %v", leg, got, want)
+		}
+		if exec.calls > cfg.MaxSQLCalls {
+			t.Errorf("start %s: %d executeSQL calls exceeds budget %d", leg, exec.calls, cfg.MaxSQLCalls)
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- Fixes incomplete B2B correlation for multi-hop call chains by expanding `sip_call.lua` to a fixed point (max 5 rounds) instead of a single hop.
- SELECT now returns `x_call_id` so each round can continue walking the parent/child graph in both directions.
- Adds the previous one-hop template hash to `legacySeedSHA256` so unmodified seeded scripts auto-upgrade while preserving status; operator-edited scripts are left alone.
- Pins the behaviour with `TestDefaultCallSeedExpandsWholeChain` (full 5-leg graph from every entry point).

Closes #895

Patch originally by Dominik Bay (@eimann).

## Test plan
- [x] `go test ./coordinator/ -run TestDefaultCallSeedExpandsWholeChain -count=1` (from `src/`)
- [x] `go test ./scripting/correlation/ ./coordinator/ -count=1`
- [ ] Manual: enable default call correlation seed, open a multi-B2BUA call from a leaf leg and confirm all legs appear in the transaction view