### PR TITLE
add Capture-ID message consolidation to call flow

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "homer-dev (go+ui)",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "context": "..",
+    "target": "devbase"
+  },
+  "workspaceFolder": "/workspaces/homer-dev",
+  "postCreateCommand": "cd src/ui && npm ci",
+  "postStartCommand": "cd src/ui && npm run build",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      },
+      "extensions": [
+        "golang.Go",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,12 @@ polyfill-glibc
 homer-core_*.deb
 homer-core_*.rpm
 bundled_extensions/
+# Local test rig (docker-compose + hepgen scenarios + generated data)
+local/
+
+# Vite local env override (proxy target etc.)
+src/ui/.env.local
+
 # Cursor IDE — ignore local workspace state; keep shared agent rules
 .cursor/*
 !.cursor/rules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # Debian/glibc: DuckDB static libs expect glibc (backtrace, malloc_trim, resolver);
 # Alpine/musl link fails. Runtime must match libc linked into the binary.
-FROM golang:bookworm AS builder
+FROM golang:bookworm AS devbase
 
 # Base build deps (no Debian nodejs — bookworm ships Node 18; Vite 7 needs 20.19+ / 22.12+).
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
     git ca-certificates build-essential curl \
     libluajit-5.1-dev \
     && rm -rf /var/lib/apt/lists/*
@@ -13,13 +14,16 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
+FROM devbase AS builder
+
 COPY . /homer-core
 WORKDIR /homer-core
 RUN make modules && make all
 
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
     ca-certificates bash sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@
 FROM golang:bookworm AS devbase
 
 # Base build deps (no Debian nodejs — bookworm ships Node 18; Vite 7 needs 20.19+ / 22.12+).
-RUN apt-get update && apt-get upgrade -y --no-install-recommends \
-    && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     git ca-certificates build-essential curl \
     libluajit-5.1-dev \
     && rm -rf /var/lib/apt/lists/*
@@ -22,8 +21,7 @@ RUN make modules && make all
 
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get upgrade -y --no-install-recommends \
-    && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates bash sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ make
 ./homer --config-path /etc/homer/homer.json --log-level debug
 ```
 
+### Development Container
+
+For an in-container development workflow (build + tests), see [docs/DEVCONTAINER.md](docs/DEVCONTAINER.md).
+
 ## Subcommands
 
 Homer uses a subcommand-based CLI. Running `homer` without arguments starts the server.

--- a/docs/DEVCONTAINER.md
+++ b/docs/DEVCONTAINER.md
@@ -1,0 +1,69 @@
+# Development Container Workflow
+
+This repository uses one Dev Container configuration for local development.
+It is intended to keep setup simple while still matching CI toolchains.
+
+## What it uses
+
+- Configuration file: `.devcontainer/devcontainer.json`
+- Build source: top-level `Dockerfile`
+- Build target: `devbase`
+
+The `devbase` stage contains build dependencies for Go and UI work, without running the full app build during image creation.
+
+## Open the project in container
+
+1. Open this repository in VS Code.
+2. Run Command Palette:
+   - Dev Containers: Reopen in Container
+3. Wait for initial setup to finish.
+
+On first create, VS Code runs:
+
+- `postCreateCommand`: installs UI dependencies
+
+On each container start, VS Code runs:
+
+- `postStartCommand`: runs a UI build smoke check
+
+## Build inside container
+
+From repository root:
+
+- Build UI only:
+  - `make frontend`
+- Build backend binary only:
+  - `make homer-only`
+- Build full release flow (UI + backend):
+  - `make all`
+
+## Run tests inside container
+
+Backend tests:
+
+- `cd src && go test ./...`
+
+UI tests:
+
+- `cd src/ui && npm run test`
+
+Targeted UI tests for call flow work:
+
+- `cd src/ui && npm run test -- flow-data.test.ts FlowItem.test.tsx`
+
+## Common troubleshooting
+
+If dependencies are missing or hooks were interrupted:
+
+- `cd src/ui && npm ci`
+
+If the container needs a full rebuild after Dockerfile or devcontainer changes:
+
+1. Command Palette:
+   - Dev Containers: Rebuild and Reopen in Container
+
+If build tools are unexpectedly missing, verify you are inside the container terminal:
+
+- `go version`
+- `node --version`
+- `npm --version`

--- a/src/ui/src/dashboard/CallFlow.css
+++ b/src/ui/src/dashboard/CallFlow.css
@@ -132,12 +132,6 @@
   padding: 4px 0;
 }
 
-.callflow-filter-note {
-  margin-top: 2px;
-  font-size: 10px;
-  color: var(--color-muted-foreground);
-}
-
 .flow-threshold-row {
   gap: 8px;
 }

--- a/src/ui/src/dashboard/CallFlow.css
+++ b/src/ui/src/dashboard/CallFlow.css
@@ -71,6 +71,7 @@
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--color-card) 96%, transparent);
+  -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14);
 }
@@ -129,6 +130,32 @@
   align-items: center;
   justify-content: space-between;
   padding: 4px 0;
+}
+
+.callflow-filter-note {
+  margin-top: 2px;
+  font-size: 10px;
+  color: var(--color-muted-foreground);
+}
+
+.flow-threshold-row {
+  gap: 8px;
+}
+
+.callflow-threshold-input {
+  width: 92px;
+  height: 24px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-background);
+  color: var(--color-foreground);
+  padding: 0 6px;
+  font-size: 11px;
+}
+
+.callflow-threshold-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 /* radio */
@@ -307,6 +334,7 @@
   z-index: 10;
   padding: 6px 12px;
   background: color-mix(in oklch, var(--color-card) 92%, transparent);
+  -webkit-backdrop-filter: blur(6px);
   backdrop-filter: blur(6px);
   border-bottom: 1px solid var(--color-border);
 }
@@ -425,6 +453,15 @@
   min-height: 64px;
 }
 
+.item-flow-packet-container.consolidated-parent {
+  min-height: 72px;
+}
+
+.item-flow-packet-container.consolidated-subitem {
+  min-height: 54px;
+  opacity: 0.9;
+}
+
 .item-flow-packet-container .bg-color-polygon {
   position: absolute;
   z-index: 0;
@@ -466,6 +503,7 @@
   cursor: pointer;
   transition: background-color 0.15s ease, box-shadow 0.15s ease;
   background-color: color-mix(in oklch, var(--color-background) 35%, transparent);
+  -webkit-backdrop-filter: blur(2px);
   backdrop-filter: blur(2px);
 }
 
@@ -493,6 +531,29 @@
   display: flex;
   align-items: center;
   gap: 4px;
