### PR TITLE
fix(search): persist HEP node_name in data_extra (#922)

### DIFF
--- a/docs/SEARCH_MAPPINGS_AND_FIELDS.md
+++ b/docs/SEARCH_MAPPINGS_AND_FIELDS.md
@@ -296,6 +296,9 @@ Multi-select with one value uses singular key (`method`); multiple values use pl
 | `src_ip`, `dst_ip`, `src_port`, `dst_port` | same | |
 | `user_agent` | column or `data_extra` | registration vs call |
 | `ruri_user` | `data_extra.request_uri` | LIKE |
+| `node` / `node_id` | `node_id` **OR** `data_extra.node_name` | HEP `-hi` / `-hn` (#922) |
+| `node_name` | `data_extra.node_name` | HEP `0x0013` when distinct from numeric id |
+| `capture_id` | `node_id` (+ `data_extra.capture_id`) | numeric Capture ID only |
 | `payload` | `payload` | substring |
 | `aor`, `contact`, `expires` | registration columns | `profile: registration` |
 | `from_tag`, `to_tag` | **virtual** `data_extra` | |

--- a/docs/STORAGE_LAYOUT.md
+++ b/docs/STORAGE_LAYOUT.md
@@ -153,10 +153,10 @@ method VARCHAR,         -- SIP method (INVITE, BYE, etc.)
 response_code VARCHAR,  -- Response code (200, 404, etc.)
 cseq_method VARCHAR,    -- Method from CSeq header
 protocol UINTEGER,      -- Transport (17=UDP, 6=TCP)
-node_id VARCHAR,        -- HEP node ID
+node_id VARCHAR,        -- HEP 0x000c capture agent id (heplify -hi)
 cid VARCHAR,            -- Correlation ID
 payload VARCHAR,        -- Raw SIP message
-data_extra JSON         -- Additional headers (via, user_agent, etc.)
+data_extra JSON         -- Headers + optional node_name (HEP 0x0013 / -hn when distinct from node_id)
 ```
 
 ### SIP Registration (hep_proto_1_registration)

--- a/examples/mappings/fields_dns_53_default.json
+++ b/examples/mappings/fields_dns_53_default.json
@@ -63,6 +63,15 @@
     "hide": true
   },
   {
+    "id": "node_name",
+    "name": "Node Name",
+    "type": "string",
+    "index": "none",
+    "form_type": "input",
+    "position": 7,
+    "hide": true
+  },
+  {
     "id": "payload",
     "name": "Payload contains",
     "type": "string",

--- a/examples/mappings/fields_log_100_default.json
+++ b/examples/mappings/fields_log_100_default.json
@@ -46,6 +46,15 @@
     "hide": true
   },
   {
+    "id": "node_name",
+    "name": "Node Name",
+    "type": "string",
+    "index": "none",
+    "form_type": "input",
+    "position": 5,
+    "hide": true
+  },
+  {
     "id": "user_agent",
     "name": "Extra JSON user_agent",
     "type": "string",

--- a/examples/mappings/fields_rtcp_5_default.json
+++ b/examples/mappings/fields_rtcp_5_default.json
@@ -73,6 +73,15 @@
     "hide": true
   },
   {
+    "id": "node_name",
+    "name": "Node Name",
+    "type": "string",
+    "index": "none",
+    "form_type": "input",
+    "position": 8,
+    "hide": true
+  },
+  {
     "id": "payload",
     "name": "Payload contains",
     "type": "string",

--- a/examples/mappings/fields_sip_call.json
+++ b/examples/mappings/fields_sip_call.json
@@ -180,6 +180,15 @@
     "hide": true
   },
   {
+    "id": "node_name",
+    "name": "Node Name",
+    "type": "string",
+    "index": "none",
+    "form_type": "input",
+    "position": 13,
+    "hide": true
+  },
+  {
     "id": "user_agent",
     "name": "User-Agent",
     "type": "string",

--- a/examples/mappings/fields_sip_default.json
+++ b/examples/mappings/fields_sip_default.json
@@ -109,6 +109,15 @@
     "hide": true
   },
   {
+    "id": "node_name",
+    "name": "Node Name",
+    "type": "string",
+    "index": "none",
+    "form_type": "input",
+    "position": 12,
+    "hide": true
+  },
+  {
     "id": "user_agent",
     "name": "User-Agent",
     "type": "string",

--- a/examples/mappings/fields_sip_registration.json
+++ b/examples/mappings/fields_sip_registration.json
@@ -113,6 +113,15 @@
     "hide": true
   },
   {
+    "id": "node_name",
+    "name": "Node Name",
+    "type": "string",
+    "index": "none",
+    "form_type": "input",
+    "position": 12,
+    "hide": true
+  },
+  {
     "id": "payload",
     "name": "Payload contains",
     "type": "string",

--- a/src/coordinator/handlers/transactions_sql_test.go
+++ b/src/coordinator/handlers/transactions_sql_test.go
@@ -25,6 +25,46 @@ func TestBuildSearchSQLV4_CaptureID(t *testing.T) {
 	}
 }
 
+func TestBuildSearchSQLV4_NodeMatchesIDOrDataExtraName(t *testing.T) {
+	req := SearchObjectV4{}
+	req.Filter.ProtoType = 1
+	req.Filter.EventType = "call"
+	req.Filter.Node = "voice"
+
+	sql, err := buildSearchSQLV4("homer_lake", &req, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(sql, "node_id = 'voice'") {
+		t.Fatalf("expected node_id match, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "json_extract_string(data_extra, '$.node_name') = 'voice'") {
+		t.Fatalf("expected data_extra.node_name OR, got:\n%s", sql)
+	}
+}
+
+func TestBuildSearchSQLV4_NodeNameFilter(t *testing.T) {
+	req := SearchObjectV4{}
+	req.Filter.ProtoType = 1
+	req.Filter.EventType = "call"
+	req.Filter.NodeName = "voice"
+
+	sql, err := buildSearchSQLV4("homer_lake", &req, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(sql, "json_extract_string(data_extra, '$.node_name')") {
+		t.Fatalf("expected node_name extract, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "voice") {
+		t.Fatalf("expected voice value, got:\n%s", sql)
+	}
+	// Dedicated node_name filter must not require node_id equality alone.
+	if strings.Contains(sql, "node_id = 'voice'") {
+		t.Fatalf("node_name-only filter should not OR node_id, got:\n%s", sql)
+	}
+}
+
 func TestBuildSearchSQLV4_SIPDefaultUsesDataExtraHosts(t *testing.T) {
 	req := SearchObjectV4{}
 	req.Filter.ProtoType = 1

--- a/src/coordinator/handlers/transactions_v4.go
+++ b/src/coordinator/handlers/transactions_v4.go
@@ -208,6 +208,7 @@ type SearchObjectV4 struct {
 		CaptureID     int      `json:"capture_id"`
 		Node          string   `json:"node"`
 		NodeID        string   `json:"node_id,omitempty"` // alias for node
+		NodeName      string   `json:"node_name,omitempty"` // HEP 0x0013 in data_extra.node_name
 		Aor           string   `json:"aor,omitempty"`           // SIP registration column
 		Contact       string   `json:"contact,omitempty"`     // SIP registration column
 		Expires       string   `json:"expires,omitempty"`     // SIP registration column
@@ -2895,10 +2896,17 @@ func buildSearchSQLV4WithOpts(lakeName string, req *SearchObjectV4, virtualRules
 			"(CAST(node_id AS VARCHAR) = '%s' OR json_extract_string(data_extra, '$.capture_id') = '%s' OR json_extract_string(data_extra, '$.captureId') = '%s')",
 			capStr, capStr, capStr))
 	}
-	// node / node_id
+	// node / node_id: match numeric column or HEP hostname in data_extra (#922).
 	nodeFilter := firstNonEmpty(req.Filter.Node, req.Filter.NodeID)
 	if nodeFilter != "" {
-		conditions = append(conditions, fmt.Sprintf("node_id = '%s'", sqlvalidator.SafeString(nodeFilter)))
+		ns := sqlvalidator.SafeString(nodeFilter)
+		conditions = append(conditions, fmt.Sprintf(
+			"(node_id = '%s' OR json_extract_string(data_extra, '$.node_name') = '%s')",
+			ns, ns))
+	}
+	if nn := strings.TrimSpace(req.Filter.NodeName); nn != "" {
+		conditions = append(conditions, sqlFormMatchClause(
+			"json_extract_string(data_extra, '$.node_name')", nn))
 	}
 	if ua := strings.TrimSpace(req.Filter.UserAgent); ua != "" {
 		if protoType == 1 && txType == "registration" {

--- a/src/coordinator/services/seeds/fields_dns_53_default.json
+++ b/src/coordinator/services/seeds/fields_dns_53_default.json
@@ -63,6 +63,15 @@
     "hide": true
   },
   {
+    "id": "node_name",
+    "name": "Node Name",
+    "type": "string",
+    "index": "none",
+    "form_type": "input",
+    "position": 7,
+    "hide": true
+  },
+  {
     "id": "payload",
     "name": "Payload contains",
     "type": "string",

--- a/src/coordinator/services/seeds/fields_log_100_default.json
+++ b/src/coordinator/services/seeds/fields_log_100_default.json
@@ -46,6 +46,15 @@
     "hide": true
   },
   {
+    "id": "node_name",
+    "name": "Node Name",
+    "type": "string",
+    "index": "none",
+    "form_type": "input",
+    "position": 5,
+    "hide": true
+  },
+  {
     "id": "user_agent",
     "name": "Extra JSON user_agent",
     "type": "string",

--- a/src/coordinator/services/seeds/fields_rtcp_5_default.json
+++ b/src/coordinator/services/seeds/fields_rtcp_5_default.json
@@ -73,6 +73,15 @@
     "hide": true
   },
   {
+    "id": "node_name",
+    "name": "Node Name",
+    "type": "string",
+    "index": "none",
+    "form_type": "input",
+    "position": 8,
+    "hide": true
+  },
+  {
     "id": "payload",
     "name": "Payload contains",
     "type": "string",

--- a/src/coordinator/services/seeds/fields_sip_call.json
+++ b/src/coordinator/services/seeds/fields_sip_call.json
@@ -180,6 +180,15 @@
     "hide": true
   },
   {
+    "id": "node_name",
+    "name": "Node Name",
+    "type": "string",
+    "index": "none",
+    "form_type": "input",
+    "position": 13,
+    "hide": true
+  },
+  {
     "id": "user_agent",
     "name": "User-Agent",
     "type": "string",

--- a/src/coordinator/services/seeds/fields_sip_default.json
+++ b/src/coordinator/services/seeds/fields_sip_default.json
@@ -109,6 +109,15 @@
     "hide": true
   },
   {
+    "id": "node_name",
+    "name": "Node Name",
+    "type": "string",
+    "index": "none",
+    "form_type": "input",
+    "position": 12,
+    "hide": true
+  },
+  {
     "id": "user_agent",
     "name": "User-Agent",
     "type": "string",

--- a/src/coordinator/services/seeds/fields_sip_registration.json
+++ b/src/coordinator/services/seeds/fields_sip_registration.json
@@ -113,6 +113,15 @@
     "hide": true
   },
   {
+    "id": "node_name",
+    "name": "Node Name",
+    "type": "string",
+    "index": "none",
+    "form_type": "input",
+    "position": 12,
+    "hide": true
+  },
+  {
     "id": "payload",
     "name": "Payload contains",
     "type": "string",

--- a/src/storage/ducklake/extra_json_test.go
+++ b/src/storage/ducklake/extra_json_test.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	duckdb "github.com/duckdb/duckdb-go/v2"
@@ -151,5 +152,84 @@ func TestAppenderJSONColumnNotDoubleEncoded(t *testing.T) {
 	}
 	if !xcid.Valid || xcid.String != "aleg-call-id-1" {
 		t.Fatalf("x_call_id = %#v, want aleg-call-id-1", xcid)
+	}
+}
+
+func TestEffectiveNodeName(t *testing.T) {
+	if got := effectiveNodeName(nil); got != "" {
+		t.Fatalf("nil hep: got %q", got)
+	}
+	hep := &decoder.HEP{NodeID: 2002, NodeName: "2002"}
+	if got := effectiveNodeName(hep); got != "" {
+		t.Fatalf("id fallback name should be skipped, got %q", got)
+	}
+	hep.NodeName = "voice"
+	if got := effectiveNodeName(hep); got != "voice" {
+		t.Fatalf("got %q, want voice", got)
+	}
+	hep.NodeName = "  "
+	if got := effectiveNodeName(hep); got != "" {
+		t.Fatalf("whitespace: got %q", got)
+	}
+}
+
+func TestBuildExtraJSONCell_NodeNameInDataExtra(t *testing.T) {
+	pkt := decoder.BenchHEP3SIPPacket()
+	hep, err := decoder.DecodeHEP(pkt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer decoder.ReleaseHEP(hep)
+
+	hep.NodeID = 2002
+	hep.NodeName = "2002"
+	cell := buildExtraJSONCell(hep)
+	raw := cellJSONBytes(t, cell)
+	releaseExtraJSONCell(cell)
+	if strings.Contains(string(raw), `"node_name"`) {
+		t.Fatalf("fallback NodeName must not be written: %s", raw)
+	}
+
+	hep.NodeName = "voice"
+	cell = buildExtraJSONCell(hep)
+	raw = cellJSONBytes(t, cell)
+	releaseExtraJSONCell(cell)
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatal(err)
+	}
+	if obj["node_name"] != "voice" {
+		t.Fatalf("node_name=%v, want voice; json=%s", obj["node_name"], raw)
+	}
+}
+
+func TestBuildSimpleExtraJSONCell_NodeName(t *testing.T) {
+	hep := &decoder.HEP{Version: 3, ProtoType: 5, NodeID: 2002, NodeName: "2002"}
+	raw := buildSimpleExtraJSONCell(hep)
+	if strings.Contains(string(raw), `"node_name"`) {
+		t.Fatalf("unexpected node_name: %s", raw)
+	}
+
+	hep.NodeName = "voice"
+	raw = buildSimpleExtraJSONCell(hep)
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatal(err)
+	}
+	if obj["node_name"] != "voice" {
+		t.Fatalf("node_name=%v, want voice; json=%s", obj["node_name"], raw)
+	}
+}
+
+func cellJSONBytes(t *testing.T, cell interface{}) []byte {
+	t.Helper()
+	switch v := cell.(type) {
+	case json.RawMessage:
+		return []byte(v)
+	case *[]byte:
+		return append([]byte(nil), (*v)...)
+	default:
+		t.Fatalf("unexpected cell type %T", cell)
+		return nil
 	}
 }

--- a/src/storage/ducklake/hep_adapter.go
+++ b/src/storage/ducklake/hep_adapter.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"math/rand"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -590,9 +591,28 @@ func buildSIPExtraJSONInto(b []byte, hep *decoder.HEP) []byte {
 	b = append(b, `"version":`...)
 	b = strconv.AppendUint(b, uint64(hep.Version), 10)
 	first := false
+	// HEP 0x0013 hostname when distinct from numeric 0x000c (issue #922).
+	appendJSONField(&b, &first, "node_name", effectiveNodeName(hep))
 	appendSIPExtraFields(&b, &first, hep)
 	b = append(b, '}')
 	return b
+}
+
+// effectiveNodeName returns HEP NodeName (chunk 0x0013 / heplify -hn) only when it
+// carries a real hostname. The decoder falls back to strconv(NodeID) when the
+// chunk is absent; we must not duplicate that into data_extra.node_name.
+func effectiveNodeName(hep *decoder.HEP) string {
+	if hep == nil {
+		return ""
+	}
+	name := strings.TrimSpace(hep.NodeName)
+	if name == "" {
+		return ""
+	}
+	if name == strconv.FormatUint(uint64(hep.NodeID), 10) {
+		return ""
+	}
+	return name
 }
 
 // buildExtraJSONCell returns a value suitable for row data_extra column.
@@ -671,26 +691,43 @@ func buildExtraJSON(hep *decoder.HEP) string {
 var simpleExtraCache sync.Map // uint32 -> json.RawMessage
 
 // buildSimpleExtraJSONCell builds a minimal extra JSON cell for non-SIP packets.
-// Result is cached since version and proto_type rarely change between packets.
+// Result is cached by version|proto_type when there is no distinct HEP NodeName.
+// Packets with data_extra.node_name skip the cache (name is per-agent).
 // Returned as json.RawMessage so the Appender writes it as a JSON document
 // (see cellToDriverValue).
 func buildSimpleExtraJSONCell(hep *decoder.HEP) json.RawMessage {
-	key := uint32(hep.Version)<<16 | (hep.ProtoType & 0xffff)
-	if v, ok := simpleExtraCache.Load(key); ok {
-		return v.(json.RawMessage)
+	nodeName := effectiveNodeName(hep)
+	if nodeName == "" {
+		key := uint32(hep.Version)<<16 | (hep.ProtoType & 0xffff)
+		if v, ok := simpleExtraCache.Load(key); ok {
+			return v.(json.RawMessage)
+		}
+		bp := sbPool.Get().(*[]byte)
+		b := (*bp)[:0]
+		b = append(b, `{"version":`...)
+		b = strconv.AppendUint(b, uint64(hep.Version), 10)
+		b = append(b, `,"proto_type":`...)
+		b = strconv.AppendUint(b, uint64(hep.ProtoType), 10)
+		b = append(b, '}')
+		m := json.RawMessage(string(b))
+		*bp = b
+		sbPool.Put(bp)
+		simpleExtraCache.Store(key, m)
+		return m
 	}
+
 	bp := sbPool.Get().(*[]byte)
 	b := (*bp)[:0]
 	b = append(b, `{"version":`...)
 	b = strconv.AppendUint(b, uint64(hep.Version), 10)
 	b = append(b, `,"proto_type":`...)
 	b = strconv.AppendUint(b, uint64(hep.ProtoType), 10)
+	first := false
+	appendJSONField(&b, &first, "node_name", nodeName)
 	b = append(b, '}')
-	// The cached value lives indefinitely, so copy out of the pooled buffer.
 	m := json.RawMessage(string(b))
 	*bp = b
 	sbPool.Put(bp)
-	simpleExtraCache.Store(key, m)
 	return m
 }
 

--- a/src/ui/src/dashboard/MessageModal.tsx
+++ b/src/ui/src/dashboard/MessageModal.tsx
@@ -106,10 +106,11 @@ function highlightSIP(payload) {
 
 import { captureIdOf } from './flow/flow-data'
 
-const META_FIELDS = ['uuid', 'date', 'timestamp', 'event', 'method', 'src_ip', 'dst_ip', 'src_port', 'dst_port', 'session_id', 'cid', 'node_id']
+const META_FIELDS = ['uuid', 'date', 'timestamp', 'event', 'method', 'src_ip', 'dst_ip', 'src_port', 'dst_port', 'session_id', 'cid', 'node_id', 'node_name']
 
 const META_FIELD_LABELS: Record<string, string> = {
   node_id: 'Capture ID',
+  node_name: 'Node Name',
 }
 
 function resolveCaptureIdDisplay(data) {
@@ -117,6 +118,27 @@ function resolveCaptureIdDisplay(data) {
   if (data.node_id != null && String(data.node_id).trim() !== '') return String(data.node_id).trim()
   const resolved = captureIdOf(data)
   return resolved || undefined
+}
+
+function resolveNodeNameDisplay(data) {
+  if (!data) return undefined
+  if (data.node_name != null && String(data.node_name).trim() !== '') {
+    return String(data.node_name).trim()
+  }
+  const extra = data.data_extra
+  if (!extra) return undefined
+  let obj = extra
+  if (typeof extra === 'string') {
+    try {
+      obj = JSON.parse(extra)
+    } catch {
+      return undefined
+    }
+  }
+  if (obj && typeof obj === 'object' && obj.node_name != null && String(obj.node_name).trim() !== '') {
+    return String(obj.node_name).trim()
+  }
+  return undefined
 }
 
 function parseTimestampValue(value) {
@@ -175,7 +197,11 @@ function MetaGrid({ data, timeZone, locale, overrides = {} }) {
             </div>
           )
         }
-        const raw = field === 'node_id' ? resolveCaptureIdDisplay(data) : data[field]
+        const raw = field === 'node_id'
+          ? resolveCaptureIdDisplay(data)
+          : field === 'node_name'
+            ? resolveNodeNameDisplay(data)
+            : data[field]
         const display = raw === undefined
           ? '—'
           : field === 'timestamp'

--- a/src/ui/src/dashboard/TransactionModal.tsx
+++ b/src/ui/src/dashboard/TransactionModal.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/components/ui/table'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { displayDstIp, displaySrcIp } from '@/lib/ipAliasDisplay'
+import { promoteDataExtraNodeName } from './promoteDataExtraNodeName'
 import {
   formatJsonField,
   highlightJSON,
@@ -267,6 +268,7 @@ function formatDateTime(value, locale, timeZone) {
 const EVENTS_TABLE_COLUMNS = [
   { header: 'Date', keys: ['timestamp', 'date', 'record_datetime'], isDate: true, colClass: 'w-[14%] min-w-0' },
   { header: 'Node_ID', keys: ['node_id', 'node'], colClass: 'w-[10%] min-w-0' },
+  { header: 'Node Name', keys: ['node_name'], colClass: 'w-[10%] min-w-0' },
   { header: 'Payload', keys: ['payload', 'message', 'data'], colClass: 'w-[26%] min-w-0', cellBreak: 'break-all' },
   { header: 'Session_ID', keys: ['session_id', 'call_id', 'callid', 'cid'], colClass: 'w-[20%] min-w-0' },
   { header: 'Storage Value', keys: ['storage_value', 'storage', 'lake_name', 'lake'], colClass: 'w-[12%] min-w-0' },
@@ -711,7 +713,9 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
     try {
       const body = buildTransactionTabBody(sessionIdsForApi, items, timeRange, timeZone)
       const data = await apiPost('/transactions/events', body)
-      setEventsData(data?.data || {})
+      const payload = data?.data || {}
+      const items = promoteDataExtraNodeName(payload.items || [])
+      setEventsData({ ...payload, items })
     } catch (err) {
       setEventsError(err.message)
     } finally {

--- a/src/ui/src/dashboard/promoteDataExtraNodeName.test.ts
+++ b/src/ui/src/dashboard/promoteDataExtraNodeName.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { ensureNodeNameKey, promoteDataExtraNodeName } from './promoteDataExtraNodeName'
+
+describe('promoteDataExtraNodeName', () => {
+  it('lifts node_name from data_extra object', () => {
+    const rows = promoteDataExtraNodeName([
+      { node_id: '2002', data_extra: { version: 3, node_name: 'voice' } },
+    ])
+    expect(rows[0].node_name).toBe('voice')
+    expect(rows[0].node_id).toBe('2002')
+  })
+
+  it('parses data_extra JSON string', () => {
+    const rows = promoteDataExtraNodeName([
+      { data_extra: JSON.stringify({ node_name: 'edge-1' }) },
+    ])
+    expect(rows[0].node_name).toBe('edge-1')
+  })
+
+  it('keeps existing top-level node_name', () => {
+    const rows = promoteDataExtraNodeName([
+      { node_name: 'keep', data_extra: { node_name: 'other' } },
+    ])
+    expect(rows[0].node_name).toBe('keep')
+  })
+
+  it('skips when name absent', () => {
+    const rows = promoteDataExtraNodeName([{ node_id: '2002', data_extra: { version: 3 } }])
+    expect(rows[0].node_name).toBeUndefined()
+  })
+})
+
+describe('ensureNodeNameKey', () => {
+  it('inserts after node_id', () => {
+    expect(ensureNodeNameKey(['uuid', 'node_id', 'cid'], [{ node_name: 'voice' }])).toEqual([
+      'uuid',
+      'node_id',
+      'node_name',
+      'cid',
+    ])
+  })
+
+  it('no-op when unused', () => {
+    expect(ensureNodeNameKey(['uuid', 'node_id'], [{ node_id: '1' }])).toEqual(['uuid', 'node_id'])
+  })
+})

--- a/src/ui/src/dashboard/promoteDataExtraNodeName.ts
+++ b/src/ui/src/dashboard/promoteDataExtraNodeName.ts
@@ -1,0 +1,43 @@
+/**
+ * Promote HEP hostname from data_extra.node_name onto a top-level row field
+ * so Results can show it (data_extra itself is hidden from the table).
+ * Issue #922 / heplify -hn.
+ */
+export function promoteDataExtraNodeName(rows) {
+  if (!Array.isArray(rows) || rows.length === 0) return rows || []
+  return rows.map((row) => {
+    if (!row || typeof row !== 'object') return row
+    if (row.node_name != null && String(row.node_name).trim() !== '') return row
+    let extra = row.data_extra
+    if (extra == null) return row
+    if (typeof extra === 'string') {
+      const s = extra.trim()
+      if (!s) return row
+      try {
+        extra = JSON.parse(s)
+      } catch {
+        return row
+      }
+    }
+    if (!extra || typeof extra !== 'object') return row
+    const name = extra.node_name
+    if (name == null || String(name).trim() === '') return row
+    return { ...row, node_name: String(name) }
+  })
+}
+
+/** Ensure keys list includes node_name when any promoted row has it. */
+export function ensureNodeNameKey(keys, rows) {
+  const list = Array.isArray(keys) ? [...keys] : []
+  const hasName = Array.isArray(rows) && rows.some(
+    (r) => r && r.node_name != null && String(r.node_name).trim() !== '',
+  )
+  if (!hasName || list.includes('node_name')) return list
+  const i = list.indexOf('node_id')
+  if (i >= 0) {
+    list.splice(i + 1, 0, 'node_name')
+    return list
+  }
+  list.push('node_name')
+  return list
+}

--- a/src/ui/src/dashboard/resultColumnLabels.test.ts
+++ b/src/ui/src/dashboard/resultColumnLabels.test.ts
@@ -7,6 +7,11 @@ describe('resultColumnLabels', () => {
     expect(columnDisplayTitle('node_id')).toBe('Capture ID (node_id)')
   })
 
+  it('aliases node_name as Node Name', () => {
+    expect(columnDisplayLabel('node_name')).toBe('Node Name')
+    expect(columnDisplayTitle('node_name')).toBe('Node Name (node_name)')
+  })
+
   it('passes through unknown columns unchanged', () => {
     expect(columnDisplayLabel('session_id')).toBe('session_id')
     expect(columnDisplayTitle('session_id')).toBe('session_id')

--- a/src/ui/src/dashboard/resultColumnLabels.ts
+++ b/src/ui/src/dashboard/resultColumnLabels.ts
@@ -6,6 +6,7 @@
  */
 const COLUMN_DISPLAY_LABELS: Record<string, string> = {
   node_id: 'Capture ID',
+  node_name: 'Node Name',
 }
 
 /** Human-readable column title; falls back to the raw key. */

--- a/src/ui/src/dashboard/widgets/ResultsPanel.tsx
+++ b/src/ui/src/dashboard/widgets/ResultsPanel.tsx
@@ -43,6 +43,7 @@ import OTLPMetricsSeriesModal from '../OTLPMetricsSeriesModal'
 import MessageModal from '../MessageModal'
 import { useLocale } from '@/components/locale/locale-provider'
 import { columnDisplayLabel, columnDisplayTitle } from '../resultColumnLabels'
+import { ensureNodeNameKey, promoteDataExtraNodeName } from '../promoteDataExtraNodeName'
 
 const OTLP_TRACES_PROTO = 200
 const OTLP_METRICS_PROTO = 201
@@ -396,9 +397,10 @@ export default function ResultsPanel({ widgetId, config: _config }) {
         return
       }
       const data = await res.json()
-      const items = data?.data?.items || []
+      const items = promoteDataExtraNodeName(data?.data?.items || [])
+      const keys = ensureNodeNameKey(data?.data?.keys || [], items)
       setRows(items)
-      setKeys(data?.data?.keys || [])
+      setKeys(keys)
       setStatus(`${items.length} rows in ${elapsed}ms`)
       setStatusType('success')
       if (useMcp && (sd.nl_mode === 'sql' || sd.nl_mode === 'auto')) {

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.311"
+	VERSION_APPLICATION = "11.0.312"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Closes the Results/search half of [#922](https://github.com/sipcapture/homer/issues/922): HEP hostname (`0x0013` / heplify `-hn`) was not stored in DuckLake.
- Writes `data_extra.node_name` when the name is distinct from numeric `node_id` (`0x000c` / `-hi`). **No table DDL / schema migrate.**
- `filter.node` / `filter.node_id` match `(node_id = X OR data_extra.node_name = X)`; new `filter.node_name` targets the JSON field only.
- Capture ID (`filter.capture_id`) stays numeric-only.
- Mapping seeds + MessageModal show Node Name from `data_extra`.
- Version **11.0.312**.

## Test plan
- [x] `go test ./storage/ducklake/ ./coordinator/handlers/`
- [ ] Ingest with `-hi 2002 -hn voice`; confirm `json_extract_string(data_extra,'$.node_name')` = `voice` and column `node_id` = `2002`
- [ ] Protocol Search «Node» = `voice` returns rows
- [ ] Capture ID = `2002` still works; Capture ID does not accept `voice` as integer