### PR TITLE
chore: bump version to 11.0.308

### DIFF
--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.307"
+	VERSION_APPLICATION = "11.0.308"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Bump `VERSION_APPLICATION` to `11.0.308` after Capture-ID consolidation (#916/#918) and MCP parser latency metric (#917).

## Test plan
- [x] Confirm `src/version.go` shows `11.0.308`
- [ ] Publish GitHub release `11.0.308` to trigger package build