### PR TITLE
fix(decoder): sanitize HEP timestamps for RTPengine (#909)

### DIFF
--- a/src/decoder/decoder.go
+++ b/src/decoder/decoder.go
@@ -222,11 +222,7 @@ func (h *HEP) parse(packet []byte) error {
 			hepV3Enable, hepV2Enable, protobufEnable)
 	}
 
-	h.Timestamp = time.Unix(int64(h.Tsec), int64(h.Tmsec*1000))
-	if h.Tsec == 0 && h.Tmsec == 0 {
-		logger.Debug("got null timestamp", "nodeID", h.NodeID)
-		h.Timestamp = time.Now()
-	}
+	h.sanitizeHEPTimestamp(time.Now())
 
 	h.normPayload()
 	h.HEPParseNs = time.Now().UnixNano() - hepStart
@@ -276,6 +272,76 @@ func (h *HEP) parse(packet []byte) error {
 	}
 
 	return nil
+}
+
+// ntpUnixOffset is seconds between NTP epoch (1900-01-01) and Unix epoch (1970-01-01).
+const ntpUnixOffset uint32 = 2208988800
+
+// hepTimestampPastWindow / hepTimestampFutureWindow bound acceptable HEP wall times
+// relative to receive time. Far-future Tsec (NTP mis-encoded as Unix, clock skew)
+// otherwise creates DuckLake date= partitions decades ahead and can OOM the catalog.
+const (
+	hepTimestampPastWindow   = 10 * 365 * 24 * time.Hour
+	hepTimestampFutureWindow = 24 * time.Hour
+)
+
+// sanitizeHEPTimestamp normalizes HEP chunk 0x0009/0x000a into a sane wall clock,
+// writing Timestamp, Tsec, and Tmsec in sync so DuckLake date partitions stay correct.
+// See https://github.com/sipcapture/homer/issues/909
+func (h *HEP) sanitizeHEPTimestamp(now time.Time) {
+	now = now.UTC()
+
+	// HEP usec must be < 1e6; larger values are typically NTP fractional seconds
+	// wrongly placed in chunk 0x000a (not wall-clock microseconds).
+	if h.Tmsec >= 1_000_000 {
+		logger.Debug("invalid HEP usec, clamping to 0", "nodeID", h.NodeID, "tmsec", h.Tmsec)
+		h.Tmsec = 0
+	}
+
+	if h.Tsec == 0 {
+		logger.Debug("got null timestamp", "nodeID", h.NodeID)
+		h.applyTimestamp(now)
+		return
+	}
+
+	// Cast Tmsec to int64 before *1000 to avoid uint32 overflow.
+	ts := time.Unix(int64(h.Tsec), int64(h.Tmsec)*1000).UTC()
+	if hepTimestampInWindow(ts, now) {
+		h.applyTimestamp(ts)
+		return
+	}
+
+	// NTP seconds misread as Unix: subtract NTP→Unix offset and re-check.
+	if h.Tsec > ntpUnixOffset {
+		converted := time.Unix(int64(h.Tsec-ntpUnixOffset), int64(h.Tmsec)*1000).UTC()
+		if hepTimestampInWindow(converted, now) {
+			logger.Debug("HEP timestamp looked like NTP epoch, converted to Unix",
+				"nodeID", h.NodeID, "rawTsec", h.Tsec, "converted", converted)
+			h.applyTimestamp(converted)
+			return
+		}
+	}
+
+	logger.Debug("HEP timestamp out of range, using receive time",
+		"nodeID", h.NodeID, "rawTsec", h.Tsec, "decoded", ts)
+	h.applyTimestamp(now)
+}
+
+func hepTimestampInWindow(ts, now time.Time) bool {
+	if ts.After(now.Add(hepTimestampFutureWindow)) {
+		return false
+	}
+	if ts.Before(now.Add(-hepTimestampPastWindow)) {
+		return false
+	}
+	return true
+}
+
+func (h *HEP) applyTimestamp(ts time.Time) {
+	ts = ts.UTC()
+	h.Timestamp = ts
+	h.Tsec = uint32(ts.Unix())
+	h.Tmsec = uint32(ts.Nanosecond() / 1000)
 }
 
 func (h *HEP) normPayload() {

--- a/src/decoder/timestamp_test.go
+++ b/src/decoder/timestamp_test.go
@@ -1,0 +1,125 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package decoder
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSanitizeHEPTimestamp(t *testing.T) {
+	// Fixed "receive" time matching the issue #909 sample window (2026-08-04).
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	validUnix := uint32(time.Date(2026, 8, 3, 11, 33, 46, 0, time.UTC).Unix()) // 1785756826
+	ntpAsUnix := uint32(3994745626)                                           // NTP MSW misread as Unix → 2096
+	brokenHeader := uint32(2608623722)                                        // packet 490 tv_sec → 2052
+	brokenUsec := uint32(1059783936)                                          // NTP frac in usec field
+
+	tests := []struct {
+		name       string
+		tsec       uint32
+		tmsec      uint32
+		wantTsec   uint32
+		wantTmsec  uint32
+		wantNow    bool // expect receive time
+		checkExact bool
+	}{
+		{
+			name:       "normal unix preserved",
+			tsec:       validUnix,
+			tmsec:      123456,
+			wantTsec:   validUnix,
+			wantTmsec:  123456,
+			checkExact: true,
+		},
+		{
+			name:       "ntp-as-unix converted",
+			tsec:       ntpAsUnix,
+			tmsec:      0,
+			wantTsec:   validUnix,
+			wantTmsec:  0,
+			checkExact: true,
+		},
+		{
+			name:    "broken header falls back to receive time",
+			tsec:    brokenHeader,
+			tmsec:   brokenUsec,
+			wantNow: true,
+		},
+		{
+			name:    "zero timestamp uses receive time and syncs Tsec",
+			tsec:    0,
+			tmsec:   0,
+			wantNow: true,
+		},
+		{
+			name:       "valid usec under 1e6 preserved",
+			tsec:       validUnix,
+			tmsec:      999999,
+			wantTsec:   validUnix,
+			wantTmsec:  999999,
+			checkExact: true,
+		},
+		{
+			name:    "invalid usec clamped then out-of-range falls back",
+			tsec:    brokenHeader,
+			tmsec:   brokenUsec,
+			wantNow: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &HEP{Tsec: tt.tsec, Tmsec: tt.tmsec, NodeID: 2001}
+			h.sanitizeHEPTimestamp(now)
+
+			if tt.wantNow {
+				if h.Timestamp.UTC() != now {
+					t.Fatalf("Timestamp = %v, want receive time %v", h.Timestamp, now)
+				}
+				if h.Tsec != uint32(now.Unix()) {
+					t.Fatalf("Tsec = %d, want %d (synced receive time)", h.Tsec, now.Unix())
+				}
+				if h.Tmsec != uint32(now.Nanosecond()/1000) {
+					t.Fatalf("Tmsec = %d, want %d", h.Tmsec, now.Nanosecond()/1000)
+				}
+				return
+			}
+
+			if !tt.checkExact {
+				return
+			}
+			if h.Tsec != tt.wantTsec {
+				t.Fatalf("Tsec = %d, want %d", h.Tsec, tt.wantTsec)
+			}
+			if h.Tmsec != tt.wantTmsec {
+				t.Fatalf("Tmsec = %d, want %d", h.Tmsec, tt.wantTmsec)
+			}
+			if h.Timestamp.Unix() != int64(tt.wantTsec) {
+				t.Fatalf("Timestamp.Unix() = %d, want %d", h.Timestamp.Unix(), tt.wantTsec)
+			}
+		})
+	}
+}
+
+func TestHepTimestampInWindow(t *testing.T) {
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+
+	if !hepTimestampInWindow(now, now) {
+		t.Fatal("now should be in window")
+	}
+	if !hepTimestampInWindow(now.Add(23*time.Hour), now) {
+		t.Fatal("now+23h should be in window")
+	}
+	if hepTimestampInWindow(now.Add(25*time.Hour), now) {
+		t.Fatal("now+25h should be out of window")
+	}
+	if hepTimestampInWindow(now.Add(-11*365*24*time.Hour), now) {
+		t.Fatal("now-11y should be out of window")
+	}
+	if !hepTimestampInWindow(now.Add(-9*365*24*time.Hour), now) {
+		t.Fatal("now-9y should be in window")
+	}
+}

