### PR TITLE
fix(security): validate LP event_type table identifiers (GHSA-94cf)

### DIFF
--- a/src/coordinator/handlers/search.go
+++ b/src/coordinator/handlers/search.go
@@ -351,7 +351,10 @@ func isLPProtoType(protoType int) bool {
 
 // lpTableForProfile decodes the "<schema>__<table>" profile encoding
 // emitted by services.LPProfileFor and returns the fully-qualified
-// DuckLake table name. When the profile lacks the separator we fall
+// DuckLake table name. Schema and table segments MUST be safe SQL
+// identifiers (see isSafeIdent); catalog/system names are rejected so
+// a crafted event_type cannot break out of the FROM clause
+// (GHSA-94cf-g6mg-6gv7). When the profile lacks the separator we fall
 // back to "main.<profile>" so legacy operators who hand-edited the
 // mapping_schema row still get a usable address.
 func lpTableForProfile(lakeName, profile string) (string, bool) {
@@ -360,12 +363,39 @@ func lpTableForProfile(lakeName, profile string) (string, bool) {
 		return "", false
 	}
 	sep := "__"
+	var schema, table string
 	if i := strings.Index(profile, sep); i > 0 && i+len(sep) < len(profile) {
-		schema := profile[:i]
-		table := profile[i+len(sep):]
-		return fmt.Sprintf("%s.%s.%s", lakeName, schema, table), true
+		schema = profile[:i]
+		table = profile[i+len(sep):]
+	} else {
+		schema = "main"
+		table = profile
 	}
-	return fmt.Sprintf("%s.main.%s", lakeName, profile), true
+	if !isSafeIdent(schema) || !isSafeIdent(table) {
+		return "", false
+	}
+	if isReservedLPSchema(schema) || isReservedLPTable(table) {
+		return "", false
+	}
+	return fmt.Sprintf("%s.%s.%s", lakeName, schema, table), true
+}
+
+// isReservedLPSchema reports schemas that must never be addressed via
+// the LP virtual mapping (system / catalog namespaces). Kept in sync
+// with the purge predicates in services.LPMappingSync.
+func isReservedLPSchema(schema string) bool {
+	switch strings.ToLower(schema) {
+	case "information_schema", "pg_catalog":
+		return true
+	default:
+		return false
+	}
+}
+
+// isReservedLPTable reports table names that must never be addressed
+// via the LP virtual mapping (DuckLake internal catalog tables).
+func isReservedLPTable(table string) bool {
+	return strings.HasPrefix(strings.ToLower(table), "ducklake_")
 }
 
 // getTableName returns the DuckLake table name based on proto_type and transaction_type

--- a/src/coordinator/handlers/transactions_sql_test.go
+++ b/src/coordinator/handlers/transactions_sql_test.go
@@ -189,6 +189,52 @@ func TestGetTableName_LPVirtualMapping(t *testing.T) {
 	}
 }
 
+func TestLpTableForProfile_RejectsInjection(t *testing.T) {
+	// GHSA-94cf-g6mg-6gv7: crafted event_type must never become part of FROM.
+	cases := []struct {
+		name    string
+		profile string
+	}{
+		{"union injection", "main__cpu UNION SELECT 1"},
+		{"comment injection", "main__cpu--"},
+		{"semicolon breakout", "main__cpu;DROP TABLE x"},
+		{"quote breakout", `main__cpu" OR 1=1`},
+		{"space in table", "main__cpu stats"},
+		{"dot path traversal", "main__cpu.secret"},
+		{"schema information_schema", "information_schema__tables"},
+		{"schema pg_catalog", "pg_catalog__pg_tables"},
+		{"ducklake catalog table", "main__ducklake_snapshot"},
+		{"legacy unsafe bare profile", "cpu;SELECT 1"},
+		{"empty", ""},
+		{"leading digit schema", "1main__cpu"},
+		{"leading digit table", "main__1cpu"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := lpTableForProfile("homer_lake", tc.profile)
+			if ok {
+				t.Fatalf("lpTableForProfile(%q) = %q, ok=true; want ok=false", tc.profile, got)
+			}
+		})
+	}
+}
+
+func TestBuildSearchSQLV4_LPRejectsUnsafeEventType(t *testing.T) {
+	req := SearchObjectV4{}
+	req.Filter.ProtoType = lpHepID
+	req.Filter.EventType = "main__cpu UNION SELECT password FROM users"
+	req.Timestamp.From = 1714400000000
+	req.Timestamp.To = 1714403600000
+
+	sql, err := buildSearchSQLV4("homer_lake", &req, nil)
+	if err == nil {
+		t.Fatalf("expected error for unsafe LP event_type, got SQL:\n%s", sql)
+	}
+	if sql != "" {
+		t.Fatalf("expected empty SQL on rejection, got:\n%s", sql)
+	}
+}
+
 func TestBuildSearchSQLV4_LPRoutesToTimeColumn(t *testing.T) {
 	req := SearchObjectV4{}
 	req.Filter.ProtoType = lpHepID

--- a/src/coordinator/handlers/transactions_v4.go
+++ b/src/coordinator/handlers/transactions_v4.go
@@ -2770,23 +2770,29 @@ func buildSearchSQLV4WithOpts(lakeName string, req *SearchObjectV4, virtualRules
 		protoType = 1
 	}
 	transactionType := req.Filter.EventType
-	tableName := getTableName(lakeName, protoType, transactionType)
 	// OTLP virtual mappings (traces / metrics / logs) use a different
 	// column layout than HEP — none of the SIP-specific columns
 	// (caller, callee, method, response_code, src_port, dst_port,
 	// node_id, payload, …) exist on otlp_*. Build SQL separately so we
 	// don't generate WHERE clauses that fail at parse time.
 	if isOTLPProtoType(protoType) {
+		tableName := getTableName(lakeName, protoType, transactionType)
 		return buildOTLPSearchSQLV4(tableName, protoType, req, opts)
 	}
 	// Line Protocol virtual mappings address dynamic lp_<measurement>
 	// tables whose only guaranteed columns are `time` and the user
 	// tags/fields. None of the SIP-specific WHERE clauses below
 	// (caller, callee, method, …) make sense for them — route to the
-	// LP-specific builder.
+	// LP-specific builder. Reject unsafe event_type profiles before
+	// they can reach the FROM clause (GHSA-94cf-g6mg-6gv7).
 	if isLPProtoType(protoType) {
+		tableName, ok := lpTableForProfile(lakeName, transactionType)
+		if !ok {
+			return "", fmt.Errorf("invalid event_type for line protocol search")
+		}
 		return buildLPSearchSQLV4(tableName, req, opts)
 	}
+	tableName := getTableName(lakeName, protoType, transactionType)
 	txType := normalizeSIPTransactionType(protoType, transactionType)
 
 	conditions := make([]string, 0)

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.299"
+	VERSION_APPLICATION = "11.0.300"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Harden `lpTableForProfile` so Line Protocol `event_type` (`schema__table`) must be safe SQL identifiers and cannot target catalog/system schemas (`information_schema`, `pg_catalog`, `ducklake_*`).
- Reject unsafe LP profiles in `buildSearchSQLV4` before they reach the `FROM` clause (GHSA-94cf-g6mg-6gv7).
- Bump version to **11.0.300**.

## Test plan
- [x] `go test ./coordinator/handlers/ -run 'TestGetTableName_LP|TestLpTableForProfile|TestBuildSearchSQLV4_LP'`
- [x] Smoke: LP search with valid `event_type` (e.g. `main__cpu`) still works
- [x] Confirm crafted profiles (`UNION`, `--`, `information_schema__tables`) return an error / no injectable SQL