### PR TITLE
feat(coordinator): time-range smart routing for UI search (opt-in)

### DIFF
--- a/docs/COORDINATOR.md
+++ b/docs/COORDINATOR.md
@@ -133,6 +133,45 @@ The Coordinator module provides REST API for frontend applications and orchestra
 }
 ```
 
+### Smart Routing (time-range node pruning)
+
+Opt-in optimization for multi-node clusters. When enabled, the Coordinator skips
+querying any node whose data time range cannot overlap a search's time window —
+so a "last 15 minutes" search never wakes a node holding only cold archives.
+**Off by default; when off, every connected node is queried (unchanged behavior).**
+
+```json
+{
+  "coordinator": {
+    "enable": true,
+    "nodes": [
+      { "name": "hot",  "host": "hot.example.com",  "port": 50051 },
+      { "name": "cold", "host": "cold.example.com", "port": 50051 }
+    ],
+    "smart_routing": {
+      "enable": true
+    }
+  }
+}
+```
+
+How it works: each node exposes `GET /metadata/stats` (`{min_ts, max_ts}`); the
+Coordinator polls it on the existing node health-check tick and caches each
+node's range. A node is skipped only when its cached range provably does not
+overlap the query window — its newest data is older than the window start, or
+its oldest data is newer than the window end. If pruning would leave no nodes,
+all connected nodes are queried, so pruning never drops results.
+
+> **Precondition — historical ingest.** The "newer than the window end" skip
+> direction assumes a node's oldest (`min`) timestamp only rises over time (true
+> for live capture plus retention). **Historical pcap import or replay that
+> ingests packets older than a node's current `min` violates this.** During the
+> ≤1 health-check interval before the cache refreshes, such a node could be
+> skipped for a query that it now has matching (older) rows for. If you run
+> historical/backfill ingest, keep `smart_routing.enable` **off**, or accept up
+> to one health-interval of staleness. The "older than the window start"
+> direction has no such hazard.
+
 ### With OAuth2 Providers
 
 Authorization **code** flow (server exchanges `code`, loads userinfo, provisions DuckDB user). See [AUTH_LDAP_AND_OAUTH.md](./AUTH_LDAP_AND_OAUTH.md#oauth2).
@@ -210,6 +249,12 @@ Authorization **code** flow (server exchanges `code`, loads userinfo, provisions
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `query_timeout_sec` | int | 30 | Per-query timeout (seconds) for coordinator → node `POST /query`. Raise for long transaction searches — see [TROUBLESHOOTING.md](TROUBLESHOOTING.md#search-timeouts-30-seconds). Env: `HOMER_COORDINATOR_QUERY_TIMEOUT_SEC`. |
+
+### smart_routing
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `enable` | bool | false | Skip nodes whose cached data time range cannot overlap a search's time window (UI search path). Off = every connected node is queried. See [Smart Routing](#smart-routing-time-range-node-pruning) — note the historical-ingest precondition before enabling. |
 
 ### jwt
 

--- a/examples/homer-coordinator.json
+++ b/examples/homer-coordinator.json
@@ -28,6 +28,9 @@
         "priority": 1
       }
     ],
+    "smart_routing": {
+      "enable": false
+    },
     "flightsql_server": {
       "enable": false,
       "host": "0.0.0.0",

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -346,9 +346,19 @@ type NodeConfig struct {
 	DuckLake DuckLakeConfig `json:"ducklake" mapstructure:"ducklake"`
 }
 
+// SmartRoutingConfig controls time-range node pruning for UI search fan-out.
+type SmartRoutingConfig struct {
+	// Enable turns on skipping nodes whose newest data predates the query
+	// window. Off by default; off = every connected node is queried.
+	Enable bool `json:"enable" mapstructure:"enable" default:"false"`
+}
+
 // CoordinatorConfig configures the API coordinator module
 type CoordinatorConfig struct {
 	Enable bool `json:"enable" mapstructure:"enable" default:"false"`
+
+	// SmartRouting: skip nodes with no data in the query time range (UI path).
+	SmartRouting SmartRoutingConfig `json:"smart_routing" mapstructure:"smart_routing"`
 
 	// HTTP API server
 	HTTPServer CoordinatorHTTPServerConfig `json:"http_server" mapstructure:"http_server"`

--- a/src/coordinator/coordinator.go
+++ b/src/coordinator/coordinator.go
@@ -77,7 +77,7 @@ func (c *Coordinator) SetLocalBroker(b *hepstream.Broker) {
 func New(cfg *config.CoordinatorConfig) (*Coordinator, error) {
 	// Create FlightSQL service
 	queryTimeout := time.Duration(cfg.QueryTimeoutSec) * time.Second
-	flightService := services.NewFlightService(cfg.Nodes, queryTimeout)
+	flightService := services.NewFlightService(cfg.Nodes, queryTimeout, cfg.SmartRouting.Enable)
 	flightService.SetLakeName(cfg.LakeName)
 
 	c := &Coordinator{

--- a/src/coordinator/handlers/mcp_llm_test.go
+++ b/src/coordinator/handlers/mcp_llm_test.go
@@ -69,7 +69,7 @@ func newLLMTestHandler(t *testing.T, llmHandler http.HandlerFunc, apiKey string)
 		TimeoutSec: 5,
 	}
 
-	fs := services.NewFlightService(nil, 0)
+	fs := services.NewFlightService(nil, 0, false)
 	h := NewSearchHandler(fs, nil, cfg, nil, nil, 0, nil, "", 0)
 	return h, ts.Close
 }
@@ -154,7 +154,7 @@ func TestTryLLMStructured_FallbackToFallbackTime(t *testing.T) {
 func TestTryLLMStructured_DisabledReturnsZeroResult(t *testing.T) {
 	cfg := &config.MCPConfig{}
 	cfg.LLM = config.MCPLLMConfig{Enable: false}
-	fs := services.NewFlightService(nil, 0)
+	fs := services.NewFlightService(nil, 0, false)
 	h := NewSearchHandler(fs, nil, cfg, nil, nil, 0, nil, "", 0)
 
 	req, res := h.tryLLMStructured(context.Background(), "anything", 0, 0, 0)
@@ -245,7 +245,7 @@ func TestV4MCPLLMStatus_OllamaPingNoAPIKey(t *testing.T) {
 		Model:      "llama3.1",
 		TimeoutSec: 2,
 	}
-	fs := services.NewFlightService(nil, 0)
+	fs := services.NewFlightService(nil, 0, false)
 	h := NewSearchHandler(fs, nil, cfg, nil, nil, 0, nil, "", 0)
 
 	e := echo.New()
@@ -289,7 +289,7 @@ func TestV4MCPLLMStatus_OllamaPingNoAPIKey(t *testing.T) {
 func TestNewSearchHandler_LLMDisabledMeansNilClient(t *testing.T) {
 	cfg := &config.MCPConfig{}
 	cfg.LLM = config.MCPLLMConfig{Enable: false}
-	fs := services.NewFlightService(nil, 0)
+	fs := services.NewFlightService(nil, 0, false)
 	h := NewSearchHandler(fs, nil, cfg, nil, nil, 0, nil, "", 0)
 	if h.llm != nil {
 		t.Fatalf("expected nil LLM client when Enable=false, got %#v", h.llm)

--- a/src/coordinator/handlers/statistics_v4_test.go
+++ b/src/coordinator/handlers/statistics_v4_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestV4StatisticsQuery_RejectsUnsafeSQL(t *testing.T) {
 	e := echo.New()
-	h := NewStatisticsHandler(services.NewFlightService(nil, 0))
+	h := NewStatisticsHandler(services.NewFlightService(nil, 0, false))
 
 	body, err := json.Marshal(map[string]interface{}{
 		"param": map[string]interface{}{
@@ -51,7 +51,7 @@ func TestV4StatisticsQuery_RejectsUnsafeSQL(t *testing.T) {
 
 func TestV4StatisticsQuery_RejectsMultiStatement(t *testing.T) {
 	e := echo.New()
-	h := NewStatisticsHandler(services.NewFlightService(nil, 0))
+	h := NewStatisticsHandler(services.NewFlightService(nil, 0, false))
 
 	body, err := json.Marshal(map[string]interface{}{
 		"param": map[string]interface{}{

--- a/src/coordinator/handlers/transactions_v4.go
+++ b/src/coordinator/handlers/transactions_v4.go
@@ -821,6 +821,14 @@ func (h *SearchHandler) queryTransactionSearch(ctx context.Context, fullSQL stri
 	return rows, nil
 }
 
+// msToNs converts a millisecond epoch to nanoseconds; non-positive stays 0.
+func msToNs(ms int64) int64 {
+	if ms <= 0 {
+		return 0
+	}
+	return ms * 1_000_000
+}
+
 // runTransactionSearch executes the search/sort phase for the configured
 // strategy. When narrow is true the wide blob columns are dropped from the
 // projection (the caller re-attaches them by uuid).
@@ -829,13 +837,13 @@ func (h *SearchHandler) runTransactionSearch(ctx context.Context, fullSQL string
 	// or non-default ordering must see the whole range at once): single query.
 	if strategy == topNFull || !transactionSearchTopNShape(req) {
 		if !narrow {
-			return h.flightService.Query(ctx, fullSQL)
+			return h.flightService.QueryWithRange(ctx, fullSQL, msToNs(req.Timestamp.From), msToNs(req.Timestamp.To))
 		}
 		sql, err := buildSearchSQLV4WithOpts(h.flightService.LakeName(), req, virtualRules, searchSQLOpts{narrowNoHeavy: true})
 		if err != nil {
 			return nil, err
 		}
-		return h.flightService.Query(ctx, sql)
+		return h.flightService.QueryWithRange(ctx, sql, msToNs(req.Timestamp.From), msToNs(req.Timestamp.To))
 	}
 
 	// stream: a single query over the whole range, ORDER BY dropped, re-sorted
@@ -848,7 +856,7 @@ func (h *SearchHandler) runTransactionSearch(ctx context.Context, fullSQL string
 		}
 		logger.Info("V4TransactionsSearch: stream execution (single query)", "limit", limit,
 			"narrow", narrow, "from", req.Timestamp.From, "to", req.Timestamp.To)
-		rows, err := h.flightService.Query(ctx, streamSQL)
+		rows, err := h.flightService.QueryWithRange(ctx, streamSQL, msToNs(req.Timestamp.From), msToNs(req.Timestamp.To))
 		if err != nil {
 			return nil, err
 		}
@@ -877,7 +885,7 @@ func (h *SearchHandler) runTransactionSearch(ctx context.Context, fullSQL string
 		if err != nil {
 			return nil, err
 		}
-		rows, err := h.flightService.Query(ctx, sql)
+		rows, err := h.flightService.QueryWithRange(ctx, sql, msToNs(chunkReq.Timestamp.From), msToNs(chunkReq.Timestamp.To))
 		if err != nil {
 			return nil, err
 		}
@@ -985,7 +993,7 @@ func (h *SearchHandler) hydrateHeavyColumns(ctx context.Context, req *SearchObje
 
 	logger.Info("V4TransactionsSearch: hydrating full rows by uuid", "uuids", len(uuids),
 		"from", fromMs, "to", toMs)
-	fullRows, err := h.flightService.Query(ctx, sql)
+	fullRows, err := h.flightService.QueryWithRange(ctx, sql, msToNs(fromMs), msToNs(toMs))
 	if err != nil {
 		logger.Warn("V4TransactionsSearch: row hydration failed, returning narrow rows",
 			"error", err)

--- a/src/coordinator/handlers/transactions_v4_correlation_test.go
+++ b/src/coordinator/handlers/transactions_v4_correlation_test.go
@@ -124,7 +124,7 @@ func newTestSearchHandler(t *testing.T, rowsPerCall [][]map[string]interface{}, 
 
 	fs := services.NewFlightService([]config.NodeEndpoint{{
 		Name: "n1", Host: host, Port: flightPort,
-	}}, 0)
+	}}, 0, false)
 	_ = fs.ConnectAll()
 	fs.SetLakeName("homer_lake")
 

--- a/src/coordinator/handlers/transactions_v4_export_whitelist_test.go
+++ b/src/coordinator/handlers/transactions_v4_export_whitelist_test.go
@@ -40,7 +40,7 @@ func TestBuildExportExcludeIPClause_escapesQuotes(t *testing.T) {
 }
 
 func TestBuildTransactionExportSQL_includesWhitelist(t *testing.T) {
-	h := &SearchHandler{flightService: services.NewFlightService(nil, 0)}
+	h := &SearchHandler{flightService: services.NewFlightService(nil, 0, false)}
 	sql, ids, err := h.buildTransactionExportSQL(&TransactionSessionRequestV4{
 		SessionID: "abc@host",
 		Whitelist: []string{"10.0.0.1", "192.168.1.5"},
@@ -63,7 +63,7 @@ func TestShareExportPayload_whitelistRoundTrip(t *testing.T) {
 	if err := json.Unmarshal(body, &req); err != nil {
 		t.Fatal(err)
 	}
-	h := &SearchHandler{flightService: services.NewFlightService(nil, 0)}
+	h := &SearchHandler{flightService: services.NewFlightService(nil, 0, false)}
 	sql, _, err := h.buildTransactionExportSQL(&req)
 	if err != nil {
 		t.Fatal(err)

--- a/src/coordinator/handlers/transactions_v4_test.go
+++ b/src/coordinator/handlers/transactions_v4_test.go
@@ -1,0 +1,14 @@
+package handlers
+
+import (
+	"testing"
+)
+
+func TestMsToNs(t *testing.T) {
+	if msToNs(0) != 0 || msToNs(-5) != 0 {
+		t.Fatal("non-positive ms must map to 0")
+	}
+	if msToNs(1737504000000) != 1737504000000000000 {
+		t.Fatalf("got %d", msToNs(1737504000000))
+	}
+}

--- a/src/coordinator/services/flight_service.go
+++ b/src/coordinator/services/flight_service.go
@@ -255,8 +255,54 @@ func (s *FlightService) QueryFirstConnected(ctx context.Context, sql string) ([]
 	return nil, fmt.Errorf("no connected storage nodes")
 }
 
-// Query executes a SQL query against all nodes and returns results
+// nodesForRange filters connected nodes to those whose cached timestamp range
+// may overlap the query window [fromNs, toNs]. A node is skipped only when its
+// cached range provably does not overlap the window in either direction:
+//   - too old: cached max is non-zero and strictly before fromNs.
+//   - too new: cached min is non-zero and strictly after toNs.
+//
+// Unknown/uncached nodes, nodes with min/max == 0, and all nodes when smart
+// routing is disabled (or the window is open-ended) are kept. Never returns an
+// empty slice when the input is non-empty.
+//
+// This is staleness-safe: a node's data max only grows over time and its min
+// only rises as old data ages out, so a stale cache can only under-skip (keep a
+// node that could now be pruned) — it can never wrongly drop a node that holds
+// matching data.
+//
+// Callers must hold at least s.mu.RLock() because it reads s.rangeCache.
+func (s *FlightService) nodesForRange(connectedNodes []config.NodeEndpoint, fromNs, toNs int64) []config.NodeEndpoint {
+	if !s.smartRouting || fromNs <= 0 || toNs <= 0 {
+		return connectedNodes
+	}
+	kept := make([]config.NodeEndpoint, 0, len(connectedNodes))
+	for _, n := range connectedNodes {
+		rng, ok := s.rangeCache[n.Name]
+		if ok && rng.max > 0 && rng.max < fromNs {
+			logger.Info("Hub: skipping node (data too old)", "node", n.Name, "node_max", rng.max, "query_from", fromNs)
+			continue
+		}
+		if ok && rng.min > 0 && rng.min > toNs {
+			logger.Info("Hub: skipping node (data too new)", "node", n.Name, "node_min", rng.min, "query_to", toNs)
+			continue
+		}
+		kept = append(kept, n)
+	}
+	if len(kept) == 0 {
+		return connectedNodes // never empty due to pruning
+	}
+	return kept
+}
+
+// Query executes SQL against all connected nodes (no time-range pruning).
 func (s *FlightService) Query(ctx context.Context, sql string) ([]map[string]interface{}, error) {
+	return s.QueryWithRange(ctx, sql, 0, 0)
+}
+
+// QueryWithRange executes SQL against connected nodes, skipping nodes that
+// provably hold no data at or after fromNs when smart routing is enabled.
+// fromNs/toNs are epoch nanoseconds; pass 0 to disable pruning.
+func (s *FlightService) QueryWithRange(ctx context.Context, sql string, fromNs, toNs int64) ([]map[string]interface{}, error) {
 	s.mu.RLock()
 	nodes := make([]config.NodeEndpoint, len(s.nodes))
 	copy(nodes, s.nodes)
@@ -270,13 +316,18 @@ func (s *FlightService) Query(ctx context.Context, sql string) ([]map[string]int
 		return nil, fmt.Errorf("no configured nodes")
 	}
 
-	connectedCount := 0
+	connectedNodes := make([]config.NodeEndpoint, 0, len(nodes))
 	for _, node := range nodes {
 		if connected[node.Name] {
-			connectedCount++
+			connectedNodes = append(connectedNodes, node)
 		}
 	}
-	logger.Info("Hub: Query to nodes", "connected", connectedCount, "total", len(nodes), "sql_chars", len(sql))
+
+	s.mu.RLock()
+	targets := s.nodesForRange(connectedNodes, fromNs, toNs)
+	s.mu.RUnlock()
+
+	logger.Info("Hub: Query to nodes", "targets", len(targets), "connected", len(connectedNodes), "total", len(nodes), "sql_chars", len(sql))
 	logger.Debug("Hub: Query to nodes", "sql", sql)
 
 	allResults := make([]map[string]interface{}, 0)
@@ -285,18 +336,11 @@ func (s *FlightService) Query(ctx context.Context, sql string) ([]map[string]int
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 
-	for _, node := range nodes {
-		if !connected[node.Name] {
-			logger.Info("Hub: Skipping disconnected node", "node", node.Name)
-			continue
-		}
-
+	for _, node := range targets {
 		wg.Add(1)
 		go func(n config.NodeEndpoint) {
 			defer wg.Done()
-
 			results, err := s.queryNode(ctx, n, sql)
-
 			mu.Lock()
 			defer mu.Unlock()
 			if err != nil {
@@ -308,7 +352,6 @@ func (s *FlightService) Query(ctx context.Context, sql string) ([]map[string]int
 			allResults = append(allResults, results...)
 		}(node)
 	}
-
 	wg.Wait()
 
 	// Surface the failure when no node produced a result; silently returning

--- a/src/coordinator/services/flight_service.go
+++ b/src/coordinator/services/flight_service.go
@@ -33,15 +33,23 @@ type FlightService struct {
 	// shorter deadline are still honored.
 	queryTimeout time.Duration
 	connected    map[string]bool
+	smartRouting bool
+	rangeCache   map[string]tsRange // node name -> cached min/max (ns)
 	mu           sync.RWMutex
 	stopCh       chan struct{}
 	stopOnce     sync.Once
 	lakeName     string
 }
 
+// tsRange is a node's cached min/max timestamp in nanoseconds.
+type tsRange struct {
+	min int64
+	max int64
+}
+
 // NewFlightService creates a new FlightSQL service.
 // queryTimeout controls the per-query timeout for data queries to nodes.
-func NewFlightService(nodes []config.NodeEndpoint, queryTimeout time.Duration) *FlightService {
+func NewFlightService(nodes []config.NodeEndpoint, queryTimeout time.Duration, smartRouting bool) *FlightService {
 	if queryTimeout <= 0 {
 		queryTimeout = 30 * time.Second
 	}
@@ -52,9 +60,11 @@ func NewFlightService(nodes []config.NodeEndpoint, queryTimeout time.Duration) *
 		healthClient: &http.Client{
 			Timeout: 5 * time.Second,
 		},
-		connected: make(map[string]bool),
-		stopCh:    make(chan struct{}),
-		lakeName:  "homer_lake",
+		connected:    make(map[string]bool),
+		rangeCache:   make(map[string]tsRange),
+		smartRouting: smartRouting,
+		stopCh:       make(chan struct{}),
+		lakeName:     "homer_lake",
 	}
 }
 
@@ -138,6 +148,13 @@ func (s *FlightService) healthCheckLoop() {
 						logger.Info("Hub: Node is now online", "node", node.Name)
 					}
 					s.connected[node.Name] = true
+					if s.smartRouting {
+						if rng, rerr := s.fetchNodeRange(node); rerr == nil {
+							s.rangeCache[node.Name] = rng
+						} else {
+							delete(s.rangeCache, node.Name) // unknown -> keep node
+						}
+					}
 				}
 			}
 			s.mu.Unlock()
@@ -163,6 +180,35 @@ func (s *FlightService) checkNode(node config.NodeEndpoint) error {
 
 	logger.Info("🔗 Hub: Connected to node", "node", node.Name, "addr", fmt.Sprintf("%s:%d", node.Host, httpPort))
 	return nil
+}
+
+// fetchNodeRange retrieves a node's min/max timestamp via GET /metadata/stats.
+func (s *FlightService) fetchNodeRange(node config.NodeEndpoint) (tsRange, error) {
+	httpPort := node.Port + 1
+	url := fmt.Sprintf("http://%s:%d/metadata/stats", node.Host, httpPort)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return tsRange{}, err
+	}
+	if tok := strings.TrimSpace(node.Token); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+	resp, err := s.healthClient.Do(req)
+	if err != nil {
+		return tsRange{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return tsRange{}, fmt.Errorf("stats HTTP error: %d", resp.StatusCode)
+	}
+	var body struct {
+		MinTs int64 `json:"min_ts"`
+		MaxTs int64 `json:"max_ts"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return tsRange{}, err
+	}
+	return tsRange{min: body.MinTs, max: body.MaxTs}, nil
 }
 
 // CloseAll closes all connections and stops the health check loop

