### PR TITLE
chore(deps): bump npm overrides for Dependabot security alerts

### DIFF
--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -6315,9 +6315,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -6791,9 +6791,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.12.34",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
+      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -6936,9 +6936,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+      "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -65,11 +65,11 @@
   },
   "overrides": {
     "express-rate-limit": "8.5.1",
-    "ip-address": "10.2.0",
-    "hono": "4.12.31",
+    "ip-address": "10.3.1",
+    "hono": "4.12.34",
     "js-yaml": "4.3.0",
     "@hono/node-server": "2.0.11",
-    "fast-uri": "3.1.4",
+    "fast-uri": "3.1.5",
     "@babel/core": "7.29.6",
     "ws": "8.21.0"
   }


### PR DESCRIPTION
## Summary
- Bump npm `overrides` in `src/ui` to close open Dependabot alerts (#59, #60, #63, #64, #65)
- `ip-address` 10.2.0 → 10.3.1, `hono` 4.12.31 → 4.12.34, `fast-uri` 3.1.4 → 3.1.5
- Regenerated `package-lock.json`; `npm install` reports 0 vulnerabilities

## Test plan
- [ ] `cd src/ui && npm install` succeeds with 0 vulnerabilities
- [ ] UI builds: `npm run build`
- [ ] Dependabot alerts #59–#65 auto-close after merge