### PR TITLE
fix(ui): show Capture ID label for node_id (11.0.307)

### DIFF
--- a/src/ui/src/dashboard/resultColumnLabels.test.ts
+++ b/src/ui/src/dashboard/resultColumnLabels.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { columnDisplayLabel, columnDisplayTitle } from './resultColumnLabels'
+
+describe('resultColumnLabels', () => {
+  it('aliases node_id as Capture ID (Homer 7 CaptureID)', () => {
+    expect(columnDisplayLabel('node_id')).toBe('Capture ID')
+    expect(columnDisplayTitle('node_id')).toBe('Capture ID (node_id)')
+  })
+
+  it('passes through unknown columns unchanged', () => {
+    expect(columnDisplayLabel('session_id')).toBe('session_id')
+    expect(columnDisplayTitle('session_id')).toBe('session_id')
+  })
+})

--- a/src/ui/src/dashboard/resultColumnLabels.ts
+++ b/src/ui/src/dashboard/resultColumnLabels.ts
@@ -1,0 +1,21 @@
+/**
+ * Display labels for lake/result column keys.
+ * Keys stay as returned by search (e.g. node_id); labels are UI-only.
+ *
+ * Homer 7 showed HEP chunk 0x000c as CaptureID; Homer 11 stores it as node_id.
+ */
+const COLUMN_DISPLAY_LABELS: Record<string, string> = {
+  node_id: 'Capture ID',
+}
+
+/** Human-readable column title; falls back to the raw key. */
+export function columnDisplayLabel(col: string): string {
+  return COLUMN_DISPLAY_LABELS[col] ?? col
+}
+
+/** Tooltip for headers / column picker (includes lake key when aliased). */
+export function columnDisplayTitle(col: string): string {
+  const label = columnDisplayLabel(col)
+  if (label === col) return col
+  return `${label} (${col})`
+}

--- a/src/ui/src/dashboard/widgets/ResultsPanel.tsx
+++ b/src/ui/src/dashboard/widgets/ResultsPanel.tsx
@@ -42,6 +42,7 @@ import OTLPLogRowModal from '../OTLPLogRowModal'
 import OTLPMetricsSeriesModal from '../OTLPMetricsSeriesModal'
 import MessageModal from '../MessageModal'
 import { useLocale } from '@/components/locale/locale-provider'
+import { columnDisplayLabel, columnDisplayTitle } from '../resultColumnLabels'
 
 const OTLP_TRACES_PROTO = 200
 const OTLP_METRICS_PROTO = 201
@@ -1108,7 +1109,11 @@ export default function ResultsPanel({ widgetId, config: _config }) {
                       'whitespace-nowrap border-b border-border px-2 py-1.5 text-left font-medium text-slate-600 dark:text-slate-300',
                       col !== '_actions' && col !== '_select' && 'cursor-pointer select-none hover:text-slate-900 dark:hover:text-sky-100',
                     )}
-                    title={col !== '_actions' && col !== '_select' ? `Sort by ${col}` : undefined}
+                    title={
+                      col !== '_actions' && col !== '_select'
+                        ? `Sort by ${columnDisplayTitle(col)}`
+                        : undefined
+                    }
                   >
                     {col === '_select' ? (
                       <span className="inline-flex items-center" onClick={(e) => e.stopPropagation()}>
@@ -1128,7 +1133,7 @@ export default function ResultsPanel({ widgetId, config: _config }) {
                       <span className="text-[10px] uppercase tracking-wider">Actions</span>
                     ) : (
                       <span className="inline-flex items-center gap-1">
-                        {col}
+                        {columnDisplayLabel(col)}
                         {sortCol === col ? (
                           sortDir === 'asc' ? (
                             <ArrowUp className="h-3 w-3" />
@@ -1390,8 +1395,12 @@ export default function ResultsPanel({ widgetId, config: _config }) {
                       })
                     }}
                   />
-                  <label htmlFor={`col-${col}`} className="flex-1 cursor-pointer truncate">
-                    {col}
+                  <label
+                    htmlFor={`col-${col}`}
+                    className="flex-1 cursor-pointer truncate"
+                    title={columnDisplayTitle(col)}
+                  >
+                    {columnDisplayLabel(col)}
                   </label>
                   <Button
                     type="button"

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.306"
+	VERSION_APPLICATION = "11.0.307"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Homer 7 showed HEP chunk `0x000c` as **CaptureID**; Homer 11 stores it as lake column `node_id`
- Add UI-only display alias: Results table header + Columns dialog show **Capture ID** (tooltip `Capture ID (node_id)`)
- No schema / ingest change — filter `capture_id` already matches `node_id`
- Bump version to **11.0.307**
- Fixes #914

## Test plan
- [x] Search SIP calls; confirm `node_id` column appears as **Capture ID** in the table header
- [x] Open Columns dialog; confirm label **Capture ID** with tooltip including `node_id`
- [x] Sorting/hiding still use key `node_id` (localStorage order/hidden keys unchanged)
- [x] `cd src/ui && npm test -- --run src/dashboard/resultColumnLabels.test.ts`