### PR TITLE
feat(mcp): add Prometheus metric for NL parser brain + latency

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -348,6 +348,28 @@ Every tool returns a JSON envelope:
 
 The `meta.parser_used` field always tells the client which path actually produced the filters, even when `parser=auto`. This lets you observe LLM hit/miss rates from the agent side.
 
+### Server-side metrics
+
+Every MCP query is also recorded on the standard `/metrics` Prometheus endpoint, so you can watch parser hit rate and latency across all clients without inspecting individual responses:
+
+| Metric                               | Labels             | Meaning                                            |
+|--------------------------------------|--------------------|----------------------------------------------------|
+| `homer_mcp_parser_duration_seconds`  | `parser`, `mode`   | NL parse duration. `parser` = `llm` \| `regex` \| `regex_fallback`; `mode` = `structured` \| `sql`. The `_count` series is the parser hit-rate. |
+
+`parser` says which brain produced the query: `llm` (model used), `regex` (rules only — LLM skipped or disabled), or `regex_fallback` (LLM tried but errored/timed out). `mode` is the resolved execution path (`auto` is resolved to `structured` or `sql` before recording). The regex paths record a near-zero duration, so use `_count` for hit-rate and filter `parser="llm"` for LLM latency.
+
+Example queries:
+
+```promql
+# LLM hit rate over 5m
+sum(rate(homer_mcp_parser_duration_seconds_count{parser="llm"}[5m]))
+  / sum(rate(homer_mcp_parser_duration_seconds_count[5m]))
+
+# LLM p95 latency
+histogram_quantile(0.95,
+  sum by (le) (rate(homer_mcp_parser_duration_seconds_bucket{parser="llm"}[5m])))
+```
+
 ## 9. HTTP API for the UI
 
 Beyond stdio, the Coordinator also exposes the MCP query path over HTTP for the UI's `AI` tab. The HTTP path uses the **same** `LLMClient` as the stdio path, so the parser strategies, provider compatibility, and diagnostics are identical.

--- a/src/coordinator/handlers/transactions_v4.go
+++ b/src/coordinator/handlers/transactions_v4.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sipcapture/homer-core/src/coordinator/sqlvalidator"
 	"github.com/sipcapture/homer-core/src/pcapwriter"
 	logger "github.com/sipcapture/homer-core/src/utils/logging"
+	"github.com/sipcapture/homer-core/src/utils/metrics"
 )
 
 // b2bSuffixRe matches B2BUA suffixes appended to Call-IDs by SIP proxies
@@ -2220,6 +2221,7 @@ func (h *SearchHandler) runMCPAsStructured(c echo.Context, req *MCPQueryRequest)
 		resp.Meta.TimeRange = &TimeRangeMeta{From: searchReq.Timestamp.From, To: searchReq.Timestamp.To}
 	}
 	resp.Meta.Parser = parserMeta
+	metrics.RecordMCPParser(parserMeta.Used, "structured", float64(parserMeta.LatencyMS)/1000.0)
 	return c.JSON(http.StatusOK, resp)
 }
 
@@ -2297,6 +2299,7 @@ func (h *SearchHandler) runMCPAsSQL(c echo.Context, req *MCPQueryRequest) error 
 		resp.Meta.TimeRange = &TimeRangeMeta{From: sqlReq.Timestamp.From, To: sqlReq.Timestamp.To}
 	}
 	resp.Meta.Parser = parserMeta
+	metrics.RecordMCPParser(parserMeta.Used, "sql", float64(parserMeta.LatencyMS)/1000.0)
 	return c.JSON(http.StatusOK, resp)
 }
 

--- a/src/utils/metrics/prometheus.go
+++ b/src/utils/metrics/prometheus.go
@@ -135,6 +135,18 @@ var (
 		[]string{"table"},
 	)
 
+	// MCP natural-language parser duration histogram, labelled by which brain
+	// produced the query (llm|regex|regex_fallback) and the execution mode
+	// (structured|sql). The _count series doubles as the parser hit-rate.
+	MCPParserDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "homer_mcp_parser_duration_seconds",
+			Help:    "MCP natural-language parse duration in seconds by parser (llm|regex|regex_fallback) and mode",
+			Buckets: []float64{0.001, 0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10},
+		},
+		[]string{"parser", "mode"},
+	)
+
 	// DuckLake flushed row counter
 	DucklakeTableFlushedRows = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -323,6 +335,12 @@ func RecordPipelineStageError(protocol, stage, reason string) {
 // RecordPipelineQueueWaitDuration records queue wait duration
 func RecordPipelineQueueWaitDuration(protocol string, duration float64) {
 	PipelineQueueWaitDuration.WithLabelValues(protocol).Observe(duration)
+}
+
+// RecordMCPParser records the MCP parse duration for the given parser brand
+// (llm|regex|regex_fallback) and execution mode (structured|sql).
+func RecordMCPParser(parser, mode string, duration float64) {
+	MCPParserDuration.WithLabelValues(parser, mode).Observe(duration)
 }
 
 // RecordDucklakeTableFlushDuration records table flush duration


### PR DESCRIPTION
## What
Adds `homer_mcp_parser_duration_seconds` — a Prometheus histogram on the
MCP natural-language query path — so parser hit-rate and LLM latency are
observable in Grafana instead of only via per-response JSON meta.

Labels:
- `parser`: `llm` | `regex` | `regex_fallback` (which brain produced the query)
- `mode`: `structured` | `sql` (resolved execution path; `auto` never appears)

Both the LLM and regex paths are recorded, so `_count` is the hit-rate
denominator and the buckets give LLM latency.

## Why
Previously the parser choice + latency lived only in each response's
`meta.parser_used` / `llm_latency_ms`. No aggregation, no p95, no panel.

## How
- `MCPParserDuration` histogram + `RecordMCPParser()` wrapper in the metrics
  package, following the existing `Record*` convention. Reuses the slow-op
  bucket set already used for DuckLake flush.
- One `RecordMCPParser` call in each of `runMCPAsStructured` and `runMCPAsSQL`.
- Documents the metric + example PromQL in `docs/MCP.md`.

## Notes
- Regex paths record ~0 duration — use `_count` for hit-rate, filter
  `parser="llm"` for latency.
- `parser=llm` hard-fails (LLM disabled/errored, returns 4xx/5xx before the
  response) are intentionally not counted in v1.

## Test
- `go build` + `go vet` clean on both changed packages.