--- a/src/coordinator/services/flight_service.go
+++ b/src/coordinator/services/flight_service.go
@@ -135,25 +135,59 @@ func (s *FlightService) healthCheckLoop() {
 		case <-s.stopCh:
 			return
 		case <-ticker.C:
-			s.mu.Lock()
+			// Snapshot the prior connected state under the lock so online/offline
+			// transition logging is accurate, then release it before any HTTP.
+			s.mu.RLock()
+			wasConnected := make(map[string]bool, len(s.connected))
+			for k, v := range s.connected {
+				wasConnected[k] = v
+			}
+			s.mu.RUnlock()
+
+			// Do ALL blocking HTTP (checkNode + fetchNodeRange) with NO lock held.
+			// s.nodes is immutable after construction, so iterating it here is safe.
+			// Results are collected locally and applied under a single write lock
+			// below, so QueryWithRange readers are never stalled behind HTTP.
+			type nodeResult struct {
+				name      string
+				connected bool
+				hasRange  bool // true only when a fresh range was fetched
+				rng       tsRange
+			}
+			results := make([]nodeResult, 0, len(s.nodes))
 			for _, node := range s.nodes {
-				wasConnected := s.connected[node.Name]
+				res := nodeResult{name: node.Name}
 				if err := s.checkNode(node); err != nil {
-					if wasConnected {
+					if wasConnected[node.Name] {
 						logger.Warn(fmt.Sprintf("Hub: Node %s went offline: %v", node.Name, err))
 					}
-					s.connected[node.Name] = false
+					res.connected = false
 				} else {
-					if !wasConnected {
+					if !wasConnected[node.Name] {
 						logger.Info("Hub: Node is now online", "node", node.Name)
 					}
-					s.connected[node.Name] = true
+					res.connected = true
 					if s.smartRouting {
 						if rng, rerr := s.fetchNodeRange(node); rerr == nil {
-							s.rangeCache[node.Name] = rng
-						} else {
-							delete(s.rangeCache, node.Name) // unknown -> keep node
+							res.hasRange = true
+							res.rng = rng
 						}
+						// Fail-safe: a stats-fetch error leaves hasRange false, which
+						// deletes the cache entry below (unknown -> keep the node).
+					}
+				}
+				results = append(results, res)
+			}
+
+			// Apply results under a single write lock: in-memory map writes only.
+			s.mu.Lock()
+			for _, res := range results {
+				s.connected[res.name] = res.connected
+				if s.smartRouting && res.connected {
+					if res.hasRange {
+						s.rangeCache[res.name] = res.rng
+					} else {
+						delete(s.rangeCache, res.name) // unknown -> keep node
 					}
 				}
 			}
@@ -278,10 +312,22 @@ func (s *FlightService) nodesForRange(connectedNodes []config.NodeEndpoint, from
 	kept := make([]config.NodeEndpoint, 0, len(connectedNodes))
 	for _, n := range connectedNodes {
 		rng, ok := s.rangeCache[n.Name]
+		// Too-old safety relies on the query window exceeding the node's
+		// persist/flush lag: buffered-but-unpersisted rows are excluded from
+		// min/max, so a "last N seconds" window with N < flush interval could
+		// skip a hot node holding only buffered rows. Typical UI windows
+		// (5/15/30 min) comfortably exceed the flush interval and are safe.
 		if ok && rng.max > 0 && rng.max < fromNs {
 			logger.Info("Hub: skipping node (data too old)", "node", n.Name, "node_max", rng.max, "query_from", fromNs)
 			continue
 		}
+		// Too-new direction assumes a node's min timestamp only rises (true for
+		// live capture + retention aging out old rows). Historical backfill
+		// (pcap import / replay ingesting rows OLDER than the cached min)
+		// violates this: for up to one health interval the stale-high cached min
+		// could skip a node that now holds matching old rows. The too-old
+		// direction has no such hazard. Operators doing historical import should
+		// keep smart_routing disabled or accept <=1 health-interval staleness.
 		if ok && rng.min > 0 && rng.min > toNs {
 			logger.Info("Hub: skipping node (data too new)", "node", n.Name, "node_min", rng.min, "query_to", toNs)
 			continue
@@ -303,29 +349,24 @@ func (s *FlightService) Query(ctx context.Context, sql string) ([]map[string]int
 // provably hold no data at or after fromNs when smart routing is enabled.
 // fromNs/toNs are epoch nanoseconds; pass 0 to disable pruning.
 func (s *FlightService) QueryWithRange(ctx context.Context, sql string, fromNs, toNs int64) ([]map[string]interface{}, error) {
+	// Single RLock critical section: snapshot nodes, build the connected set,
+	// and compute range-pruned targets before releasing the lock. The goroutine
+	// fan-out below must NOT hold the lock.
 	s.mu.RLock()
 	nodes := make([]config.NodeEndpoint, len(s.nodes))
 	copy(nodes, s.nodes)
-	connected := make(map[string]bool)
-	for k, v := range s.connected {
-		connected[k] = v
+	connectedNodes := make([]config.NodeEndpoint, 0, len(s.nodes))
+	for _, node := range s.nodes {
+		if s.connected[node.Name] {
+			connectedNodes = append(connectedNodes, node)
+		}
 	}
+	targets := s.nodesForRange(connectedNodes, fromNs, toNs)
 	s.mu.RUnlock()
 
 	if len(nodes) == 0 {
 		return nil, fmt.Errorf("no configured nodes")
 	}
-
-	connectedNodes := make([]config.NodeEndpoint, 0, len(nodes))
-	for _, node := range nodes {
-		if connected[node.Name] {
-			connectedNodes = append(connectedNodes, node)
-		}
-	}
-
-	s.mu.RLock()
-	targets := s.nodesForRange(connectedNodes, fromNs, toNs)
-	s.mu.RUnlock()
 
 	logger.Info("Hub: Query to nodes", "targets", len(targets), "connected", len(connectedNodes), "total", len(nodes), "sql_chars", len(sql))
 	logger.Debug("Hub: Query to nodes", "sql", sql)

--- a/src/coordinator/services/flight_service_prune_test.go
+++ b/src/coordinator/services/flight_service_prune_test.go
@@ -1,0 +1,87 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sipcapture/homer-core/src/config"
+)
+
+func TestSmartRoutingSkipsColdNode(t *testing.T) {
+	var hotHit, warmHit, coldHit int32
+	mk := func(minNs, maxNs int64, hit *int32) *httptest.Server {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/metadata/stats", func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(map[string]int64{"min_ts": minNs, "max_ts": maxNs})
+		})
+		mux.HandleFunc("/query", func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(hit, 1)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"success": true, "count": 1,
+				"data": []map[string]interface{}{{"n": 1}},
+			})
+		})
+		return httptest.NewServer(mux)
+	}
+	now := time.Now().UnixNano()
+	hour := int64(time.Hour)
+	minute := int64(time.Minute)
+	// hot and warm both overlap the last-15-minutes window [now-15m, now]:
+	// hot's max is now, warm's max is now-5m (still inside the window). cold's
+	// max is ~80 days ago, so it is skipped as "too old" by the full-overlap rule.
+	hot := mk(now-2*hour, now, &hotHit)
+	warm := mk(now-6*hour, now-5*minute, &warmHit)
+	cold := mk(now-90*24*hour, now-80*24*hour, &coldHit)
+	defer hot.Close()
+	defer warm.Close()
+	defer cold.Close()
+
+	ep := func(name string, srv *httptest.Server) config.NodeEndpoint {
+		host, portStr, _ := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+		port, _ := strconv.Atoi(portStr)
+		return config.NodeEndpoint{Name: name, Host: host, Port: port - 1} // node HTTP = Port+1
+	}
+	nodes := []config.NodeEndpoint{ep("hot", hot), ep("warm", warm), ep("cold", cold)}
+	s := NewFlightService(nodes, 2*time.Second, true)
+	s.mu.Lock()
+	for _, n := range nodes {
+		s.connected[n.Name] = true
+		rng, err := s.fetchNodeRange(n)
+		if err != nil {
+			s.mu.Unlock()
+			t.Fatalf("fetch %s: %v", n.Name, err)
+		}
+		s.rangeCache[n.Name] = rng
+	}
+	s.mu.Unlock()
+
+	from := now - 15*int64(time.Minute) // last 15 minutes
+	rows, err := s.QueryWithRange(context.Background(), "SELECT 1", from, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if atomic.LoadInt32(&coldHit) != 0 {
+		t.Fatalf("cold node must not be queried, hits=%d", coldHit)
+	}
+	if atomic.LoadInt32(&hotHit) != 1 || atomic.LoadInt32(&warmHit) != 1 {
+		t.Fatalf("hot/warm must each be queried once, got hot=%d warm=%d", hotHit, warmHit)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("want 2 merged rows (hot+warm), got %d", len(rows))
+	}
+}

--- a/src/coordinator/services/flight_service_test.go
+++ b/src/coordinator/services/flight_service_test.go
@@ -2,6 +2,8 @@ package services
 
 import (
 	"context"
+	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -14,7 +16,7 @@ import (
 )
 
 func TestFlightServiceCloseAllIsIdempotent(t *testing.T) {
-	svc := NewFlightService(nil, 0)
+	svc := NewFlightService(nil, 0, false)
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -29,7 +31,7 @@ func TestFlightServiceCloseAllIsIdempotent(t *testing.T) {
 func TestFlightServiceQueryNodeNotFound(t *testing.T) {
 	svc := NewFlightService([]config.NodeEndpoint{
 		{Name: "node-a", Host: "127.0.0.1", Port: 30000},
-	}, 0)
+	}, 0, false)
 
 	_, err := svc.QueryNode(context.Background(), "missing-node", "SELECT 1")
 	if err == nil {
@@ -58,7 +60,7 @@ func TestFlightServiceQuerySendsBearerToken(t *testing.T) {
 	// queryNode uses Port+1 for HTTP; point Port at serverPort-1.
 	svc := NewFlightService([]config.NodeEndpoint{
 		{Name: "local", Host: host, Port: port - 1, Token: "node-secret"},
-	}, time.Second)
+	}, time.Second, false)
 
 	rows, err := svc.QueryNode(context.Background(), "local", "SELECT 1")
 	if err != nil {
@@ -69,5 +71,30 @@ func TestFlightServiceQuerySendsBearerToken(t *testing.T) {
 	}
 	if gotAuth != "Bearer node-secret" {
 		t.Fatalf("Authorization=%q", gotAuth)
+	}
+}
+
+func TestFetchNodeRangeParsesStats(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/metadata/stats" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"min_ts": int64(100), "max_ts": int64(200),
+		})
+	}))
+	defer srv.Close()
+	host, portStr, _ := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+	port, _ := strconv.Atoi(portStr)
+	// Node HTTP API is at Port+1, so configure Port = port-1.
+	s := NewFlightService([]config.NodeEndpoint{{Name: "n1", Host: host, Port: port - 1}}, time.Second, true)
+
+	rng, err := s.fetchNodeRange(config.NodeEndpoint{Name: "n1", Host: host, Port: port - 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rng.min != 100 || rng.max != 200 {
+		t.Fatalf("got %+v, want {100 200}", rng)
 	}
 }

--- a/src/coordinator/services/flight_service_test.go
+++ b/src/coordinator/services/flight_service_test.go
@@ -98,3 +98,47 @@ func TestFetchNodeRangeParsesStats(t *testing.T) {
 		t.Fatalf("got %+v, want {100 200}", rng)
 	}
 }
+
+func TestNodesForRangeSkipsNonOverlapping(t *testing.T) {
+	s := NewFlightService(nil, time.Second, true)
+	s.rangeCache = map[string]tsRange{
+		"hot":    {min: 0, max: 1_000},     // overlaps window -> keep
+		"cold":   {min: 0, max: 100},       // max < from -> skip (too old)
+		"future": {min: 5_000, max: 6_000}, // min > to -> skip (too new)
+		"empty":  {min: 0, max: 0},         // unknown -> keep
+	}
+	nodes := []config.NodeEndpoint{{Name: "hot"}, {Name: "cold"}, {Name: "future"}, {Name: "empty"}, {Name: "uncached"}}
+	got := s.nodesForRange(nodes, 500, 2_000) // query window [500, 2000]ns
+	names := map[string]bool{}
+	for _, n := range got {
+		names[n.Name] = true
+	}
+	if !names["hot"] || !names["empty"] || !names["uncached"] {
+		t.Fatalf("hot/empty/uncached must be kept, got %v", names)
+	}
+	if names["cold"] {
+		t.Fatalf("cold (max<from) must be skipped, got %v", names)
+	}
+	if names["future"] {
+		t.Fatalf("future (min>to) must be skipped, got %v", names)
+	}
+}
+
+func TestNodesForRangeNeverEmpties(t *testing.T) {
+	s := NewFlightService(nil, time.Second, true)
+	s.rangeCache = map[string]tsRange{"a": {max: 100}, "b": {max: 200}}
+	nodes := []config.NodeEndpoint{{Name: "a"}, {Name: "b"}}
+	got := s.nodesForRange(nodes, 1_000, 2_000) // both too old
+	if len(got) != 2 {
+		t.Fatalf("filter must not empty the set; want 2 got %d", len(got))
+	}
+}
+
+func TestNodesForRangeDisabledKeepsAll(t *testing.T) {
+	s := NewFlightService(nil, time.Second, false) // smart routing off
+	s.rangeCache = map[string]tsRange{"a": {max: 100}}
+	nodes := []config.NodeEndpoint{{Name: "a"}}
+	if len(s.nodesForRange(nodes, 1_000, 2_000)) != 1 {
+		t.Fatalf("disabled must keep all")
+	}
+}

--- a/src/node/metadata.go
+++ b/src/node/metadata.go
@@ -34,8 +34,14 @@ func nodeTimeRange(db *sql.DB) (minNs, maxNs int64, err error) {
 			return 0, 0, err
 		}
 		fqn := fmt.Sprintf(`"%s"."%s"."%s"`, dbName, schema, table)
+		// Apply epoch_ns to the result of min/max (not min/max of epoch_ns):
+		// epoch_ns is monotonic so the values are identical, but min(timestamp)/
+		// max(timestamp) operate on the bare column, letting DuckDB answer from
+		// Parquet zone-map stats instead of scanning. The epoch conversion still
+		// happens in-DB (BIGINT ns, timezone-independent) — important since these
+		// stats gate node pruning; no Go-side time.Time/timezone conversion.
 		union = append(union, fmt.Sprintf(
-			`SELECT min(epoch_ns(timestamp)) AS mn, max(epoch_ns(timestamp)) AS mx FROM %s`, fqn))
+			`SELECT epoch_ns(min(timestamp)) AS mn, epoch_ns(max(timestamp)) AS mx FROM %s`, fqn))
 	}
 	if err := rows.Err(); err != nil {
 		return 0, 0, err

--- a/src/node/metadata.go
+++ b/src/node/metadata.go
@@ -1,0 +1,84 @@
+// Copyright (C) 2025 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package node
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// nodeTimeRange returns the min/max timestamp (nanoseconds since epoch) across
+// all hep_proto_* tables visible to this node's DuckDB connection, spanning any
+// attached DuckLake volumes. Returns 0,0 when the node holds no data.
+func nodeTimeRange(db *sql.DB) (minNs, maxNs int64, err error) {
+	// duckdb_tables() spans every attached catalog, so tiered volumes are
+	// covered automatically.
+	rows, err := db.Query(`SELECT database_name, schema_name, table_name
+		FROM duckdb_tables() WHERE table_name LIKE 'hep_proto_%'`)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer rows.Close()
+
+	var union []string
+	for rows.Next() {
+		var dbName, schema, table string
+		if err := rows.Scan(&dbName, &schema, &table); err != nil {
+			return 0, 0, err
+		}
+		fqn := fmt.Sprintf(`"%s"."%s"."%s"`, dbName, schema, table)
+		union = append(union, fmt.Sprintf(
+			`SELECT min(epoch_ns(timestamp)) AS mn, max(epoch_ns(timestamp)) AS mx FROM %s`, fqn))
+	}
+	if err := rows.Err(); err != nil {
+		return 0, 0, err
+	}
+	if len(union) == 0 {
+		return 0, 0, nil
+	}
+
+	q := "SELECT min(mn), max(mx) FROM (" + strings.Join(union, " UNION ALL ") + ")"
+	var mn, mx sql.NullInt64
+	if err := db.QueryRow(q).Scan(&mn, &mx); err != nil {
+		return 0, 0, err
+	}
+	if mn.Valid {
+		minNs = mn.Int64
+	}
+	if mx.Valid {
+		maxNs = mx.Int64
+	}
+	return minNs, maxNs, nil
+}
+
+// handleMetadataStats handles GET /metadata/stats.
+func (n *Node) handleMetadataStats(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if n.db == nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+			"error": "database not initialized",
+		})
+		return
+	}
+	minNs, maxNs, err := nodeTimeRange(n.db)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+			"error": err.Error(),
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"min_ts": minNs,
+		"max_ts": maxNs,
+	})
+}

