### PR TITLE
fix(storage): detect corrupt ducklake_data_file.table_id (#900)

### DIFF
--- a/docs/OOM.md
+++ b/docs/OOM.md
@@ -296,7 +296,7 @@ do **not** have to choose one over the other:
 | Trigger | automatic, on every restart | manual, operator-run |
 | Data | **lossless** — only drops duplicate metadata rows | discards the catalog, re-ingests from parquet; **inline-only rows are lost** |
 | Downtime | none (runs before attach, under the writer lock) | yes — writer must be **stopped** |
-| Scope | duplicate `ducklake_snapshot`/`ducklake_table` rows (the common case) | catalog unreadable / desynced beyond duplicate rows |
+| Scope | duplicate `ducklake_snapshot`/`ducklake_table` rows (the common case); also **detects** (does not auto-fix) duplicate table names and non-INTEGER `ducklake_data_file.table_id` values ([#900](https://github.com/sipcapture/homer/issues/900)) | catalog unreadable / desynced beyond duplicate rows |
 | Cost | negligible | heavy (rewrites every table, re-allocates all ids) |
 
 Rule of thumb: **auto-repair is the first line of defence** — it self-heals the
@@ -340,6 +340,31 @@ kept:
 ```bash
 homer system --config-path /etc/homer/config.json --rebuild-catalog --rebuild-cleanup-orphans
 ```
+
+#### Symptom: `Mismatch Type Error` on `table_id` ([#900](https://github.com/sipcapture/homer/issues/900))
+
+If lake queries fail with:
+
+```text
+Mismatch Type Error: Failed to get data file list from DuckLake:
+Invalid type in column "table_id": column was declared as integer,
+found "date=YYYY-MM-DD/ducklake-….parquet" of type "text" instead.
+```
+
+at least one `ducklake_data_file` row has a **parquet path string stored in the
+integer `table_id` column**. Startup auto-repair **detects** this and logs an
+error pointing at `--rebuild-catalog`; it does **not** rewrite those rows
+(doing so safely requires re-registering files). Confirm with:
+
+```sql
+SELECT rowid, typeof(table_id), table_id, path
+FROM ducklake_data_file
+WHERE typeof(table_id) != 'integer'
+LIMIT 50;
+```
+
+Then stop the writer and run `--rebuild-catalog` as above. This is catalog
+corruption, not a cross-table `date=` glob leak on the query path.
 
 Notes:
 - Run with the writer **stopped** (it discards the live catalog).

--- a/src/storage/ducklake/ducklake.go
+++ b/src/storage/ducklake/ducklake.go
@@ -474,6 +474,17 @@ func (mtw *MultiTableWriter) connect() error {
 				"duplicate_table_names", res.DuplicateTableNames,
 				"catalog", mtw.config.CatalogPath)
 		}
+		// Non-INTEGER table_id values in ducklake_data_file (sipcapture/homer#900)
+		// abort DuckLake file-list resolution with a Mismatch Type Error. Auto-
+		// repair cannot rewrite those rows safely — rebuild from parquet.
+		if err == nil && res.CorruptDataFileTableIDs > 0 {
+			logger.Error("DuckLake catalog has corrupt ducklake_data_file.table_id values "+
+				"(expected INTEGER, found non-integer storage class such as a parquet path). "+
+				"Lake queries will fail with 'Mismatch Type Error: Failed to get data file list'. "+
+				"Stop the writer and run `homer system --rebuild-catalog`.",
+				"corrupt_table_id_rows", res.CorruptDataFileTableIDs,
+				"catalog", mtw.config.CatalogPath)
+		}
 	}
 
 	// SET s3_* is applied per pooled connection by the connector init above.

--- a/src/storage/ducklake/repair.go
+++ b/src/storage/ducklake/repair.go
@@ -32,6 +32,13 @@ type RepairResult struct {
 	// table). Cleaning these correctly requires knowing which table_id the
 	// data files reference, so we only report it.
 	DuplicateTableNames int
+	// CorruptDataFileTableIDs counts ducklake_data_file rows whose table_id
+	// column is not stored as INTEGER (sipcapture/homer#900). SQLite permits
+	// mixed storage classes, so a parquet path string can sit in table_id;
+	// DuckDB's sqlite_scanner then aborts file-list resolution with
+	// "Mismatch Type Error … column was declared as integer, found … text".
+	// Detection-only: rewriting those rows safely requires --rebuild-catalog.
+	CorruptDataFileTableIDs int
 	// Malformed is set when an operation failed because the SQLite file is
 	// physically corrupt ("database disk image is malformed"). Only a
 	// .dump/reimport salvage or a full rebuild recovers from this.
@@ -46,7 +53,7 @@ func (r RepairResult) Changed() bool {
 // NeedsRebuild reports whether the lightweight repair was insufficient and the
 // operator should run `homer system --rebuild-catalog`.
 func (r RepairResult) NeedsRebuild() bool {
-	return r.Malformed || r.DuplicateTableNames > 0 || !r.Healthy()
+	return r.Malformed || r.DuplicateTableNames > 0 || r.CorruptDataFileTableIDs > 0 || !r.Healthy()
 }
 
 // isMalformedErr reports whether a SQLite error indicates physical file
@@ -168,6 +175,13 @@ func RepairCatalogSnapshots(catalogPath string) (RepairResult, error) {
 		res.DuplicateTableNames = countDuplicateTableNames(db)
 	}
 
+	// Detect (do NOT auto-fix) non-INTEGER table_id values in
+	// ducklake_data_file — sipcapture/homer#900. A single bad row aborts every
+	// lake query during DuckLake file-list resolution.
+	if exists, _ := sqliteTableExists(db, "ducklake_data_file"); exists {
+		res.CorruptDataFileTableIDs = countCorruptDataFileTableIDs(db)
+	}
+
 	// Push the cleaned state back into the main DB file so the about-to-run
 	// DuckLake ATTACH reads it without depending on our WAL frames.
 	checkpointWAL(db)
@@ -202,6 +216,18 @@ func countDuplicateTableNames(db *sql.DB) int {
 	q := fmt.Sprintf(
 		`SELECT COALESCE(SUM(c-1),0) FROM (SELECT COUNT(*) c FROM ducklake_table %s GROUP BY table_name HAVING c>1)`,
 		filter)
+	var n int
+	if err := db.QueryRow(q).Scan(&n); err != nil {
+		return 0
+	}
+	return n
+}
+
+// countCorruptDataFileTableIDs returns how many ducklake_data_file rows store
+// table_id as something other than INTEGER (TEXT path strings, NULL, …).
+// Returns 0 on any error (best-effort detection).
+func countCorruptDataFileTableIDs(db *sql.DB) int {
+	const q = `SELECT COUNT(*) FROM ducklake_data_file WHERE typeof(table_id) != 'integer'`
 	var n int
 	if err := db.QueryRow(q).Scan(&n); err != nil {
 		return 0

--- a/src/storage/ducklake/repair_test.go
+++ b/src/storage/ducklake/repair_test.go
@@ -181,6 +181,49 @@ func TestRepairCatalogDuplicateTableNames(t *testing.T) {
 	}
 }
 
+// TestRepairCatalogCorruptDataFileTableIDs covers sipcapture/homer#900: a
+// parquet relative path stored in ducklake_data_file.table_id (TEXT storage
+// class). Detection-only — auto-repair must not delete those rows.
+func TestRepairCatalogCorruptDataFileTableIDs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "catalog.sqlite")
+	db := openTestCatalog(t, path)
+	for _, s := range []string{
+		`CREATE TABLE ducklake_snapshot (snapshot_id BIGINT, next_file_id BIGINT)`,
+		`INSERT INTO ducklake_snapshot VALUES (1,10)`,
+		`CREATE TABLE ducklake_data_file (data_file_id BIGINT, table_id, path TEXT)`,
+		// Healthy row + corrupt row with path string in table_id.
+		`INSERT INTO ducklake_data_file VALUES (1, 42, 'date=2026-07-30/ok.parquet')`,
+		`INSERT INTO ducklake_data_file VALUES (2, 'date=2026-07-30/ducklake-019fb128-3ac0-7662-8a3c-ba00875c1066.parquet', 'date=2026-07-30/bad.parquet')`,
+	} {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("setup %q: %v", s, err)
+		}
+	}
+	db.Close()
+
+	res, err := RepairCatalogSnapshots(path)
+	if err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+	if res.CorruptDataFileTableIDs != 1 {
+		t.Errorf("CorruptDataFileTableIDs=%d want 1", res.CorruptDataFileTableIDs)
+	}
+	if !res.NeedsRebuild() {
+		t.Errorf("NeedsRebuild()=false want true")
+	}
+	if res.Changed() {
+		t.Errorf("Changed()=true want false (detection must not mutate rows)")
+	}
+	db2 := openTestCatalog(t, path)
+	var cnt int
+	if err := db2.QueryRow(`SELECT COUNT(*) FROM ducklake_data_file`).Scan(&cnt); err != nil {
+		t.Fatal(err)
+	}
+	if cnt != 2 {
+		t.Errorf("ducklake_data_file rows=%d want 2 (no rows deleted)", cnt)
+	}
+}
+
 func TestRepairCatalogSnapshotsHealthy(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "catalog.sqlite")
 	db := openTestCatalog(t, path)

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.301"
+	VERSION_APPLICATION = "11.0.302"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Detect non-INTEGER `ducklake_data_file.table_id` values during startup catalog auto-repair (sipcapture/homer#900).
- Log a clear `--rebuild-catalog` hint; do not auto-delete those rows (unsafe without re-registering parquet).
- Document the `Mismatch Type Error` / path-in-`table_id` recovery path in `docs/OOM.md`.
- Bump version to **11.0.302**.

## Context
DuckLake resolves the data file list from the SQLite catalog, not by globbing `date=` directories across tables. When a parquet path string is stored in the INTEGER `table_id` column, DuckDB’s sqlite_scanner aborts with a type mismatch and all lake queries 500. Auto-repair previously only handled duplicate snapshot/table metadata.

## Test plan
- [x] `go test ./storage/ducklake/ -run TestRepairCatalog`
- [x] On a healthy catalog: startup log shows no corrupt_table_id warning
- [x] Optional: inject a TEXT `table_id` row and confirm startup Error + `NeedsRebuild`

Closes #900 (detection + operator path; full recovery remains `--rebuild-catalog`)