### PR TITLE
fix(security): block self-assigned admin role (GHSA-24vc-w334-95wm)

### DIFF
--- a/src/coordinator/handlers/users_v4.go
+++ b/src/coordinator/handlers/users_v4.go
@@ -178,13 +178,20 @@ func (h *UsersHandler) V4UsersUpdate(c echo.Context) error {
 		return writeError(c, http.StatusBadRequest, "Bad Request", "Invalid user id")
 	}
 
-	if !isAdmin(c) && !isSelf(c, h.userService, userID) {
+	adminCaller := isAdmin(c)
+	if !adminCaller && !isSelf(c, h.userService, userID) {
 		return writeError(c, http.StatusForbidden, "Forbidden", "Insufficient permissions")
 	}
 
 	var req UserPatchRequest
 	if err := c.Bind(&req); err != nil {
 		return writeError(c, http.StatusBadRequest, "Bad Request", "Invalid request body")
+	}
+
+	// Non-admins may update their own profile fields, but must not elevate
+	// privileges or change account activation state (GHSA-24vc-w334-95wm).
+	if !adminCaller && (req.UserGroup != nil || req.Enabled != nil) {
+		return writeError(c, http.StatusForbidden, "Forbidden", "Only administrators can change user_group or enabled")
 	}
 
 	var isAdminValue *bool

--- a/src/coordinator/handlers/users_v4_test.go
+++ b/src/coordinator/handlers/users_v4_test.go
@@ -1,0 +1,136 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+func newTestUsersHandler(t *testing.T) (*UsersHandler, *AuthHandler, int64) {
+	t.Helper()
+	auth, userSvc := newTestAuthHandlerWithUsers(t)
+	ctx := context.Background()
+
+	id, err := userSvc.CreateUser(ctx, "alice", "secret", "alice@example.com", "Alice", false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return NewUsersHandler(userSvc), auth, id
+}
+
+func TestV4UsersUpdate_NonAdminCannotSelfAssignAdmin(t *testing.T) {
+	h, auth, userID := newTestUsersHandler(t)
+	e := echo.New()
+
+	body := `{"user_group":"admin"}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/v4/users/"+strconv.FormatInt(userID, 10), strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("userId")
+	c.SetParamValues(strconv.FormatInt(userID, 10))
+	setJWTOnContext(t, c, auth, "alice", false)
+
+	if err := h.V4UsersUpdate(c); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status: got %d want 403 body=%s", rec.Code, rec.Body.String())
+	}
+
+	user, err := h.userService.GetUserByID(context.Background(), userID)
+	if err != nil || user == nil {
+		t.Fatalf("GetUserByID: err=%v user=%v", err, user)
+	}
+	if user.IsAdmin {
+		t.Fatal("user became admin after forbidden self-role escalation attempt")
+	}
+}
+
+func TestV4UsersUpdate_NonAdminCannotChangeEnabled(t *testing.T) {
+	h, auth, userID := newTestUsersHandler(t)
+	e := echo.New()
+
+	body := `{"enabled":false}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/v4/users/"+strconv.FormatInt(userID, 10), strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("userId")
+	c.SetParamValues(strconv.FormatInt(userID, 10))
+	setJWTOnContext(t, c, auth, "alice", false)
+
+	if err := h.V4UsersUpdate(c); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status: got %d want 403 body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestV4UsersUpdate_NonAdminCanUpdateOwnEmail(t *testing.T) {
+	h, auth, userID := newTestUsersHandler(t)
+	e := echo.New()
+
+	body := `{"email":"alice-new@example.com"}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/v4/users/"+strconv.FormatInt(userID, 10), strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("userId")
+	c.SetParamValues(strconv.FormatInt(userID, 10))
+	setJWTOnContext(t, c, auth, "alice", false)
+
+	if err := h.V4UsersUpdate(c); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200 body=%s", rec.Code, rec.Body.String())
+	}
+
+	user, err := h.userService.GetUserByID(context.Background(), userID)
+	if err != nil || user == nil {
+		t.Fatalf("GetUserByID: err=%v user=%v", err, user)
+	}
+	if user.Email != "alice-new@example.com" {
+		t.Fatalf("email: got %q want alice-new@example.com", user.Email)
+	}
+	if user.IsAdmin {
+		t.Fatal("unexpected admin elevation")
+	}
+}
+
+func TestV4UsersUpdate_AdminCanChangeUserGroup(t *testing.T) {
+	h, auth, userID := newTestUsersHandler(t)
+	e := echo.New()
+
+	body := `{"user_group":"admin"}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/v4/users/"+strconv.FormatInt(userID, 10), strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("userId")
+	c.SetParamValues(strconv.FormatInt(userID, 10))
+	setJWTOnContext(t, c, auth, "admin", true)
+
+	if err := h.V4UsersUpdate(c); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200 body=%s", rec.Code, rec.Body.String())
+	}
+
+	user, err := h.userService.GetUserByID(context.Background(), userID)
+	if err != nil || user == nil {
+		t.Fatalf("GetUserByID: err=%v user=%v", err, user)
+	}
+	if !user.IsAdmin {
+		t.Fatal("admin update did not grant admin role")
+	}
+}

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.308"
+	VERSION_APPLICATION = "11.0.309"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Fix privilege escalation where any authenticated user could `PATCH /api/v4/users/:id` with `user_group: admin` on their own account
- Non-admins may still update own email/password/name; `user_group` and `enabled` require admin
- Add regression tests; bump to `11.0.309`

**Note:** the advisory suggested `!isAdmin || !isSelf`, which would incorrectly require both admin *and* self and break normal profile updates / admin management of other users.

Fixes GHSA-24vc-w334-95wm

## Test plan
- [x] `go test ./coordinator/handlers/ -run V4UsersUpdate_`
- [ ] Non-admin JWT cannot self-elevate via `PATCH /api/v4/users/<id> {"user_group":"admin"}` → 403
- [ ] Non-admin can still patch own email
- [ ] Admin can still change another user's `user_group`