### PR TITLE
fix(ui): tighten Capture-ID consolidation follow-ups

### DIFF
--- a/src/ui/src/dashboard/CallFlow.tsx
+++ b/src/ui/src/dashboard/CallFlow.tsx
@@ -5,7 +5,7 @@ import { FilterPanel } from './flow/FilterPanel'
 import { FlowHostsLine } from './flow/FlowHostsLine'
 import { FlowItem } from './flow/FlowItem'
 import type { FlowItemData, RawMessage } from './flow/flow-data'
-import { buildFlow, buildCallIdLegend, consolidateFlowItems } from './flow/flow-data'
+import { buildFlow, buildCallIdLegend, canConsolidateFlowItems, consolidateFlowItems } from './flow/flow-data'
 import { useFlowFilters } from './flow/useFlowFilters'
 import { useLocale } from '@/components/locale/locale-provider'
 
@@ -40,7 +40,7 @@ export default function CallFlow({ items, timeZone, onClickMessage }: CallFlowPr
   )
 
   const canConsolidateCaptureIds = useMemo(
-    () => flowItems.some((item) => (item.runtimeFingerprint ?? '') !== ''),
+    () => canConsolidateFlowItems(flowItems),
     [flowItems],
   )
 

--- a/src/ui/src/dashboard/MessageModal.tsx
+++ b/src/ui/src/dashboard/MessageModal.tsx
@@ -104,10 +104,19 @@ function highlightSIP(payload) {
   return out.join('\n')
 }
 
+import { captureIdOf } from './flow/flow-data'
+
 const META_FIELDS = ['uuid', 'date', 'timestamp', 'event', 'method', 'src_ip', 'dst_ip', 'src_port', 'dst_port', 'session_id', 'cid', 'node_id']
 
 const META_FIELD_LABELS: Record<string, string> = {
   node_id: 'Capture ID',
+}
+
+function resolveCaptureIdDisplay(data) {
+  if (!data) return undefined
+  if (data.node_id != null && String(data.node_id).trim() !== '') return String(data.node_id).trim()
+  const resolved = captureIdOf(data)
+  return resolved || undefined
 }
 
 function parseTimestampValue(value) {
@@ -166,7 +175,7 @@ function MetaGrid({ data, timeZone, locale, overrides = {} }) {
             </div>
           )
         }
-        const raw = data[field]
+        const raw = field === 'node_id' ? resolveCaptureIdDisplay(data) : data[field]
         const display = raw === undefined
           ? '—'
           : field === 'timestamp'

--- a/src/ui/src/dashboard/TransactionModal.tsx
+++ b/src/ui/src/dashboard/TransactionModal.tsx
@@ -749,6 +749,11 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
     const raw = flowItem.raw || flowItem
     const uuid = raw.uuid || raw.id || flowItem.id
     const isConsolidatedParent = Array.isArray(flowItem.subItems) && flowItem.subItems.length > 0
+    const captureIdOverride = isConsolidatedParent
+      ? 'multiple'
+      : (flowItem.captureId != null && String(flowItem.captureId).trim() !== ''
+        ? String(flowItem.captureId).trim()
+        : undefined)
     const messageContext = {
       proto_type: 1,
       event_type: 'call',
@@ -756,7 +761,7 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
         const ts = resolveTimeRange(timeRange, timeZone)
         return ts ? { from: ts.from, to: ts.to } : undefined
       })(),