--- a/src/storage/ducklake/hep_adapter.go
+++ b/src/storage/ducklake/hep_adapter.go
@@ -178,8 +178,11 @@ func (a *MultiTableAdapter) convertHEPToValues(hep *decoder.HEP) (TableKey, []in
 // If forcedSIPSubtype is non-empty and hep is SIP (proto 1), that subtype selects the
 // DuckLake table and row shape (call / registration / default) instead of inferring from the method.
 func (a *MultiTableAdapter) convertHEPToValuesWithSIPSubtype(hep *decoder.HEP, forcedSIPSubtype string) (TableKey, []interface{}) {
-	// Calculate timestamp as time.Time for DuckDB TIMESTAMP type
-	ts := time.Unix(int64(hep.Tsec), int64(hep.Tmsec)*1000)
+	// Use decoder-sanitized Timestamp (Tsec/Tmsec are kept in sync there).
+	ts := hep.Timestamp
+	if ts.IsZero() {
+		ts = time.Unix(int64(hep.Tsec), int64(hep.Tmsec)*1000)
+	}
 	date := fastDuckDate(ts)
 	uid := fastUUID()
 	nodeID := fastNodeID(hep.NodeID)
@@ -424,8 +427,11 @@ func (a *MultiTableAdapter) GetReader() *MultiTableReader {
 
 // convertHEP converts a HEP packet to a DuckLake record (legacy)
 func (a *HEPAdapter) convertHEP(hep *decoder.HEP) HEPRecord {
-	// Calculate timestamp as time.Time for DuckDB TIMESTAMP type
-	ts := time.Unix(int64(hep.Tsec), int64(hep.Tmsec)*1000)
+	// Use decoder-sanitized Timestamp (Tsec/Tmsec are kept in sync there).
+	ts := hep.Timestamp
+	if ts.IsZero() {
+		ts = time.Unix(int64(hep.Tsec), int64(hep.Tmsec)*1000)
+	}
 
 	record := HEPRecord{
 		UUID:      fastUUID(),

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.305"
+	VERSION_APPLICATION = "11.0.306"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Sanitize HEP `Tsec`/`Tmsec` after decode: clamp usec ≥1e6, NTP→Unix heuristic (`−2208988800`), fall back to receive time outside `[now−10y, now+24h]`, and keep `Timestamp`/`Tsec`/`Tmsec` in sync.
- DuckLake adapter uses sanitized `hep.Timestamp` so `hep_proto_5_default` `date=` partitions no longer land in 2032–2106 from bad RTPengine HEP headers ([#909](https://github.com/sipcapture/homer/issues/909)).
- Bump version to **11.0.306**.

## Test plan
- [x] `go test ./decoder/` (table-driven cases from #909)
- [x] `go vet ./decoder/ ./storage/ducklake/`
- [x] Ingest RTPengine HEP with NTP-like `0x0009` and confirm `date=` is today (not 2096)
- [x] Zero `Tsec`/`Tmsec` writes today’s partition (not `1970-01-01`)
- [x] Existing future `date=*` under `hep_proto_5_default` still need manual cleanup

Fixes #909