### PR TITLE
fix(metrics): align SIP/RTCP node_id via prometheus.agent_label

### DIFF
--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -28,6 +28,7 @@ Field names follow the `mapstructure` tags on [`Config` in `src/config/config.go
 - Loader: `config.Load` — `SetEnvPrefix("HOMER")`, `SetEnvKeyReplacer(".", "_")`, `AutomaticEnv()` ([source](../src/config/config.go)).
 - SIP ingest (`ingest.sip`): `aleg_ids`, `custom_headers`, `force_aleg_id`; see [LUA_CORRELATION.md](LUA_CORRELATION.md#sip-header-lists-writer-ingest) (CID / correlation).
 - High-PPS ingest / DuckLake / Prometheus batching: [INGEST_PERFORMANCE.md](INGEST_PERFORMANCE.md).
+- Prometheus agent label (`prometheus.agent_label` → `HOMER_PROMETHEUS_AGENT_LABEL`): `node_id` (HEP 0x000c / heplify `-hi`, default) or `node_name` (HEP 0x0013 / heplify `-hn`). Controls the value of the Prometheus `node_id` label for SIP/RTCP/RTP metrics.
 - Tiered storage fields: [`docs/STORAGE_POLICIES.md`](STORAGE_POLICIES.md) (conceptual); same paths appear under `storage.ducklake.storage_policy` and `node.ducklake` in JSON — mirror them as `HOMER_*` as above.
 - Example with variables declared inline in Compose: [`examples/docker/docker-compose.yml`](../examples/docker/docker-compose.yml) (`homer.environment`).
 - **Data retention (TTL):** [`RETENTION.md`](RETENTION.md) — `HOMER_STORAGE_DUCKLAKE_COMPACTION_RETENTION_DAYS` and related compaction env vars. Per-table overrides (`retention_days_by_table`) are configured in JSON (map), not as a single env scalar.

--- a/examples/homer-coordinator.json
+++ b/examples/homer-coordinator.json
@@ -73,6 +73,7 @@
     "enable": true,
     "host": "0.0.0.0",
     "port": 9092,
-    "path": "/metrics"
+    "path": "/metrics",
+    "agent_label": "node_id"
   }
 }

--- a/examples/homer-edge.json
+++ b/examples/homer-edge.json
@@ -94,6 +94,7 @@
     "enable": true,
     "host": "0.0.0.0",
     "port": 9090,
-    "path": "/metrics"
+    "path": "/metrics",
+    "agent_label": "node_id"
   }
 }

--- a/examples/homer-modular.json
+++ b/examples/homer-modular.json
@@ -157,7 +157,7 @@
       "secret": "change-me-in-production",
       "expire_hours": 24
     },
-    "auth": { "type": "internal" }
+    "auth": { "type": "internal" },
     "hep_stream": {
       "enable": true,
       "allow_payload": false,
@@ -190,6 +190,7 @@
     "enable": false,
     "host": "0.0.0.0",
     "port": 9090,
-    "path": "/metrics"
+    "path": "/metrics",
+    "agent_label": "node_id"
   }
 }

--- a/examples/homer-node.json
+++ b/examples/homer-node.json
@@ -61,6 +61,7 @@
     "enable": true,
     "host": "0.0.0.0",
     "port": 9091,
-    "path": "/metrics"
+    "path": "/metrics",
+    "agent_label": "node_id"
   }
 }

--- a/examples/homer-s3-parquet-only.json
+++ b/examples/homer-s3-parquet-only.json
@@ -185,6 +185,7 @@
     "enable": true,
     "host": "0.0.0.0",
     "port": 9090,
-    "path": "/metrics"
+    "path": "/metrics",
+    "agent_label": "node_id"
   }
 }

--- a/examples/homer-writer-rustfs.json
+++ b/examples/homer-writer-rustfs.json
@@ -174,6 +174,7 @@
     "enable": true,
     "host": "0.0.0.0",
     "port": 9090,
-    "path": "/metrics"
+    "path": "/metrics",
+    "agent_label": "node_id"
   }
 }

--- a/examples/homer-writer.json
+++ b/examples/homer-writer.json
@@ -166,7 +166,8 @@
     "enable": true,
     "host": "0.0.0.0",
     "port": 9090,
-    "path": "/metrics"
+    "path": "/metrics",
+    "agent_label": "node_id"
   },
   "remote_logging": {
     "loki": {

--- a/examples/homer.json
+++ b/examples/homer.json
@@ -170,6 +170,7 @@
     "enable": true,
     "host": "0.0.0.0",
     "port": 9090,
-    "path": "/metrics"
+    "path": "/metrics",
+    "agent_label": "node_id"
   }
 }

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -1111,6 +1111,28 @@ type PrometheusConfig struct {
 	Path       string `json:"path" mapstructure:"path" default:"/metrics"`
 	TargetIP   string `json:"target_ip" mapstructure:"target_ip" default:""`     // Comma-separated IPs for target mapping
 	TargetName string `json:"target_name" mapstructure:"target_name" default:""` // Comma-separated names for target mapping
+	// AgentLabel selects which HEP capture-agent field fills the Prometheus
+	// "node_id" label for SIP/RTCP/RTP metrics:
+	//   "node_id"   — HEP chunk 0x000c / heplify -hi (numeric; default)
+	//   "node_name" — HEP chunk 0x0013 / heplify -hn (hostname string; falls
+	//                 back to node_id when the name chunk is absent)
+	AgentLabel string `json:"agent_label" mapstructure:"agent_label" default:"node_id"`
+}
+
+const (
+	PrometheusAgentLabelNodeID   = "node_id"
+	PrometheusAgentLabelNodeName = "node_name"
+)
+
+// NormalizePrometheusAgentLabel returns a supported agent_label value.
+// Empty or unknown values fall back to node_id.
+func NormalizePrometheusAgentLabel(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case PrometheusAgentLabelNodeName:
+		return PrometheusAgentLabelNodeName
+	default:
+		return PrometheusAgentLabelNodeID
+	}
 }
 
 // Global configuration instance
@@ -1532,6 +1554,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("prometheus.host", "0.0.0.0")
 	v.SetDefault("prometheus.port", 9090)
 	v.SetDefault("prometheus.path", "/metrics")
+	v.SetDefault("prometheus.agent_label", "node_id")
 }
 
 // applyDefaults applies default values for missing fields
@@ -1793,6 +1816,7 @@ func applyDefaults(cfg *Config) {
 	if cfg.Prometheus.Path == "" {
 		cfg.Prometheus.Path = "/metrics"
 	}
+	cfg.Prometheus.AgentLabel = NormalizePrometheusAgentLabel(cfg.Prometheus.AgentLabel)
 }
 
 // SaveExample writes an example configuration file
@@ -1935,10 +1959,11 @@ func SaveExample(path string) error {
 			},
 		},
 		Prometheus: PrometheusConfig{
-			Enable: false,
-			Host:   "0.0.0.0",
-			Port:   9090,
-			Path:   "/metrics",
+			Enable:     false,
+			Host:       "0.0.0.0",
+			Port:       9090,
+			Path:       "/metrics",
+			AgentLabel: "node_id",
 		},
 	}
 

--- a/src/utils/metrics/sip_metrics.go
+++ b/src/utils/metrics/sip_metrics.go
@@ -207,16 +207,41 @@ type SIPMetricsProcessor struct {
 	TargetConf  *sync.RWMutex
 	srdCache    *fastcache.Cache
 	cacheSize   int
+	// agentLabel is "node_id" (HEP 0x000c) or "node_name" (HEP 0x0013).
+	// It controls which value fills the Prometheus "node_id" label.
+	agentLabel string
 }
 
 const defaultCacheSize = 60 * 1024 * 1024
 
-// NewSIPMetricsProcessor creates a new SIP metrics processor
-func NewSIPMetricsProcessor(targetIP, targetName string) *SIPMetricsProcessor {
+const (
+	AgentLabelNodeID   = "node_id"
+	AgentLabelNodeName = "node_name"
+)
+
+// ResolveAgentLabel picks the Prometheus node_id label value.
+// mode "node_name" prefers the HEP NodeName (hostname); otherwise NodeID.
+// Empty nodeName falls back to nodeID so RTCP/SIP stay consistent.
+func ResolveAgentLabel(mode, nodeID, nodeName string) string {
+	if strings.EqualFold(strings.TrimSpace(mode), AgentLabelNodeName) {
+		if name := strings.TrimSpace(nodeName); name != "" {
+			return name
+		}
+	}
+	if id := strings.TrimSpace(nodeID); id != "" {
+		return id
+	}
+	return strings.TrimSpace(nodeName)
+}
+
+// NewSIPMetricsProcessor creates a new SIP metrics processor.
+// agentLabel selects "node_id" or "node_name" for the Prometheus node_id label.
+func NewSIPMetricsProcessor(targetIP, targetName, agentLabel string) *SIPMetricsProcessor {
 	p := &SIPMetricsProcessor{
 		TargetConf: new(sync.RWMutex),
 		srdCache:   fastcache.New(defaultCacheSize),
 		cacheSize:  defaultCacheSize,
+		agentLabel: normalizeAgentLabel(agentLabel),
 	}
 
 	p.TargetIP = strings.Split(strings.ReplaceAll(targetIP, " ", ""), ",")
@@ -234,6 +259,24 @@ func NewSIPMetricsProcessor(targetIP, targetName string) *SIPMetricsProcessor {
 	}
 
 	return p
+}
+
+func normalizeAgentLabel(value string) string {
+	if strings.EqualFold(strings.TrimSpace(value), AgentLabelNodeName) {
+		return AgentLabelNodeName
+	}
+	return AgentLabelNodeID
+}
+
+func (p *SIPMetricsProcessor) agentLabelFor(nodeID, nodeName string) string {
+	return ResolveAgentLabel(p.agentLabel, nodeID, nodeName)
+}
+
+func (p *SIPMetricsProcessor) agentLabelForPacket(pkt *SIPPacketInfo) string {
+	if pkt == nil {
+		return ""
+	}
+	return p.agentLabelFor(pkt.NodeID, pkt.NodeName)
 }
 
 // SIPPacketInfo contains information about a SIP packet for metrics
@@ -256,9 +299,11 @@ type SIPPacketInfo struct {
 
 // ProcessSIPPacket processes a SIP packet and records metrics
 func (p *SIPMetricsProcessor) ProcessSIPPacket(pkt *SIPPacketInfo) {
+	agent := p.agentLabelForPacket(pkt)
+
 	// Record packets by type
-	SIPPacketsByType.WithLabelValues(pkt.NodeName, pkt.ProtoString).Inc()
-	SIPPacketsBySize.WithLabelValues(pkt.NodeName, pkt.ProtoString).Set(float64(pkt.PayloadSize))
+	SIPPacketsByType.WithLabelValues(agent, pkt.ProtoString).Inc()
+	SIPPacketsBySize.WithLabelValues(agent, pkt.ProtoString).Set(float64(pkt.PayloadSize))
 
 	var srcTarget, dstTarget string
 	var srcHit, dstHit bool
@@ -272,16 +317,16 @@ func (p *SIPMetricsProcessor) ProcessSIPPacket(pkt *SIPPacketInfo) {
 	if pkt.ProtoType == 1 && pkt.Method != "" {
 		if !p.TargetEmpty {
 			if srcHit {
-				SIPMethodResponses.WithLabelValues(srcTarget, "src", pkt.NodeName, pkt.Response, pkt.CseqMethod).Inc()
+				SIPMethodResponses.WithLabelValues(srcTarget, "src", agent, pkt.Response, pkt.CseqMethod).Inc()
 				if pkt.ReasonVal != "" && strings.Contains(pkt.ReasonVal, "850") {
 					SIPReasonCause.WithLabelValues(srcTarget, extractCause(pkt.ReasonVal), pkt.Response).Inc()
 				}
 			}
 			if dstHit {
-				SIPMethodResponses.WithLabelValues(dstTarget, "dst", pkt.NodeName, pkt.Response, pkt.CseqMethod).Inc()
+				SIPMethodResponses.WithLabelValues(dstTarget, "dst", agent, pkt.Response, pkt.CseqMethod).Inc()
 			}
 			if !srcHit && !dstHit {
-				SIPMethodResponses.WithLabelValues("unknown", "", pkt.NodeName, pkt.Response, pkt.CseqMethod).Inc()
+				SIPMethodResponses.WithLabelValues("unknown", "", agent, pkt.Response, pkt.CseqMethod).Inc()
 			}
 		}
 
@@ -322,9 +367,9 @@ func (p *SIPMetricsProcessor) ProcessSIPPacket(pkt *SIPPacketInfo) {
 				}
 
 				if pkt.CseqMethod == "INVITE" {
-					SIPSRD.WithLabelValues(dstTarget, pkt.NodeName).Set(float64(d) / 1e9) // Convert to seconds
+					SIPSRD.WithLabelValues(dstTarget, agent).Set(float64(d) / 1e9) // Convert to seconds
 				} else {
-					SIPRRD.WithLabelValues(dstTarget, pkt.NodeName).Set(float64(d) / 1e9)
+					SIPRRD.WithLabelValues(dstTarget, agent).Set(float64(d) / 1e9)
 					p.srdCache.Del([]byte(callID))
 				}
 				p.srdCache.Del(did)
@@ -347,7 +392,7 @@ func (p *SIPMetricsProcessor) ProcessSIPPacket(pkt *SIPPacketInfo) {
 				return
 			}
 			p.srdCache.Set(k, nil)
-			SIPMethodResponses.WithLabelValues(pkt.NodeName, "", pkt.NodeName, pkt.Response, pkt.CseqMethod).Inc()
+			SIPMethodResponses.WithLabelValues(agent, "", agent, pkt.Response, pkt.CseqMethod).Inc()
 
 			if pkt.ReasonVal != "" && strings.Contains(pkt.ReasonVal, "850") {
 				SIPReasonCause.WithLabelValues("unknown", extractCause(pkt.ReasonVal), pkt.Response).Inc()
@@ -356,8 +401,11 @@ func (p *SIPMetricsProcessor) ProcessSIPPacket(pkt *SIPPacketInfo) {
 	}
 }
 
-// ProcessRTCPPacket processes RTCP packet (ProtoType 5)
-func (p *SIPMetricsProcessor) ProcessRTCPPacket(nodeID, srcIP, dstIP string, payload []byte) {
+// ProcessRTCPPacket processes RTCP packet (ProtoType 5).
+// nodeID is HEP 0x000c; nodeName is HEP 0x0013 (may be empty).
+func (p *SIPMetricsProcessor) ProcessRTCPPacket(nodeID, nodeName, srcIP, dstIP string, payload []byte) {
+	agent := p.agentLabelFor(nodeID, nodeName)
+
 	var srcTarget, dstTarget string
 	var srcHit, dstHit bool
 
@@ -367,19 +415,20 @@ func (p *SIPMetricsProcessor) ProcessRTCPPacket(nodeID, srcIP, dstIP string, pay
 	}
 
 	if srcHit {
-		p.dissectRTCPStats(srcTarget, "src", nodeID, payload)
+		p.dissectRTCPStats(srcTarget, "src", agent, payload)
 	}
 	if dstHit {
-		p.dissectRTCPStats(dstTarget, "dst", nodeID, payload)
+		p.dissectRTCPStats(dstTarget, "dst", agent, payload)
 	}
 	if !srcHit && !dstHit {
-		p.dissectRTCPStats("unknown", "", nodeID, payload)
+		p.dissectRTCPStats("unknown", "", agent, payload)
 	}
 }
 
-// ProcessRTPAgentPacket processes RTPAgent packet (ProtoType 34)
-func (p *SIPMetricsProcessor) ProcessRTPAgentPacket(nodeID string, payload []byte) {
-	p.dissectRTPAgentStats(nodeID, payload)
+// ProcessRTPAgentPacket processes RTPAgent packet (ProtoType 34).
+// nodeID is HEP 0x000c; nodeName is HEP 0x0013 (may be empty).
+func (p *SIPMetricsProcessor) ProcessRTPAgentPacket(nodeID, nodeName string, payload []byte) {
+	p.dissectRTPAgentStats(p.agentLabelFor(nodeID, nodeName), payload)
 }
 
 // dissectXRTPStats extracts and records X-RTP-Stat metrics

--- a/src/utils/metrics/sip_metrics_test.go
+++ b/src/utils/metrics/sip_metrics_test.go
@@ -1,0 +1,62 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package metrics
+
+import "testing"
+
+func TestResolveAgentLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     string
+		nodeID   string
+		nodeName string
+		want     string
+	}{
+		{name: "default uses node_id", mode: "node_id", nodeID: "2002", nodeName: "voice", want: "2002"},
+		{name: "empty mode uses node_id", mode: "", nodeID: "2002", nodeName: "voice", want: "2002"},
+		{name: "node_name mode", mode: "node_name", nodeID: "2002", nodeName: "voice", want: "voice"},
+		{name: "node_name case insensitive", mode: "Node_Name", nodeID: "2002", nodeName: "voice", want: "voice"},
+		{name: "node_name falls back to id", mode: "node_name", nodeID: "2002", nodeName: "", want: "2002"},
+		{name: "node_name whitespace falls back", mode: "node_name", nodeID: "2002", nodeName: "  ", want: "2002"},
+		{name: "empty id uses name", mode: "node_id", nodeID: "", nodeName: "voice", want: "voice"},
+		{name: "both empty", mode: "node_name", nodeID: "", nodeName: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveAgentLabel(tt.mode, tt.nodeID, tt.nodeName)
+			if got != tt.want {
+				t.Fatalf("ResolveAgentLabel(%q,%q,%q)=%q, want %q", tt.mode, tt.nodeID, tt.nodeName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeAgentLabel(t *testing.T) {
+	if got := normalizeAgentLabel(""); got != AgentLabelNodeID {
+		t.Fatalf("empty -> %q, want %q", got, AgentLabelNodeID)
+	}
+	if got := normalizeAgentLabel("bogus"); got != AgentLabelNodeID {
+		t.Fatalf("bogus -> %q, want %q", got, AgentLabelNodeID)
+	}
+	if got := normalizeAgentLabel("NODE_NAME"); got != AgentLabelNodeName {
+		t.Fatalf("NODE_NAME -> %q, want %q", got, AgentLabelNodeName)
+	}
+}
+
+func TestNewSIPMetricsProcessorAgentLabel(t *testing.T) {
+	p := NewSIPMetricsProcessor("", "", "node_name")
+	if got := p.agentLabelFor("2002", "voice"); got != "voice" {
+		t.Fatalf("agentLabelFor=%q, want voice", got)
+	}
+
+	p = NewSIPMetricsProcessor("", "", "")
+	if got := p.agentLabelFor("2002", "voice"); got != "2002" {
+		t.Fatalf("default agentLabelFor=%q, want 2002", got)
+	}
+}

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.310"
+	VERSION_APPLICATION = "11.0.311"
 
 	// BuildDate is the build date
 	BuildDate = ""

--- a/src/writer/writer.go
+++ b/src/writer/writer.go
@@ -176,8 +176,8 @@ func New(ingestCfg *config.IngestConfig, storageCfg *config.StorageConfig, promC
 
 	// Initialize SIP metrics processor if Prometheus is enabled
 	if promCfg != nil && promCfg.Enable {
-		w.sipMetrics = metrics.NewSIPMetricsProcessor(promCfg.TargetIP, promCfg.TargetName)
-		logger.Info("Writer: SIP metrics processor initialized")
+		w.sipMetrics = metrics.NewSIPMetricsProcessor(promCfg.TargetIP, promCfg.TargetName, promCfg.AgentLabel)
+		logger.Info("Writer: SIP metrics processor initialized", "agent_label", config.NormalizePrometheusAgentLabel(promCfg.AgentLabel))
 	}
 
 	// Initialize remote logging clients
@@ -565,9 +565,11 @@ func (w *Writer) Reload() error {
 		newProcessor := metrics.NewSIPMetricsProcessor(
 			w.prometheusConfig.TargetIP,
 			w.prometheusConfig.TargetName,
+			w.prometheusConfig.AgentLabel,
 		)
 		w.sipMetrics = newProcessor
-		logger.Info("Writer: SIP metrics target mapping reloaded")
+		logger.Info("Writer: SIP metrics target mapping reloaded",
+			"agent_label", config.NormalizePrometheusAgentLabel(w.prometheusConfig.AgentLabel))
 	}
 
 	logger.Info("Writer: Configuration reloaded")
@@ -787,11 +789,12 @@ func (w *Writer) processSIPMetrics(hepPkt *decoder.HEP) {
 	}
 
 	nodeID := fmt.Sprintf("%d", hepPkt.NodeID)
+	nodeName := hepPkt.NodeName
 
 	// Process SIP packets (ProtoType 1)
 	if hepPkt.ProtoType == 1 && hepPkt.SIP != nil {
 		pkt := &metrics.SIPPacketInfo{
-			NodeName:      hepPkt.NodeName,
+			NodeName:      nodeName,
 			NodeID:        nodeID,
 			ProtoType:     hepPkt.ProtoType,
 			ProtoString:   hepPkt.ProtoString,
@@ -815,12 +818,12 @@ func (w *Writer) processSIPMetrics(hepPkt *decoder.HEP) {
 
 	// Process RTCP packets (ProtoType 5)
 	if hepPkt.ProtoType == 5 {
-		w.sipMetrics.ProcessRTCPPacket(nodeID, hepPkt.SrcIP, hepPkt.DstIP, []byte(hepPkt.Payload))
+		w.sipMetrics.ProcessRTCPPacket(nodeID, nodeName, hepPkt.SrcIP, hepPkt.DstIP, []byte(hepPkt.Payload))
 	}
 
 	// Process RTPAgent packets (ProtoType 34)
 	if hepPkt.ProtoType == 34 {
-		w.sipMetrics.ProcessRTPAgentPacket(nodeID, []byte(hepPkt.Payload))
+		w.sipMetrics.ProcessRTPAgentPacket(nodeID, nodeName, []byte(hepPkt.Payload))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes [#922](https://github.com/sipcapture/homer/issues/922): SIP Prometheus metrics used HEP `NodeName` (0x0013 / heplify `-hn`) while RTCP used numeric `NodeID` (0x000c / `-hi`) for the same label `node_id`.
- Adds `prometheus.agent_label` (`node_id` | `node_name`, default `node_id`) so SIP/RTCP/RTP resolve the Prometheus `node_id` label value the same way.
- Keeps the Prometheus label name as `node_id` for dashboard compatibility; documents env `HOMER_PROMETHEUS_AGENT_LABEL`.
- Version bump to **11.0.311**.

## Test plan
- [x] `go test ./utils/metrics/ ./config/`
- [x] `go build`
- [ ] Enable prometheus, send HEP with `-hi 2002 -hn voice`
- [ ] Default config: SIP and RTCP `node_id` label both show `2002`
- [ ] `agent_label: node_name`: both show `voice` (fallback to id if name empty)