### PR TITLE
fix(node): reconnect DuckDB on catalog refresh (11.0.310)

### DIFF
--- a/docs/GRAFANA_INTEGRATION.md
+++ b/docs/GRAFANA_INTEGRATION.md
@@ -51,7 +51,7 @@ Minimal additions under `node`:
 ```
 
 - **`auth_token`**: if non-empty, clients must send `Authorization: Bearer <token>`.
-- **`catalog_refresh_interval_sec`**: periodic catalog refresh on the node when it does **not** share the writer’s DuckDB (`sharedDB`). With an all-in-one writer+node process, hot rows usually come from the shared DB path instead.
+- **`catalog_refresh_interval_sec`**: periodic catalog refresh on the node when it does **not** share the writer’s DuckDB (`sharedDB`). Refresh reconnects DuckDB (open → ATTACH → swap → close old) so DuckLake ObjectCache does not grow from in-place `DETACH`/`ATTACH`. With an all-in-one writer+node process, hot rows usually come from the shared DB path instead.
 
 Use the **same** lake name as `storage.ducklake.lake_name` / `node.ducklake.lake_name` (default `homer_lake`). In all-in-one deployments, **`node.ducklake`** should mirror **`storage.ducklake`** (same `lake_name`, `catalog_path`, data `path`, and volume `name` entries where applicable). If you use **tiered** storage, keep **`node.ducklake.volumes`** aligned with **`storage.ducklake.storage_policy.volumes`** (see [NODE.md](NODE.md) and [STORAGE_POLICIES.md](STORAGE_POLICIES.md)).
 

--- a/docs/NODE.md
+++ b/docs/NODE.md
@@ -123,7 +123,7 @@ The Node module exposes **DuckDB Airport** on `flight_server` (Arrow Flight with
 | `host` | string | "0.0.0.0" | Listen address |
 | `port` | int | 50055 | gRPC FlightSQL port |
 | `auth_token` | string | "" | If set, require `Authorization: Bearer <token>` |
-| `catalog_refresh_interval_sec` | int | 30 | Periodic `DETACH`/`ATTACH` refresh when not using a shared writer DB |
+| `catalog_refresh_interval_sec` | int | 30 | Periodic DuckDB reconnect (re-ATTACH volumes on a fresh handle) when not using a shared writer DB; avoids DuckLake ObjectCache growth from in-place `DETACH`/`ATTACH` |
 
 See [FLIGHTSQL.md](FLIGHTSQL.md) for Grafana setup and coordinator proxy (`coordinator.flightsql_server`, default port **32010**).
 

--- a/src/node/catalog.go
+++ b/src/node/catalog.go
@@ -49,6 +49,20 @@ func NewDuckLakeCatalog(db *sql.DB, lakeName string, volumes []VolumeInfo) *Duck
 	return c
 }
 
+// replaceDB swaps the underlying DuckDB handle and rebuilds schema wrappers
+// after a catalog reconnect. Must be called while holding the Node refresh
+// write lock so no Airport query still uses the previous *sql.DB.
+func (c *DuckLakeCatalog) replaceDB(db *sql.DB, volumes []VolumeInfo) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.db = db
+	c.volumes = volumes
+	c.schemas = make(map[string]*DuckLakeSchema)
+	mainSchema := NewDuckLakeSchema(db, c.lakeName, "main", volumes)
+	c.schemas["main"] = mainSchema
+	c.schemas[c.lakeName] = mainSchema
+}
+
 // Name returns the catalog name
 func (c *DuckLakeCatalog) Name() string {
 	return "homer"

--- a/src/node/catalog_reconnect_test.go
+++ b/src/node/catalog_reconnect_test.go
@@ -1,0 +1,87 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package node
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+)
+
+func TestCatalogReplaceDB(t *testing.T) {
+	t.Parallel()
+
+	oldDB, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open old: %v", err)
+	}
+	t.Cleanup(func() { _ = oldDB.Close() })
+
+	cat := NewDuckLakeCatalog(oldDB, "homer_lake", nil)
+	if cat.db != oldDB {
+		t.Fatal("expected catalog to hold old DB")
+	}
+
+	newDB, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open new: %v", err)
+	}
+	t.Cleanup(func() { _ = newDB.Close() })
+
+	vols := []VolumeInfo{{Name: "default", LakeName: "homer_lake", Path: "/tmp"}}
+	cat.replaceDB(newDB, vols)
+
+	if cat.db != newDB {
+		t.Fatal("catalog.db not swapped")
+	}
+	if len(cat.volumes) != 1 || cat.volumes[0].Name != "default" {
+		t.Fatalf("volumes not swapped: %+v", cat.volumes)
+	}
+	main, err := cat.Schema(t.Context(), "main")
+	if err != nil {
+		t.Fatalf("main schema missing after replace: %v", err)
+	}
+	schema, ok := main.(*DuckLakeSchema)
+	if !ok {
+		t.Fatalf("unexpected schema type %T", main)
+	}
+	if schema.db != newDB {
+		t.Fatal("schema still points at old DB")
+	}
+}
+
+func TestQueryDBSeesSwappedHandle(t *testing.T) {
+	t.Parallel()
+
+	oldDB, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open old: %v", err)
+	}
+	t.Cleanup(func() { _ = oldDB.Close() })
+
+	newDB, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open new: %v", err)
+	}
+	t.Cleanup(func() { _ = newDB.Close() })
+
+	n := &Node{db: oldDB, catalog: NewDuckLakeCatalog(oldDB, "homer_lake", nil)}
+	if n.queryDB() != oldDB {
+		t.Fatal("expected old DB from queryDB")
+	}
+
+	n.mu.Lock()
+	n.db = newDB
+	n.mu.Unlock()
+	n.catalog.replaceDB(newDB, nil)
+
+	if n.queryDB() != newDB {
+		t.Fatal("queryDB did not observe swapped handle")
+	}
+}

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -62,6 +62,10 @@ type Node struct {
 	// fsql is the optional Apache Arrow FlightSQL server (Grafana / InfluxDB FlightSQL).
 	fsql *fsqlServer
 
+	// refreshMu serializes catalog reconnect on n.db so queries never observe
+	// a half-swapped handle while ObjectCache from DETACH+ATTACH is avoided.
+	refreshMu sync.Mutex
+
 	// broker is optional: wired from main.go when the ingest module is
 	// running in the same process and ingest.hep_stream.enable is true.
 	// When nil the /stream endpoint responds with 503 so the coordinator
@@ -137,15 +141,23 @@ func New(cfg *config.NodeConfig) (*Node, error) {
 // Start starts the node module
 func (n *Node) Start() error {
 	n.mu.Lock()
-	defer n.mu.Unlock()
-
 	if n.running {
+		n.mu.Unlock()
 		return fmt.Errorf("node already running")
 	}
+	// Release the lock before refreshCatalog: that function acquires n.mu
+	// internally, so calling it while holding the lock causes a self-deadlock
+	// (sync.RWMutex is not reentrant). Re-acquire after the refresh.
+	n.mu.Unlock()
 
-	// Refresh catalog: DETACH + re-ATTACH so we see tables created by the
-	// storage module that started before us but used a separate DuckDB instance.
+	// Refresh catalog so we see tables created by the storage module (which
+	// runs its own DuckDB instance sharing the same catalog file). Reconnect
+	// DuckDB instead of DETACH+ATTACH in place so DuckLake ObjectCache is
+	// freed — see refreshCatalog and QXIP/hepic-lake#70.
 	n.refreshCatalog()
+
+	n.mu.Lock()
+	defer n.mu.Unlock()
 
 	// Start gRPC server for FlightSQL (Airport protocol)
 	grpcAddr := fmt.Sprintf("%s:%d", n.config.FlightServer.Host, n.config.FlightServer.Port)
@@ -188,6 +200,8 @@ func (n *Node) Start() error {
 	}()
 
 	if n.fsql != nil {
+		// Periodic refresh only when the node owns its DuckDB. With a shared
+		// writer DB, queries already see live flushes via queryDB().
 		if n.sharedDB == nil {
 			n.fsql.withCatalogRefresher(func() { n.refreshCatalog() })
 		}
@@ -199,27 +213,50 @@ func (n *Node) Start() error {
 	return nil
 }
 
-// refreshCatalog detaches and re-attaches all DuckLake volumes so that
-// the node sees any tables created by the storage module (which runs
-// its own DuckDB instance sharing the same catalog file).
+// refreshCatalog opens a fresh in-memory DuckDB, re-ATTACHes DuckLake volumes,
+// swaps the Node *sql.DB under refreshMu, then closes the previous Database.
+// Closing the old handle frees DuckDB's ObjectCache, which is required because
+// DETACH+ATTACH on the same Database orphans DuckLake schema/stats cache
+// entries keyed by a per-ATTACH random instance_id (upstream duckdb/ducklake;
+// tracked as QXIP/hepic-lake#70 / sipcapture/homer catalog refresh).
+//
+// FlightSQL reads through queryDB() / n.db, so swapping n.db is enough for
+// Grafana. Airport catalog wrappers hold their own *sql.DB pointers and are
+// updated via DuckLakeCatalog.replaceDB.
 func (n *Node) refreshCatalog() {
-	for _, vol := range n.volumes {
-		detachSQL := fmt.Sprintf("DETACH %s;", vol.LakeName)
-		if _, err := n.db.Exec(detachSQL); err != nil {
-			logger.Warn(fmt.Sprintf("Node: refreshCatalog: DETACH %s failed: %v", vol.LakeName, err))
-		}
-	}
+	n.refreshMu.Lock()
+	defer n.refreshMu.Unlock()
 
-	// Re-attach volumes using the original config
-	newVolumes, err := configureDuckLake(n.db, n.config)
+	newDB, err := sql.Open("duckdb", "")
 	if err != nil {
-		logger.Error(fmt.Sprintf("Node: refreshCatalog: re-attach failed: %v", err))
+		logger.Error(fmt.Sprintf("Node: catalog reconnect failed to open DuckDB: %v", err))
+		return
+	}
+	newDB.SetMaxOpenConns(1)
+
+	newVolumes, err := configureDuckLake(newDB, n.config)
+	if err != nil {
+		_ = newDB.Close()
+		logger.Error(fmt.Sprintf("Node: catalog reconnect failed: %v", err))
 		return
 	}
 
+	n.mu.Lock()
+	oldDB := n.db
+	n.db = newDB
 	n.volumes = newVolumes
-	n.catalog = NewDuckLakeCatalog(n.db, n.config.DuckLake.LakeName, newVolumes)
-	logger.Info("Node: catalog refreshed", "volumes", len(newVolumes))
+	n.mu.Unlock()
+
+	if n.catalog != nil {
+		n.catalog.replaceDB(newDB, newVolumes)
+	}
+
+	if oldDB != nil {
+		if err := oldDB.Close(); err != nil {
+			logger.Warn(fmt.Sprintf("Node: closing previous DuckDB after catalog reconnect: %v", err))
+		}
+	}
+	logger.Info("Node: catalog refreshed via reconnect", "volumes", len(newVolumes))
 }
 
 // Stop stops the node module
@@ -1586,7 +1623,10 @@ func (n *Node) SetTieredQueryDB(db *sql.DB) {
 
 // queryDB returns the best DuckDB connection for queries.
 // Prefers the shared writer DB (real-time visibility) over the node's own DB.
+// Takes n.mu so callers never observe a half-swapped handle during reconnect.
 func (n *Node) queryDB() *sql.DB {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
 	if n.sharedDB != nil {
 		return n.sharedDB
 	}

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.309"
+	VERSION_APPLICATION = "11.0.310"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Node catalog refresh no longer uses in-place `DETACH`+`ATTACH` (orphans DuckLake ObjectCache / RSS growth).
- Refresh reconnects DuckDB (open → ATTACH → swap under `refreshMu` → close old); `DuckLakeCatalog.replaceDB` updates Airport wrappers; FlightSQL already uses `queryDB()`.
- Docs + tests; version **11.0.310**.

## Test plan
- [x] `go test ./node/ -run 'TestCatalogReplaceDB|TestQueryDBSeesSwappedHandle'`
- [x] `go vet ./node/`
- [ ] Deploy node/FlightSQL with `catalog_refresh_interval_sec=30`; confirm log `catalog refreshed via reconnect`
- [ ] Confirm RSS plateaus over several hours on a reader node