+}
+
+.item-flow-packet .subitems-toggle {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 3px;
+  border: 1px solid var(--color-border);
+  border: 1px solid color-mix(in oklch, var(--color-border) 65%, transparent);
+  background: var(--color-background);
+  background: color-mix(in oklch, var(--color-background) 75%, transparent);
+  color: var(--color-muted-foreground);
+  font-size: 9px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.item-flow-packet .subitems-count {
+  font-size: 10px;
+  color: var(--color-muted-foreground);
+  font-weight: 500;
 }
 
 .item-flow-packet .call_text.right {
@@ -679,6 +740,7 @@
   flex-shrink: 0;
   z-index: 15;
   background-color: color-mix(in oklch, var(--color-card) 85%, transparent);
+  -webkit-backdrop-filter: blur(6px);
   backdrop-filter: blur(6px);
   border-top: 1px solid var(--color-border);
   line-height: 1.2;

--- a/src/ui/src/dashboard/CallFlow.tsx
+++ b/src/ui/src/dashboard/CallFlow.tsx
@@ -5,7 +5,7 @@ import { FilterPanel } from './flow/FilterPanel'
 import { FlowHostsLine } from './flow/FlowHostsLine'
 import { FlowItem } from './flow/FlowItem'
 import type { FlowItemData, RawMessage } from './flow/flow-data'
-import { buildFlow, buildCallIdLegend } from './flow/flow-data'
+import { buildFlow, buildCallIdLegend, consolidateFlowItems, hasRuntimeFingerprintCandidates } from './flow/flow-data'
 import { useFlowFilters } from './flow/useFlowFilters'
 import { useLocale } from '@/components/locale/locale-provider'
 
@@ -27,6 +27,8 @@ export default function CallFlow({ items, timeZone, onClickMessage }: CallFlowPr
     filteredItems,
   } = useFlowFilters(items)
 
+  const [expandedItemKey, setExpandedItemKey] = useState<string | null>(null)
+
   const { hosts, flowItems } = useMemo(
     () =>
       buildFlow(filteredItems, {
@@ -36,6 +38,26 @@ export default function CallFlow({ items, timeZone, onClickMessage }: CallFlowPr
       }),
     [filteredItems, timeZone, filters.hostGrouping, locale],
   )
+
+  const canConsolidateCaptureIds = useMemo(
+    () => hasRuntimeFingerprintCandidates(filteredItems),
+    [filteredItems],
+  )
+
+  const consolidatedFlowItems = useMemo(
+    () =>
+      consolidateFlowItems(flowItems, {
+        enabled: filters.isConsolidateCaptureIds && canConsolidateCaptureIds,
+        timeThresholdMs: filters.consolidationTimeThresholdMs,
+      }),
+    [flowItems, filters.isConsolidateCaptureIds, filters.consolidationTimeThresholdMs, canConsolidateCaptureIds],
+  )
+
+  useEffect(() => {
+    if (!expandedItemKey) return
+    const exists = consolidatedFlowItems.some((item) => String(item.id ?? item.idx) === expandedItemKey)
+    if (!exists) setExpandedItemKey(null)
+  }, [expandedItemKey, consolidatedFlowItems])
 
   const callIds = useMemo(() => buildCallIdLegend(items), [items])
 
@@ -93,8 +115,9 @@ export default function CallFlow({ items, timeZone, onClickMessage }: CallFlowPr
           filterMethod={filterMethod}
           filterPayloadType={filterPayloadType}
           filterCallId={filterCallId}
+          canConsolidateCaptureIds={canConsolidateCaptureIds}
         />
-        <span>{flowItems.length} messages</span>
+        <span>{consolidatedFlowItems.length} messages</span>
         <span className="callflow-toolbar-spacer" />
         <span>{hosts.length} hosts</span>
       </div>
@@ -119,10 +142,10 @@ export default function CallFlow({ items, timeZone, onClickMessage }: CallFlowPr
             <FlowHostsLine hosts={hosts} />
 
             <div className="callflow-items">
-              {flowItems.length === 0 ? (
+              {consolidatedFlowItems.length === 0 ? (
                 <div className="callflow-empty-state">No rows match the current filters</div>
               ) : (
-                flowItems.map((item) => (
+                consolidatedFlowItems.map((item) => (
                   <FlowItem
                     key={item.id}
                     item={item}
@@ -130,6 +153,8 @@ export default function CallFlow({ items, timeZone, onClickMessage }: CallFlowPr
                     isAbsoluteTime={filters.isAbsoluteTime}
                     singleHost={hosts.length === 1}
                     onClickItem={onClickMessage}
+                    expandedKey={expandedItemKey}
+                    setExpandedKey={setExpandedItemKey}
                   />
                 ))
               )}

--- a/src/ui/src/dashboard/CallFlow.tsx
+++ b/src/ui/src/dashboard/CallFlow.tsx
@@ -5,7 +5,7 @@ import { FilterPanel } from './flow/FilterPanel'
 import { FlowHostsLine } from './flow/FlowHostsLine'
 import { FlowItem } from './flow/FlowItem'
 import type { FlowItemData, RawMessage } from './flow/flow-data'
-import { buildFlow, buildCallIdLegend, consolidateFlowItems, hasRuntimeFingerprintCandidates } from './flow/flow-data'
+import { buildFlow, buildCallIdLegend, consolidateFlowItems } from './flow/flow-data'
 import { useFlowFilters } from './flow/useFlowFilters'
 import { useLocale } from '@/components/locale/locale-provider'
 
@@ -40,8 +40,8 @@ export default function CallFlow({ items, timeZone, onClickMessage }: CallFlowPr
   )
 
   const canConsolidateCaptureIds = useMemo(
-    () => hasRuntimeFingerprintCandidates(filteredItems),
-    [filteredItems],
+    () => flowItems.some((item) => (item.runtimeFingerprint ?? '') !== ''),
+    [flowItems],
   )
 
   const consolidatedFlowItems = useMemo(

--- a/src/ui/src/dashboard/MessageModal.tsx
+++ b/src/ui/src/dashboard/MessageModal.tsx
@@ -186,7 +186,7 @@ function MetaGrid({ data, timeZone, locale, overrides = {} }) {
             : String(display)
         return (
           <div key={field} className="flex min-w-0 flex-col">
-            <dt className="text-[10px] uppercase tracking-wider text-muted-foreground">{field}</dt>
+            <dt className="text-[10px] uppercase tracking-wider text-muted-foreground">{META_FIELD_LABELS[field] ?? field}</dt>
             <dd className="truncate font-mono text-foreground" title={tip}>
               {String(display)}
             </dd>

--- a/src/ui/src/dashboard/MessageModal.tsx
+++ b/src/ui/src/dashboard/MessageModal.tsx
@@ -104,7 +104,11 @@ function highlightSIP(payload) {
   return out.join('\n')
 }
 
-const META_FIELDS = ['uuid', 'date', 'timestamp', 'event', 'method', 'src_ip', 'dst_ip', 'src_port', 'dst_port', 'session_id', 'cid']
+const META_FIELDS = ['uuid', 'date', 'timestamp', 'event', 'method', 'src_ip', 'dst_ip', 'src_port', 'dst_port', 'session_id', 'cid', 'node_id']
+
+const META_FIELD_LABELS: Record<string, string> = {
+  node_id: 'Capture ID',
+}
 
 function parseTimestampValue(value) {
   if (!value && value !== 0) return null
@@ -147,11 +151,21 @@ function formatDateTime(value, locale, timeZone, dateOnly = false) {
   return new Intl.DateTimeFormat(locale, options).format(date)
 }
 
-function MetaGrid({ data, timeZone, locale }) {
+function MetaGrid({ data, timeZone, locale, overrides = {} }) {
   if (!data) return null
   return (
     <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-[11px] sm:grid-cols-3">
       {META_FIELDS.map((field) => {
+        if (field in overrides) {
+          return (
+            <div key={field} className="flex min-w-0 flex-col">
+              <dt className="text-[10px] uppercase tracking-wider text-muted-foreground">{META_FIELD_LABELS[field] ?? field}</dt>
+              <dd className="truncate font-mono text-muted-foreground" title={String(overrides[field])}>
+                {String(overrides[field])}
+              </dd>
+            </div>
+          )
+        }
         const raw = data[field]
         const display = raw === undefined
           ? '—'
@@ -253,7 +267,7 @@ export default function MessageModal({ modal, onClose, timeZone }) {
 
         {!loading && !error && (
           <>
-            <MetaGrid data={data} timeZone={timeZone} locale={locale} />
+            <MetaGrid data={data} timeZone={timeZone} locale={locale} overrides={messageContext?.metaOverrides ?? {}} />
 
             <div className="flex items-center justify-between">
               <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">

--- a/src/ui/src/dashboard/TransactionModal.tsx
+++ b/src/ui/src/dashboard/TransactionModal.tsx
@@ -748,6 +748,7 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
   const handleFlowMessageClick = async (flowItem) => {
     const raw = flowItem.raw || flowItem
     const uuid = raw.uuid || raw.id || flowItem.id
+    const isConsolidatedParent = Array.isArray(flowItem.subItems) && flowItem.subItems.length > 0
     const messageContext = {
       proto_type: 1,
       event_type: 'call',
@@ -755,6 +756,7 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
         const ts = resolveTimeRange(timeRange, timeZone)
         return ts ? { from: ts.from, to: ts.to } : undefined
       })(),
+      metaOverrides: isConsolidatedParent ? { node_id: 'multiple' } : undefined,
     }
     const nestedKey = newModalKey()
     const update = (modal) => setMessageModals(prev =>

--- a/src/ui/src/dashboard/flow/FilterPanel.tsx
+++ b/src/ui/src/dashboard/flow/FilterPanel.tsx
@@ -96,39 +96,39 @@ export function FilterPanel({
                   onCheckedChange={(v) => setFilters((p) => ({ ...p, isHighContrast: !!v }))}
                 />
               </div>
-              <div className="callflow-filter-row">
-                <Label htmlFor="flow-consolidate-capture-ids">Consolidate by fingerprint</Label>
-                <Switch
-                  id="flow-consolidate-capture-ids"
-                  checked={filters.isConsolidateCaptureIds && canConsolidateCaptureIds}
-                  disabled={!canConsolidateCaptureIds}
-                  onCheckedChange={(v) =>
-                    setFilters((p) => ({ ...p, isConsolidateCaptureIds: !!v }))
-                  }
-                />
-              </div>
-              {!canConsolidateCaptureIds ? (
-                <div className="callflow-filter-note">No fingerprint-capable rows in current flow.</div>
+              {canConsolidateCaptureIds ? (
+                <>
+                  <div className="callflow-filter-row">
+                    <Label htmlFor="flow-consolidate-capture-ids">Consolidate by fingerprint</Label>
+                    <Switch
+                      id="flow-consolidate-capture-ids"
+                      checked={filters.isConsolidateCaptureIds}
+                      onCheckedChange={(v) =>
+                        setFilters((p) => ({ ...p, isConsolidateCaptureIds: !!v }))
+                      }
+                    />
+                  </div>
+                  <div className="callflow-filter-row flow-threshold-row">
+                    <Label htmlFor="flow-consolidate-threshold">Threshold (ms)</Label>
+                    <input
+                      id="flow-consolidate-threshold"
+                      type="number"
+                      min={0}
+                      step={1}
+                      className="callflow-threshold-input"
+                      disabled={!filters.isConsolidateCaptureIds}
+                      value={filters.consolidationTimeThresholdMs}
+                      onChange={(e) => {
+                        const next = Number.parseInt(e.target.value || '0', 10)
+                        setFilters((p) => ({
+                          ...p,
+                          consolidationTimeThresholdMs: Number.isFinite(next) ? Math.max(0, next) : 0,
+                        }))
+                      }}
+                    />
+                  </div>
+                </>
               ) : null}
-              <div className="callflow-filter-row flow-threshold-row">
-                <Label htmlFor="flow-consolidate-threshold">Threshold (ms)</Label>
-                <input
-                  id="flow-consolidate-threshold"
-                  type="number"
-                  min={0}
-                  step={1}
-                  className="callflow-threshold-input"
-                  disabled={!canConsolidateCaptureIds || !filters.isConsolidateCaptureIds}
-                  value={filters.consolidationTimeThresholdMs}
-                  onChange={(e) => {
-                    const next = Number.parseInt(e.target.value || '0', 10)
-                    setFilters((p) => ({
-                      ...p,
-                      consolidationTimeThresholdMs: Number.isFinite(next) ? Math.max(0, next) : 0,
-                    }))
-                  }}
-                />
-              </div>
             </section>
 
             <section className="callflow-filter-section">

--- a/src/ui/src/dashboard/flow/FilterPanel.tsx
+++ b/src/ui/src/dashboard/flow/FilterPanel.tsx
@@ -19,6 +19,7 @@ interface FilterPanelProps {
   filterMethod: FilterToken[]
   filterPayloadType: FilterToken[]
   filterCallId: FilterToken[]
+  canConsolidateCaptureIds?: boolean
 }
 
 function toggleTokens(tokens: FilterToken[], value: string): FilterToken[] {
@@ -36,6 +37,7 @@ export function FilterPanel({
   filterMethod,
   filterPayloadType,
   filterCallId,
+  canConsolidateCaptureIds = false,
 }: FilterPanelProps) {
   const [open, setOpen] = useState(false)
 
@@ -92,6 +94,39 @@ export function FilterPanel({
                   id="flow-hc"
                   checked={filters.isHighContrast}
                   onCheckedChange={(v) => setFilters((p) => ({ ...p, isHighContrast: !!v }))}
+                />
+              </div>
+              <div className="callflow-filter-row">
+                <Label htmlFor="flow-consolidate-capture-ids">Consolidate by fingerprint</Label>
+                <Switch
+                  id="flow-consolidate-capture-ids"
+                  checked={filters.isConsolidateCaptureIds && canConsolidateCaptureIds}
+                  disabled={!canConsolidateCaptureIds}
+                  onCheckedChange={(v) =>
+                    setFilters((p) => ({ ...p, isConsolidateCaptureIds: !!v }))
+                  }
+                />
+              </div>
+              {!canConsolidateCaptureIds ? (
+                <div className="callflow-filter-note">No fingerprint-capable rows in current flow.</div>
+              ) : null}
+              <div className="callflow-filter-row flow-threshold-row">
+                <Label htmlFor="flow-consolidate-threshold">Threshold (ms)</Label>
+                <input
+                  id="flow-consolidate-threshold"
+                  type="number"
+                  min={0}
+                  step={1}
+                  className="callflow-threshold-input"
+                  disabled={!canConsolidateCaptureIds || !filters.isConsolidateCaptureIds}
+                  value={filters.consolidationTimeThresholdMs}
+                  onChange={(e) => {
+                    const next = Number.parseInt(e.target.value || '0', 10)
+                    setFilters((p) => ({
+                      ...p,
+                      consolidationTimeThresholdMs: Number.isFinite(next) ? Math.max(0, next) : 0,
+                    }))
+                  }}
                 />
               </div>
             </section>

--- a/src/ui/src/dashboard/flow/FlowItem.test.tsx
+++ b/src/ui/src/dashboard/flow/FlowItem.test.tsx
@@ -1,9 +1,9 @@
-import { describe, expect, it } from 'vitest'
-import { render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
 import { FlowItem } from './FlowItem'
 import type { FlowItemData } from './flow-data'
 
-function makeItem(direction: boolean): FlowItemData {
+function makeItem(direction: boolean, overrides: Partial<FlowItemData> = {}): FlowItemData {
   return {
     id: '1',
     idx: 1,
@@ -33,6 +33,7 @@ function makeItem(direction: boolean): FlowItemData {
     isLastHost: false,
     arrowStyleSolid: true,
     raw: {},
+    ...overrides,
   }
 }
 
@@ -53,5 +54,56 @@ describe('FlowItem port labels', () => {
 
     expect(container.querySelector('.port-label-left')?.textContent).toBe('5070')
     expect(container.querySelector('.port-label-right')?.textContent).toBe('5060')
+  })
+})
+
+describe('FlowItem consolidation', () => {
+  const subItem = makeItem(false, { id: 'sub1', method: 'BYE' })
+  const parentItem = makeItem(false, { id: 'parent', subItems: [subItem] })
+
+  it('renders toggle button and +N badge when item has subItems', () => {
+    const { container } = render(
+      <FlowItem item={parentItem} isSimplify={false} isAbsoluteTime={false}
+        expandedKey={null} setExpandedKey={() => {}} />,
+    )
+    expect(container.querySelector('.subitems-toggle')).toBeTruthy()
+    expect(container.querySelector('.subitems-count')?.textContent).toBe('+1')
+  })
+
+  it('does not render toggle when item has no subItems', () => {
+    const { container } = render(
+      <FlowItem item={makeItem(false)} isSimplify={false} isAbsoluteTime={false} />,
+    )
+    expect(container.querySelector('.subitems-toggle')).toBeNull()
+    expect(container.querySelector('.subitems-count')).toBeNull()
+  })
+
+  it('shows sub-items when expandedKey matches item id', () => {
+    const { container } = render(
+      <FlowItem item={parentItem} isSimplify={false} isAbsoluteTime={false}
+        expandedKey="parent" setExpandedKey={() => {}} />,
+    )
+    const packets = container.querySelectorAll('.item-flow-packet-container')
+    expect(packets.length).toBe(2)
+  })
+
+  it('hides sub-items when expandedKey does not match', () => {
+    const { container } = render(
+      <FlowItem item={parentItem} isSimplify={false} isAbsoluteTime={false}
+        expandedKey={null} setExpandedKey={() => {}} />,
+    )
+    expect(container.querySelectorAll('.item-flow-packet-container').length).toBe(1)
+  })
+
+  it('toggle click calls setExpandedKey and does not call onClickItem', () => {
+    const setExpandedKey = vi.fn()
+    const onClickItem = vi.fn()
+    const { container } = render(
+      <FlowItem item={parentItem} isSimplify={false} isAbsoluteTime={false}
+        expandedKey={null} setExpandedKey={setExpandedKey} onClickItem={onClickItem} />,
+    )
+    fireEvent.click(container.querySelector('.subitems-toggle')!)
+    expect(setExpandedKey).toHaveBeenCalledWith('parent')
+    expect(onClickItem).not.toHaveBeenCalled()
   })
 })

--- a/src/ui/src/dashboard/flow/FlowItem.tsx
+++ b/src/ui/src/dashboard/flow/FlowItem.tsx
@@ -69,19 +69,21 @@ export function FlowItem({
                 style={{ color: item.methodColor }}
               >
                 {hasSubItems ? (
-                  <span
+                  <button
+                    type="button"
                     className="subitems-toggle"
+                    aria-expanded={showSubItems}
+                    aria-label={showSubItems ? 'Collapse consolidated messages' : 'Expand consolidated messages'}
+                    title={showSubItems ? 'Collapse consolidated messages' : 'Expand consolidated messages'}
                     onClick={(event) => {
                       event.stopPropagation()
                       if (!setExpandedKey) return
                       const nextExpanded = showSubItems ? null : itemKey
                       setExpandedKey(nextExpanded)
                     }}
-                    aria-label={showSubItems ? 'Collapse consolidated messages' : 'Expand consolidated messages'}
-                    title={showSubItems ? 'Collapse consolidated messages' : 'Expand consolidated messages'}
                   >
                     {showSubItems ? '▽' : '▷'}
-                  </span>
+                  </button>
                 ) : null}
                 <span>{item.method || '—'}</span>
                 {item.protoLabel ? <span className="proto-label">{item.protoLabel}</span> : null}

--- a/src/ui/src/dashboard/flow/FlowItem.tsx
+++ b/src/ui/src/dashboard/flow/FlowItem.tsx
@@ -1,4 +1,5 @@
 import type { FlowItemData } from './flow-data'
+import { useEffect, useState } from 'react'
 
 interface FlowItemProps {
   item: FlowItemData
@@ -6,6 +7,9 @@ interface FlowItemProps {
   isAbsoluteTime: boolean
   singleHost?: boolean
   onClickItem?: (item: FlowItemData) => void
+  expandedKey?: string | null
+  setExpandedKey?: (key: string | null) => void
+  isSubItem?: boolean
 }
 
 export function FlowItem({
@@ -14,7 +18,22 @@ export function FlowItem({
   isAbsoluteTime,
   singleHost,
   onClickItem,
+  expandedKey,
+  setExpandedKey,
+  isSubItem,
 }: FlowItemProps) {
+  const itemKey = String(item.id ?? item.idx)
+  const hasSubItems = !!item.subItems && item.subItems.length > 0
+  const [showSubItems, setShowSubItems] = useState(false)
+
+  useEffect(() => {
+    if (!hasSubItems) {
+      setShowSubItems(false)
+      return
+    }
+    setShowSubItems(expandedKey === itemKey)
+  }, [expandedKey, hasSubItems, itemKey])
+
   const flexStart = item.start || 0.0000001
   const flexMiddle = item.middle || 0.0000001
   const flexRight = item.isRadial
@@ -23,73 +42,108 @@ export function FlowItem({
 
   const arrowColor = item.callidColors.arrowColor
   const radialDottedClass = item.arrowStyleSolid ? '' : ' dotted'
-  const containerClass = `item-flow-packet-container${singleHost ? ' single-host' : ''}`
+  const containerClass = `item-flow-packet-container${singleHost ? ' single-host' : ''}${
+    hasSubItems ? ' consolidated-parent' : ''
+  }${isSubItem ? ' consolidated-subitem' : ''}`
 
   return (
-    <div className={containerClass}>
-      <div className="bg-color-polygon" style={{ backgroundColor: item.callidColors.color }} />
-      <div className="bg-color-tab" style={{ backgroundColor: item.callidColors.tabColor }} />
-      <div
-        className="item-flow-packet"
-        onClick={() => onClickItem?.(item)}
-      >
-        <div className="item-flow-track">
-          <div style={{ flex: flexStart }} />
-          <div
-            className="item-flow-segment"
-            style={{
-              flex: flexMiddle,
-              textAlign: item.direction ? 'right' : 'left',
-            }}
-          >
+    <>
+      <div className={containerClass}>
+        <div className="bg-color-polygon" style={{ backgroundColor: item.callidColors.color }} />
+        <div className="bg-color-tab" style={{ backgroundColor: item.callidColors.tabColor }} />
+        <div
+          className="item-flow-packet"
+          onClick={() => onClickItem?.(item)}
+        >
+          <div className="item-flow-track">
+            <div style={{ flex: flexStart }} />
             <div
-              className={`call_text${item.direction ? ' right' : ''}`}
-              style={{ color: item.methodColor }}
+              className="item-flow-segment"
+              style={{
+                flex: flexMiddle,
+                textAlign: item.direction ? 'right' : 'left',
+              }}
             >
-              <span>{item.method || '—'}</span>
-              {item.protoLabel ? <span className="proto-label">{item.protoLabel}</span> : null}
-            </div>
-
-            {!isSimplify && <div className="call_text-mini">{item.description}</div>}
-
-            {!item.isRadial ? (
               <div
-                className={`arrow ${item.direction ? 'left ' : ''}${
-                  item.arrowStyleSolid ? 'arrow-solid' : 'arrow-dotted'
-                }`}
-                style={{ color: arrowColor }}
-              />
-            ) : (
-              <div
-                className={`${item.isLastHost ? 'radial-arrow-end' : 'radial-arrow'}${radialDottedClass}`}
-                style={{ color: arrowColor }}
-              />
-            )}
-
-            {item.isRadial ? (
-              <div className="radial-port-labels">
-                <span className="radial-port-src">{item.srcPort || ''}</span>
-                <span className="radial-port-dst">{item.dstPort || ''}</span>
+                className={`call_text${item.direction ? ' right' : ''}`}
+                style={{ color: item.methodColor }}
+              >
+                {hasSubItems ? (
+                  <span
+                    className="subitems-toggle"
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      if (!setExpandedKey) return
+                      const nextExpanded = showSubItems ? null : itemKey
+                      setExpandedKey(nextExpanded)
+                    }}
+                    aria-label={showSubItems ? 'Collapse consolidated messages' : 'Expand consolidated messages'}
+                    title={showSubItems ? 'Collapse consolidated messages' : 'Expand consolidated messages'}
+                  >
+                    {showSubItems ? '▽' : '▷'}
+                  </span>
+                ) : null}
+                <span>{item.method || '—'}</span>
+                {item.protoLabel ? <span className="proto-label">{item.protoLabel}</span> : null}
+                {hasSubItems ? <span className="subitems-count">+{item.subItems!.length}</span> : null}
               </div>
-            ) : (
-              <>
-                <div className={item.direction ? 'port-label-right' : 'port-label-left'}>
-                  {item.srcPort || ''}
-                </div>
-                <div className={item.direction ? 'port-label-left' : 'port-label-right'}>
-                  {item.dstPort || ''}
-                </div>
-              </>
-            )}
 
-            {!isSimplify && (
-              <div className="call-text-date">{isAbsoluteTime ? item.fullDateStr : item.diffStr}</div>
-            )}
-            {isSimplify && <div className="call-text-date">{item.diffStr}</div>}
+              {!isSimplify && <div className="call_text-mini">{item.description}</div>}
+
+              {!item.isRadial ? (
+                <div
+                  className={`arrow ${item.direction ? 'left ' : ''}${
+                    item.arrowStyleSolid ? 'arrow-solid' : 'arrow-dotted'
+                  }`}
+                  style={{ color: arrowColor }}
+                />
+              ) : (
+                <div
+                  className={`${item.isLastHost ? 'radial-arrow-end' : 'radial-arrow'}${radialDottedClass}`}
+                  style={{ color: arrowColor }}
+                />
+              )}
+
+              {item.isRadial ? (
+                <div className="radial-port-labels">
+                  <span className="radial-port-src">{item.srcPort || ''}</span>
+                  <span className="radial-port-dst">{item.dstPort || ''}</span>
+                </div>
+              ) : (
+                <>
+                  <div className={item.direction ? 'port-label-right' : 'port-label-left'}>
+                    {item.srcPort || ''}
+                  </div>
+                  <div className={item.direction ? 'port-label-left' : 'port-label-right'}>
+                    {item.dstPort || ''}
+                  </div>
+                </>
+              )}
+
+              {!isSimplify && (
+                <div className="call-text-date">{isAbsoluteTime ? item.fullDateStr : item.diffStr}</div>
+              )}
+              {isSimplify && <div className="call-text-date">{item.diffStr}</div>}
+            </div>
+            <div style={{ flex: flexRight }} />
           </div>
-          <div style={{ flex: flexRight }} />
         </div>
       </div>
-    </div>
+      {hasSubItems && showSubItems
+        ? item.subItems!.map((subItem, idx) => (
+            <FlowItem
+              key={`${itemKey}:sub:${subItem.id ?? idx}`}
+              item={subItem}
+              isSimplify={isSimplify}
+              isAbsoluteTime={isAbsoluteTime}
+              singleHost={singleHost}
+              onClickItem={onClickItem}
+              expandedKey={expandedKey}
+              setExpandedKey={setExpandedKey}
+              isSubItem
+            />
+          ))
+        : null}
+    </>
   )
 }

--- a/src/ui/src/dashboard/flow/flow-data.test.ts
+++ b/src/ui/src/dashboard/flow/flow-data.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { buildFlow, buildHosts, endpointAlias, hostKey, hostKeyFromMessage } from './flow-data'
+import {
+  buildFlow, buildHosts, endpointAlias, hostKey, hostKeyFromMessage,
+  runtimeFingerprintOf, captureIdOf, consolidateFlowItems,
+} from './flow-data'
+import type { FlowItemData, RawMessage } from './flow-data'
 
 describe('hostKey group-by-alias', () => {
   it('uses alias prefix when enrichment provides alias', () => {
@@ -86,5 +90,124 @@ describe('buildFlow group-by-alias', () => {
     expect(flowItems).toHaveLength(2)
     expect(flowItems[0].start).toBe(flowItems[1].start)
     expect(endpointAlias({ src_ip: '1.2.3.4', aliasSrc: 'Edge' }, 'src')).toBe('Edge')
+  })
+})
+
+function makeFlowItem(overrides: Partial<FlowItemData> & { ts?: number } = {}): FlowItemData {
+  const { ts, ...rest } = overrides
+  return {
+    id: 'x', idx: 0, method: 'INVITE', description: '', srcIp: '10.0.0.1',
+    dstIp: '10.0.0.2', srcPort: 5060, dstPort: 5060, callid: 'c1',
+    callidColors: { color: '#000', tabColor: '#000', arrowColor: '#000' },
+    methodColor: '#000', timeStr: '', fullDateStr: '', diffStr: '',
+    protoLabel: '', payloadType: 'SIP', start: 0, middle: 1, rightEnd: 0,
+    direction: false, isRadial: false, isLastHost: false, arrowStyleSolid: true,
+    raw: { timestamp: ts ?? new Date('2026-01-01T00:00:00Z').getTime() },
+    runtimeFingerprint: 'fp1',
+    captureId: '1001',
+    ...rest,
+  }
+}
+
+describe('runtimeFingerprintOf', () => {
+  it('returns empty string when payload is missing', () => {
+    expect(runtimeFingerprintOf({ src_ip: '10.0.0.1', dst_ip: '10.0.0.2' })).toBe('')
+  })
+
+  it('returns empty string when src_ip is missing', () => {
+    expect(runtimeFingerprintOf({ dst_ip: '10.0.0.2', payload: 'INVITE sip:bob SIP/2.0' })).toBe('')
+  })
+
+  it('produces the same hash for identical inputs', () => {
+    const msg: RawMessage = { src_ip: '10.0.0.1', src_port: 5060, dst_ip: '10.0.0.2', dst_port: 5060, payload: 'INVITE sip:bob SIP/2.0' }
+    expect(runtimeFingerprintOf(msg)).toBe(runtimeFingerprintOf({ ...msg }))
+  })
+
+  it('produces different hashes for different payloads', () => {
+    const base: RawMessage = { src_ip: '10.0.0.1', src_port: 5060, dst_ip: '10.0.0.2', dst_port: 5060 }
+    const a = runtimeFingerprintOf({ ...base, payload: 'INVITE sip:bob SIP/2.0' })
+    const b = runtimeFingerprintOf({ ...base, payload: 'BYE sip:bob SIP/2.0' })
+    expect(a).not.toBe('')
+    expect(a).not.toBe(b)
+  })
+
+  it('returns a pre-existing fingerprint field without recomputing', () => {
+    const msg: RawMessage = {
+      src_ip: '10.0.0.1', src_port: 5060, dst_ip: '10.0.0.2', dst_port: 5060,
+      payload: 'INVITE sip:bob SIP/2.0', fingerprint: 'precomputed-abc123',
+    }
+    expect(runtimeFingerprintOf(msg)).toBe('precomputed-abc123')
+  })
+})
+
+describe('captureIdOf', () => {
+  it('reads capture_id from the top-level row', () => {
+    expect(captureIdOf({ capture_id: '1001' } as RawMessage)).toBe('1001')
+  })
+
+  it('falls back to node_id', () => {
+    expect(captureIdOf({ node_id: 42 } as RawMessage)).toBe('42')
+  })
+
+  it('reads capture_id from data_extra JSON string', () => {
+    expect(captureIdOf({ data_extra: JSON.stringify({ capture_id: '2002' }) } as RawMessage)).toBe('2002')
+  })
+
+  it('returns empty string when nothing is present', () => {
+    expect(captureIdOf({} as RawMessage)).toBe('')
+  })
+})
+
+describe('consolidateFlowItems', () => {
+  it('returns items without subItems when disabled', () => {
+    const items = [makeFlowItem({ id: 'a' }), makeFlowItem({ id: 'b', captureId: '1002' })]
+    const result = consolidateFlowItems(items, { enabled: false, timeThresholdMs: 500 })
+    expect(result).toHaveLength(2)
+    expect(result.every((i) => i.subItems === undefined)).toBe(true)
+  })
+
+  it('consolidates items with same fingerprint and different capture IDs within threshold', () => {
+    const base = new Date('2026-01-01T00:00:00Z').getTime()
+    const a = makeFlowItem({ id: 'a', captureId: '1001', ts: base })
+    const b = makeFlowItem({ id: 'b', captureId: '1002', ts: base + 100 })
+    const result = consolidateFlowItems([a, b], { enabled: true, timeThresholdMs: 500 })
+    expect(result).toHaveLength(1)
+    expect(result[0].subItems).toHaveLength(1)
+    expect(result[0].subItems![0].captureId).toBe('1002')
+  })
+
+  it('does not consolidate items outside the time threshold', () => {
+    const base = new Date('2026-01-01T00:00:00Z').getTime()
+    const a = makeFlowItem({ id: 'a', captureId: '1001', ts: base })
+    const b = makeFlowItem({ id: 'b', captureId: '1002', ts: base + 1000 })
+    const result = consolidateFlowItems([a, b], { enabled: true, timeThresholdMs: 500 })
+    expect(result).toHaveLength(2)
+    expect(result.every((i) => i.subItems === undefined)).toBe(true)
+  })
+
+  it('does not consolidate items with the same capture ID', () => {
+    const base = new Date('2026-01-01T00:00:00Z').getTime()
+    const a = makeFlowItem({ id: 'a', captureId: '1001', ts: base })
+    const b = makeFlowItem({ id: 'b', captureId: '1001', ts: base + 100 })
+    const result = consolidateFlowItems([a, b], { enabled: true, timeThresholdMs: 500 })
+    expect(result).toHaveLength(2)
+  })
+
+  it('does not consolidate items with different fingerprints', () => {
+    const base = new Date('2026-01-01T00:00:00Z').getTime()
+    const a = makeFlowItem({ id: 'a', captureId: '1001', runtimeFingerprint: 'fp1', ts: base })
+    const b = makeFlowItem({ id: 'b', captureId: '1002', runtimeFingerprint: 'fp2', ts: base + 100 })
+    const result = consolidateFlowItems([a, b], { enabled: true, timeThresholdMs: 500 })
+    expect(result).toHaveLength(2)
+  })
+
+  it('does not mutate original items', () => {
+    const base = new Date('2026-01-01T00:00:00Z').getTime()
+    const a = makeFlowItem({ id: 'a', captureId: '1001', ts: base })
+    const b = makeFlowItem({ id: 'b', captureId: '1002', ts: base + 100 })
+    const original = [a, b]
+    consolidateFlowItems(original, { enabled: true, timeThresholdMs: 500 })
+    expect(original[0].subItems).toBeUndefined()
+    expect(original[1].subItems).toBeUndefined()
   })
 })

--- a/src/ui/src/dashboard/flow/flow-data.test.ts
+++ b/src/ui/src/dashboard/flow/flow-data.test.ts
@@ -111,11 +111,11 @@ function makeFlowItem(overrides: Partial<FlowItemData> & { ts?: number } = {}): 
 
 describe('runtimeFingerprintOf', () => {
   it('returns empty string when payload is missing', () => {
-    expect(runtimeFingerprintOf({ src_ip: '10.0.0.1', dst_ip: '10.0.0.2' })).toBe('')
+    expect(runtimeFingerprintOf({ src_ip: '10.0.0.1', src_port: 5060, dst_ip: '10.0.0.2', dst_port: 5060 })).toBe('')
   })
 
-  it('returns empty string when src_ip is missing', () => {
-    expect(runtimeFingerprintOf({ dst_ip: '10.0.0.2', payload: 'INVITE sip:bob SIP/2.0' })).toBe('')
+  it('returns empty string when ports are missing', () => {
+    expect(runtimeFingerprintOf({ src_ip: '10.0.0.1', dst_ip: '10.0.0.2', payload: 'INVITE sip:bob SIP/2.0' })).toBe('')
   })
 
   it('produces the same hash for identical inputs', () => {

--- a/src/ui/src/dashboard/flow/flow-data.ts
+++ b/src/ui/src/dashboard/flow/flow-data.ts
@@ -271,14 +271,14 @@ function adoptParentGeometry(parent: FlowItemData, child: FlowItemData): FlowIte
 
 export function consolidateFlowItems(items: FlowItemData[], opts: ConsolidationOptions): FlowItemData[] {
   if (!opts.enabled || items.length === 0) {
-    return items.map((item) => (item.subItems ? { ...item, subItems: undefined } : item))
+    return items.map((item) => ({ ...item, subItems: undefined }))
   }
 
   const groups = new Map<string, FlowItemData[]>()
   const visible: FlowItemData[] = []
 
   for (const item of items) {
-    const resetItem = item.subItems ? { ...item, subItems: undefined } : item
+    const resetItem = { ...item, subItems: undefined }
     const fp = resetItem.runtimeFingerprint || ''
     if (!fp) {
       visible.push(resetItem)

--- a/src/ui/src/dashboard/flow/flow-data.ts
+++ b/src/ui/src/dashboard/flow/flow-data.ts
@@ -227,7 +227,7 @@ export function runtimeFingerprintOf(msg: RawMessage): string {
   const dstPort = String(msg.dst_port ?? '').trim()
   const payload = typeof msg.payload === 'string' ? msg.payload.replace(/\r\n/g, '\n').trim() : ''
 
-  if (!srcIp || !dstIp || !payload) return ''
+  if (!srcIp || !srcPort || !dstIp || !dstPort || !payload) return ''
 
   const source = `${srcIp}:${srcPort}-${dstIp}:${dstPort}-${payload}`
   return fnv1a32Hex(source)
@@ -286,7 +286,7 @@ export function consolidateFlowItems(items: FlowItemData[], opts: ConsolidationO
     }
 
     const candidates = groups.get(fp) || []
-    const parent = candidates.find((candidate) =>
+    const parent = candidates.slice().reverse().find((candidate) =>
       canConsolidateInto(candidate, resetItem, Math.max(0, opts.timeThresholdMs)),
     )
 

--- a/src/ui/src/dashboard/flow/flow-data.ts
+++ b/src/ui/src/dashboard/flow/flow-data.ts
@@ -67,6 +67,9 @@ export interface FlowItemData {
   isLastHost: boolean
   arrowStyleSolid: boolean
   raw: RawMessage
+  runtimeFingerprint?: string
+  captureId?: string
+  subItems?: FlowItemData[]
 }
 
 export interface CallIdLegend {
@@ -75,6 +78,11 @@ export interface CallIdLegend {
 }
 
 export type HostGrouping = 'ungrouped' | 'group-by-ip' | 'group-by-alias'
+
+export interface ConsolidationOptions {
+  enabled: boolean
+  timeThresholdMs: number
+}
 
 const ALIAS_KEY_PREFIX = 'alias:'
 
@@ -174,6 +182,131 @@ export function payloadTypeOf(msg: RawMessage): string {
   if (p === '100') return 'LOG'
   if (msg.sip_method || msg.method) return 'SIP'
   return 'OTHER'
+}
+
+function parseJSONLike(value: unknown): Record<string, unknown> | null {
+  if (!value) return null
+  if (typeof value === 'object') return value as Record<string, unknown>
+  if (typeof value !== 'string') return null
+  try {
+    const parsed = JSON.parse(value)
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : null
+  } catch {
+    return null
+  }
+}
+
+function fnv1a32Hex(input: string): string {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0')
+}
+
+export function captureIdOf(msg: RawMessage): string {
+  const direct = msg.capture_id ?? msg.captureId ?? msg.node_id
+  if (direct != null && String(direct).trim() !== '') return String(direct).trim()
+
+  const extra = parseJSONLike(msg.data_extra)
+  if (!extra) return ''
+
+  const fromExtra = extra.capture_id ?? extra.captureId ?? extra.node_id
+  if (fromExtra == null) return ''
+  return String(fromExtra).trim()
+}
+
+export function runtimeFingerprintOf(msg: RawMessage): string {
+  const existing = msg.fingerprint
+  if (existing != null && String(existing).trim() !== '') return String(existing).trim()
+
+  const srcIp = String(msg.src_ip ?? '').trim()
+  const srcPort = String(msg.src_port ?? '').trim()
+  const dstIp = String(msg.dst_ip ?? '').trim()
+  const dstPort = String(msg.dst_port ?? '').trim()
+  const payload = typeof msg.payload === 'string' ? msg.payload.replace(/\r\n/g, '\n').trim() : ''
+
+  if (!srcIp || !dstIp || !payload) return ''
+
+  const source = `${srcIp}:${srcPort}-${dstIp}:${dstPort}-${payload}`
+  return fnv1a32Hex(source)
+}
+
+function itemTimestampMs(item: FlowItemData): number {
+  const d = parseTs(item.raw?.timestamp ?? item.raw?.create_ts)
+  if (!d) return Number.NaN
+  return d.getTime()
+}
+
+function canConsolidateInto(parent: FlowItemData, child: FlowItemData, timeThresholdMs: number): boolean {
+  if (!parent.runtimeFingerprint || !child.runtimeFingerprint) return false
+  if (parent.runtimeFingerprint !== child.runtimeFingerprint) return false
+
+  const parentCapture = parent.captureId
+  const childCapture = child.captureId
+  if (!parentCapture || !childCapture || parentCapture === childCapture) return false
+
+  if (parent.subItems?.some((s) => s.captureId && s.captureId === childCapture)) return false
+
+  const parentTs = itemTimestampMs(parent)
+  const childTs = itemTimestampMs(child)
+  if (!Number.isFinite(parentTs) || !Number.isFinite(childTs)) return false
+
+  return Math.abs(parentTs - childTs) <= timeThresholdMs
+}
+
+function adoptParentGeometry(parent: FlowItemData, child: FlowItemData): FlowItemData {
+  return {
+    ...child,
+    start: parent.start,
+    middle: parent.middle,
+    rightEnd: parent.rightEnd,
+    direction: parent.direction,
+    isRadial: parent.isRadial,
+    isLastHost: parent.isLastHost,
+    arrowStyleSolid: parent.arrowStyleSolid,
+  }
+}
+
+export function consolidateFlowItems(items: FlowItemData[], opts: ConsolidationOptions): FlowItemData[] {
+  if (!opts.enabled || items.length === 0) {
+    return items.map((item) => (item.subItems ? { ...item, subItems: undefined } : item))
+  }
+
+  const groups = new Map<string, FlowItemData[]>()
+  const visible: FlowItemData[] = []
+
+  for (const item of items) {
+    const resetItem = item.subItems ? { ...item, subItems: undefined } : item
+    const fp = resetItem.runtimeFingerprint || ''
+    if (!fp) {
+      visible.push(resetItem)
+      continue
+    }
+
+    const candidates = groups.get(fp) || []
+    const parent = candidates.find((candidate) =>
+      canConsolidateInto(candidate, resetItem, Math.max(0, opts.timeThresholdMs)),
+    )
+
+    if (!parent) {
+      candidates.push(resetItem)
+      groups.set(fp, candidates)
+      visible.push(resetItem)
+      continue
+    }
+
+    const sub = adoptParentGeometry(parent, resetItem)
+    parent.subItems = parent.subItems ? [...parent.subItems, sub] : [sub]
+  }
+
+  return visible
+}
+
+export function hasRuntimeFingerprintCandidates(items: RawMessage[] | null | undefined): boolean {
+  if (!items || items.length === 0) return false
+  return items.some((msg) => runtimeFingerprintOf(msg) !== '')
 }
 
 export function shortcutIPv6(str: string): string {
@@ -470,6 +603,8 @@ export function buildFlow(items: RawMessage[] | null | undefined, opts: BuildOpt
       isLastHost,
       arrowStyleSolid,
       raw: msg,
+      runtimeFingerprint: runtimeFingerprintOf(msg),
+      captureId: captureIdOf(msg),
     }
   })
 

--- a/src/ui/src/dashboard/flow/flow-data.ts
+++ b/src/ui/src/dashboard/flow/flow-data.ts
@@ -286,9 +286,14 @@ export function consolidateFlowItems(items: FlowItemData[], opts: ConsolidationO
     }
 
     const candidates = groups.get(fp) || []
-    const parent = candidates.slice().reverse().find((candidate) =>
-      canConsolidateInto(candidate, resetItem, Math.max(0, opts.timeThresholdMs)),
-    )
+    const threshold = Math.max(0, opts.timeThresholdMs)
+    let parent: FlowItemData | undefined
+    for (let i = candidates.length - 1; i >= 0; i--) {
+      if (canConsolidateInto(candidates[i], resetItem, threshold)) {
+        parent = candidates[i]
+        break
+      }
+    }
 
     if (!parent) {
       candidates.push(resetItem)

--- a/src/ui/src/dashboard/flow/flowFilterPrefs.test.ts
+++ b/src/ui/src/dashboard/flow/flowFilterPrefs.test.ts
@@ -25,6 +25,8 @@ describe('flowFilterPrefs', () => {
       isSimplify: true,
       isAbsoluteTime: true,
       isHighContrast: true,
+      isConsolidateCaptureIds: false,
+      consolidationTimeThresholdMs: 500,
     })
   })
 

--- a/src/ui/src/dashboard/flow/flowFilterPrefs.test.ts
+++ b/src/ui/src/dashboard/flow/flowFilterPrefs.test.ts
@@ -48,4 +48,24 @@ describe('flowFilterPrefs', () => {
     expect(f.ipExcluded.size).toBe(0)
     expect(f.methodExcluded.size).toBe(0)
   })
+
+  it('round-trips consolidation prefs', () => {
+    saveStoredFlowPrefs({ ...DEFAULT_FILTERS, isConsolidateCaptureIds: true, consolidationTimeThresholdMs: 250 })
+    expect(loadStoredFlowPrefs()).toMatchObject({ isConsolidateCaptureIds: true, consolidationTimeThresholdMs: 250 })
+  })
+
+  it('ignores non-boolean isConsolidateCaptureIds', () => {
+    localStorage.setItem(FLOW_FILTER_PREFS_LS_KEY, JSON.stringify({ isConsolidateCaptureIds: 'yes' }))
+    expect(loadStoredFlowPrefs().isConsolidateCaptureIds).toBeUndefined()
+  })
+
+  it('clamps negative consolidationTimeThresholdMs to 0', () => {
+    localStorage.setItem(FLOW_FILTER_PREFS_LS_KEY, JSON.stringify({ consolidationTimeThresholdMs: -100 }))
+    expect(loadStoredFlowPrefs().consolidationTimeThresholdMs).toBe(0)
+  })
+
+  it('ignores non-finite consolidationTimeThresholdMs', () => {
+    localStorage.setItem(FLOW_FILTER_PREFS_LS_KEY, JSON.stringify({ consolidationTimeThresholdMs: null }))
+    expect(loadStoredFlowPrefs().consolidationTimeThresholdMs).toBeUndefined()
+  })
 })

--- a/src/ui/src/dashboard/flow/flowFilterPrefs.ts
+++ b/src/ui/src/dashboard/flow/flowFilterPrefs.ts
@@ -8,6 +8,8 @@ export interface FlowFilters {
   isSimplify: boolean
   isAbsoluteTime: boolean
   isHighContrast: boolean
+  isConsolidateCaptureIds: boolean
+  consolidationTimeThresholdMs: number
   hostGrouping: HostGrouping
   ipExcluded: Set<string>
   methodExcluded: Set<string>
@@ -19,6 +21,8 @@ export const DEFAULT_FILTERS: FlowFilters = {
   isSimplify: false,
   isAbsoluteTime: false,
   isHighContrast: false,
+  isConsolidateCaptureIds: false,
+  consolidationTimeThresholdMs: 500,
   hostGrouping: 'ungrouped',
   ipExcluded: new Set(),
   methodExcluded: new Set(),
@@ -31,6 +35,8 @@ export interface StoredFlowPrefs {
   isSimplify?: boolean
   isAbsoluteTime?: boolean
   isHighContrast?: boolean
+  isConsolidateCaptureIds?: boolean
+  consolidationTimeThresholdMs?: number
 }
 
 export function isHostGrouping(value: unknown): value is HostGrouping {
@@ -49,6 +55,15 @@ export function loadStoredFlowPrefs(): StoredFlowPrefs {
     if (typeof parsed.isSimplify === 'boolean') out.isSimplify = parsed.isSimplify
     if (typeof parsed.isAbsoluteTime === 'boolean') out.isAbsoluteTime = parsed.isAbsoluteTime
     if (typeof parsed.isHighContrast === 'boolean') out.isHighContrast = parsed.isHighContrast
+    if (typeof parsed.isConsolidateCaptureIds === 'boolean') {
+      out.isConsolidateCaptureIds = parsed.isConsolidateCaptureIds
+    }
+    if (
+      typeof parsed.consolidationTimeThresholdMs === 'number' &&
+      Number.isFinite(parsed.consolidationTimeThresholdMs)
+    ) {
+      out.consolidationTimeThresholdMs = Math.max(0, Math.round(parsed.consolidationTimeThresholdMs))
+    }
     return out
   } catch {
     return {}
@@ -62,6 +77,8 @@ export function saveStoredFlowPrefs(filters: FlowFilters): void {
     isSimplify: filters.isSimplify,
     isAbsoluteTime: filters.isAbsoluteTime,
     isHighContrast: filters.isHighContrast,
+    isConsolidateCaptureIds: filters.isConsolidateCaptureIds,
+    consolidationTimeThresholdMs: filters.consolidationTimeThresholdMs,
   }
   try {
     localStorage.setItem(FLOW_FILTER_PREFS_LS_KEY, JSON.stringify(payload))

--- a/src/ui/src/dashboard/flow/useFlowFilters.ts
+++ b/src/ui/src/dashboard/flow/useFlowFilters.ts
@@ -55,7 +55,14 @@ export function useFlowFilters(items: RawMessage[] | null | undefined): UseFlowF
 
   useEffect(() => {
     saveStoredFlowPrefs(filters)
-  }, [filters.hostGrouping, filters.isSimplify, filters.isAbsoluteTime, filters.isHighContrast])
+  }, [
+    filters.hostGrouping,
+    filters.isSimplify,
+    filters.isAbsoluteTime,
+    filters.isHighContrast,
+    filters.isConsolidateCaptureIds,
+    filters.consolidationTimeThresholdMs,
+  ])
 
   const { filterIP, filterMethod, filterPayloadType, filterCallId, filteredItems } = useMemo(() => {
     const safe = items ?? []

--- a/src/ui/vite.config.ts
+++ b/src/ui/vite.config.ts
@@ -18,7 +18,7 @@ function readHomerAppVersion(): string {
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '')
+  const env = loadEnv(mode, __dirname, '')
   const proxyTarget = env.HOMER_PROXY_TARGET || 'http://de7.sipcapture.io:8081'
   return {
   define: {

--- a/src/ui/vite.config.ts
+++ b/src/ui/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitest/config'
+import { loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import fs from 'node:fs'
 import path from "path"
@@ -16,7 +17,10 @@ function readHomerAppVersion(): string {
 }
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const proxyTarget = env.HOMER_PROXY_TARGET || 'http://de7.sipcapture.io:8081'
+  return {
   define: {
     __HOMER_APP_VERSION__: JSON.stringify(readHomerAppVersion()),
   },
@@ -30,13 +34,13 @@ export default defineConfig({
     port: 5173,
     proxy: {
       '/api': {
-        target: 'http://de7.sipcapture.io:8081',
+        target: proxyTarget,
         changeOrigin: true,
       },
       // Doom widget IWAD — served by the coordinator from gamedata_dir,
       // never part of the UI bundle (see docs/VOIPGames.md).
       '/gamedata': {
-        target: 'http://de7.sipcapture.io:8081',
+        target: proxyTarget,
         changeOrigin: true,
       },
     },
@@ -49,4 +53,5 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
   },
+  }
 })


### PR DESCRIPTION
This change allows the UI to group messages in the Call Flow tab such that all
rows with the same fingerprint but from different Capture IDs are presented as
one, with a dropdown to access the individual messages.

In multi-sensor deployments, multiple capture agents frequently see the same SIP
message. Without consolidation this creates duplicate rows in the call flow,
which can obscure the actual sequence of events and make the diagram harder to
read. This feature collapses those duplicates into a single row with a +N badge
and an expand control, so the flow chart stays clean without losing access to
the per-agent detail.

The fingerprint is computed on the fly in the UI from each message's source IP,
source port, destination IP, destination port, and payload so no ingest-side
changes or server configuration are required. If a pre-computed fingerprint
field is already present on a message row it is used directly instead.

The feature is only available in the filter panel when the current flow actually
contains rows that can be fingerprinted, so it remains hidden for data that
doesn't benefit from it. Capture ID is also shown as a field in the message
detail dialog, displaying "multiple" when a consolidated parent row is opened.

This submission supersedes the original Homer 7 implementation from PR 
sipcapture/homer-ui#646.

AI has assisted in the development of this feature. I confirm that I have read
and understand the changes and take responsibility for the submission.
