### PR TITLE
chore: bump version to 11.0.301

### DIFF
--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.300"
+	VERSION_APPLICATION = "11.0.301"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Bump `VERSION_APPLICATION` to `11.0.301` after the transitive correlation fix (#896) and aliases docs (#898).

## Test plan
- [x] Confirm `src/version.go` shows `11.0.301`
- [x] Package/CI workflows pick up the version from `VERSION_APPLICATION`