--- a/src/node/metadata_test.go
+++ b/src/node/metadata_test.go
@@ -1,0 +1,50 @@
+package node
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+)
+
+func TestNodeTimeRange(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	// Two hep_proto_* tables with known timestamps.
+	mustExec(t, db, `CREATE TABLE hep_proto_1_call (timestamp TIMESTAMP)`)
+	mustExec(t, db, `INSERT INTO hep_proto_1_call VALUES (TIMESTAMP '2025-01-22 00:00:00')`)
+	mustExec(t, db, `CREATE TABLE hep_proto_1_default (timestamp TIMESTAMP)`)
+	mustExec(t, db, `INSERT INTO hep_proto_1_default VALUES (TIMESTAMP '2025-01-23 00:00:00')`)
+
+	minNs, maxNs, err := nodeTimeRange(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantMin := int64(1737504000000000000) // 2025-01-22T00:00:00Z
+	wantMax := int64(1737590400000000000) // 2025-01-23T00:00:00Z
+	if minNs != wantMin || maxNs != wantMax {
+		t.Fatalf("got min=%d max=%d, want min=%d max=%d", minNs, maxNs, wantMin, wantMax)
+	}
+}
+
+func TestNodeTimeRangeEmpty(t *testing.T) {
+	db, _ := sql.Open("duckdb", "")
+	defer db.Close()
+	minNs, maxNs, err := nodeTimeRange(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if minNs != 0 || maxNs != 0 {
+		t.Fatalf("empty node should report 0/0, got %d/%d", minNs, maxNs)
+	}
+}
+
+func mustExec(t *testing.T, db *sql.DB, q string) {
+	t.Helper()
+	if _, err := db.Exec(q); err != nil {
+		t.Fatalf("exec %q: %v", q, err)
+	}
+}

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -190,6 +190,7 @@ func (n *Node) Start() error {
 	mux.HandleFunc("/query", withBearerAuth(authTok, n.handleQuery))
 	mux.HandleFunc("/health", n.handleHealth)
 	mux.HandleFunc("/vacuum", withBearerAuth(authTok, n.handleVacuum))
+	mux.HandleFunc("/metadata/stats", withBearerAuth(authTok, n.handleMetadataStats))
 	mux.HandleFunc("/stream", n.handleStream)
 
 	n.httpServer = &http.Server{

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.313"
+	VERSION_APPLICATION = "11.0.314"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
Adds opt-in **smart routing** to the Coordinator's UI search fan-out: before querying storage nodes, skip any node whose cached data range provably does not overlap the search's time window. Cold/archive nodes are no longer queried for recent-data searches. Off by default (`coordinator.smart_routing.enable`, default `false`) — zero behavior change until enabled.

## How it works
- **Node** exposes read-only `GET /metadata/stats` → `{min_ts, max_ts}` (nanoseconds), computed as `epoch_ns(min(timestamp))`/`epoch_ns(max(timestamp))` across all `hep_proto_*` tables (zone-map-friendly, timezone-independent).
- **Coordinator** polls it on the existing health-loop tick, caching each node's `tsRange`. HTTP runs outside the state lock; the lock is held only for the in-memory cache write.
- **`QueryWithRange(ctx, sql, fromNs, toNs)`** prunes a node iff its range can't overlap `[from,to]`: `max < from` (too old) **or** `min > to` (too new). `Query` delegates with `0,0` (no pruning).
- The transactions search handler threads `req.Timestamp.From/To` (ms→ns) into `QueryWithRange` on the bounded search paths.

## Safety
- **Never drops rows:** skip only on provable non-overlap; if the filter empties the set, all connected nodes are queried. Unknown/uncached/disabled/no-window → keep the node.
- **Staleness-safe:** a node's `max` only grows and `min` only rises, so a stale cache can only *under*-skip (keep), never wrongly drop data.
- **Known precondition (documented in code):** the too-new direction assumes no historical backfill (pcap import/replay ingesting rows older than cached min); under backfill, exposure is bounded to ≤1 health interval. Keep `smart_routing` off if using historical import.

## Config
```json
{ "coordinator": { "smart_routing": { "enable": false } } }
```

## Testing
- Unit: overlap skip-rule (too-old/too-new/unknown/disabled/never-empty), node min/max over multi-table fixture, ms→ns.
- Integration: 3-node (hot/warm/cold) — a last-15-min search issues **zero** `/query` to the cold node and returns complete hot+warm results.
- Full suite: 553 pass across 10 packages. (Root `src` package's `all:dist` embed error is pre-existing/unrelated — needs the frontend build.)