-      metaOverrides: isConsolidatedParent ? { node_id: 'multiple' } : undefined,
+      metaOverrides: captureIdOverride != null ? { node_id: captureIdOverride } : undefined,
     }
     const nestedKey = newModalKey()
     const update = (modal) => setMessageModals(prev =>

--- a/src/ui/src/dashboard/flow/FlowItem.test.tsx
+++ b/src/ui/src/dashboard/flow/FlowItem.test.tsx
@@ -70,6 +70,14 @@ describe('FlowItem consolidation', () => {
     expect(container.querySelector('.subitems-count')?.textContent).toBe('+1')
   })
 
+  it('does not render toggle when setExpandedKey is missing', () => {
+    const { container } = render(
+      <FlowItem item={parentItem} isSimplify={false} isAbsoluteTime={false} />,
+    )
+    expect(container.querySelector('.subitems-toggle')).toBeNull()
+    expect(container.querySelector('.subitems-count')?.textContent).toBe('+1')
+  })
+
   it('does not render toggle when item has no subItems', () => {
     const { container } = render(
       <FlowItem item={makeItem(false)} isSimplify={false} isAbsoluteTime={false} />,

--- a/src/ui/src/dashboard/flow/FlowItem.tsx
+++ b/src/ui/src/dashboard/flow/FlowItem.tsx
@@ -1,5 +1,4 @@
 import type { FlowItemData } from './flow-data'
-import { useEffect, useState } from 'react'
 
 interface FlowItemProps {
   item: FlowItemData
@@ -24,15 +23,8 @@ export function FlowItem({
 }: FlowItemProps) {
   const itemKey = String(item.id ?? item.idx)
   const hasSubItems = !!item.subItems && item.subItems.length > 0
-  const [showSubItems, setShowSubItems] = useState(false)
-
-  useEffect(() => {
-    if (!hasSubItems) {
-      setShowSubItems(false)
-      return
-    }
-    setShowSubItems(expandedKey === itemKey)
-  }, [expandedKey, hasSubItems, itemKey])
+  const canToggleSubItems = hasSubItems && typeof setExpandedKey === 'function'
+  const showSubItems = canToggleSubItems && expandedKey === itemKey
 
   const flexStart = item.start || 0.0000001
   const flexMiddle = item.middle || 0.0000001
@@ -68,7 +60,7 @@ export function FlowItem({
                 className={`call_text${item.direction ? ' right' : ''}`}
                 style={{ color: item.methodColor }}
               >
-                {hasSubItems ? (
+                {canToggleSubItems ? (
                   <button
                     type="button"
                     className="subitems-toggle"
@@ -77,9 +69,7 @@ export function FlowItem({
                     title={showSubItems ? 'Collapse consolidated messages' : 'Expand consolidated messages'}
                     onClick={(event) => {
                       event.stopPropagation()
-                      if (!setExpandedKey) return
-                      const nextExpanded = showSubItems ? null : itemKey
-                      setExpandedKey(nextExpanded)
+                      setExpandedKey(showSubItems ? null : itemKey)
                     }}
                   >
                     {showSubItems ? '▽' : '▷'}

--- a/src/ui/src/dashboard/flow/flow-data.test.ts
+++ b/src/ui/src/dashboard/flow/flow-data.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildFlow, buildHosts, endpointAlias, hostKey, hostKeyFromMessage,
-  runtimeFingerprintOf, captureIdOf, consolidateFlowItems,
+  runtimeFingerprintOf, captureIdOf, consolidateFlowItems, canConsolidateFlowItems,
 } from './flow-data'
 import type { FlowItemData, RawMessage } from './flow-data'
 
@@ -209,5 +209,31 @@ describe('consolidateFlowItems', () => {
     consolidateFlowItems(original, { enabled: true, timeThresholdMs: 500 })
     expect(original[0].subItems).toBeUndefined()
     expect(original[1].subItems).toBeUndefined()
+  })
+})
+
+describe('canConsolidateFlowItems', () => {
+  it('returns true when the same fingerprint appears with different capture IDs', () => {
+    const items = [
+      makeFlowItem({ id: 'a', captureId: '1001', runtimeFingerprint: 'fp1' }),
+      makeFlowItem({ id: 'b', captureId: '1002', runtimeFingerprint: 'fp1' }),
+    ]
+    expect(canConsolidateFlowItems(items)).toBe(true)
+  })
+
+  it('returns false when fingerprints exist but capture IDs are unique per fingerprint', () => {
+    const items = [
+      makeFlowItem({ id: 'a', captureId: '1001', runtimeFingerprint: 'fp1' }),
+      makeFlowItem({ id: 'b', captureId: '1001', runtimeFingerprint: 'fp1' }),
+      makeFlowItem({ id: 'c', captureId: '1002', runtimeFingerprint: 'fp2' }),
+    ]
+    expect(canConsolidateFlowItems(items)).toBe(false)
+  })
+
+  it('returns false when capture IDs or fingerprints are missing', () => {
+    expect(canConsolidateFlowItems([
+      makeFlowItem({ id: 'a', captureId: '', runtimeFingerprint: 'fp1' }),
+      makeFlowItem({ id: 'b', captureId: '1002', runtimeFingerprint: '' }),
+    ])).toBe(false)
   })
 })

--- a/src/ui/src/dashboard/flow/flow-data.ts
+++ b/src/ui/src/dashboard/flow/flow-data.ts
@@ -314,6 +314,24 @@ export function hasRuntimeFingerprintCandidates(items: RawMessage[] | null | und
   return items.some((msg) => runtimeFingerprintOf(msg) !== '')
 }
 
+/** True when at least one fingerprint is shared by two or more distinct capture IDs. */
+export function canConsolidateFlowItems(items: FlowItemData[]): boolean {
+  const captureIdsByFp = new Map<string, Set<string>>()
+  for (const item of items) {
+    const fp = item.runtimeFingerprint || ''
+    const captureId = item.captureId || ''
+    if (!fp || !captureId) continue
+    let ids = captureIdsByFp.get(fp)
+    if (!ids) {
+      ids = new Set()
+      captureIdsByFp.set(fp, ids)
+    }
+    ids.add(captureId)
+    if (ids.size >= 2) return true
+  }
+  return false
+}
+
 export function shortcutIPv6(str: string): string {
   if (!str) return ''
   const m = str.match(/^\[?([\da-fA-F]+):.*:([\da-fA-F]+)]?$/)


### PR DESCRIPTION
## Summary
- Resolve Capture ID in message meta via `captureIdOf()` (not only `node_id`), and pass `flowItem.captureId` / `multiple` through Call Flow `metaOverrides`
- Derive consolidated sub-item expand state from `expandedKey` synchronously; render the toggle only when `setExpandedKey` is provided
- Show consolidation filter controls only when a fingerprint is shared by two or more distinct Capture IDs

Follow-up to #916.

## Test plan
- [x] `cd src/ui && npm test -- --run flow-data.test.ts FlowItem.test.tsx flowFilterPrefs.test.ts`
- [x] Multi-sensor call flow: toggle appears only with duplicate fingerprints across Capture IDs
- [x] Expand/collapse consolidated row updates immediately; sub-item click opens message with correct Capture ID
- [x] Consolidated parent still shows Capture ID as `multiple`