### PR TITLE
fix(coordinator): smart routing follow-ups after #930

### DIFF
--- a/docs/COORDINATOR.md
+++ b/docs/COORDINATOR.md
@@ -162,6 +162,15 @@ overlap the query window — its newest data is older than the window start, or
 its oldest data is newer than the window end. If pruning would leave no nodes,
 all connected nodes are queried, so pruning never drops results.
 
+Pruning applies to UI search and transaction paths that carry a time window
+(search, call flow / messages, QoS, callinfo, events, export, OTLP tabs).
+Admin/raw SQL, schema discovery, and unbounded lookups still fan out to every
+connected node.
+
+Cached `max` is widened by a fixed slack (default health interval + DuckLake
+flush lag ≈ 45s) so short windows and buffered-but-unflushed rows do not cause
+false too-old skips.
+
 > **Precondition — historical ingest.** The "newer than the window end" skip
 > direction assumes a node's oldest (`min`) timestamp only rises over time (true
 > for live capture plus retention). **Historical pcap import or replay that
@@ -170,7 +179,7 @@ all connected nodes are queried, so pruning never drops results.
 > skipped for a query that it now has matching (older) rows for. If you run
 > historical/backfill ingest, keep `smart_routing.enable` **off**, or accept up
 > to one health-interval of staleness. The "older than the window start"
-> direction has no such hazard.
+> direction is hardened with flush/health slack on cached `max`.
 
 ### With OAuth2 Providers
 
@@ -254,7 +263,7 @@ Authorization **code** flow (server exchanges `code`, loads userinfo, provisions
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `enable` | bool | false | Skip nodes whose cached data time range cannot overlap a search's time window (UI search path). Off = every connected node is queried. See [Smart Routing](#smart-routing-time-range-node-pruning) — note the historical-ingest precondition before enabling. |
+| `enable` | bool | false | Skip nodes whose cached data time range cannot overlap a search's time window (UI search + transaction paths with timestamps). Off = every connected node is queried. See [Smart Routing](#smart-routing-time-range-node-pruning) — note the historical-ingest precondition before enabling. |
 
 ### jwt
 

--- a/src/coordinator/handlers/search.go
+++ b/src/coordinator/handlers/search.go
@@ -165,8 +165,8 @@ func (h *SearchHandler) SearchCalls(c echo.Context) error {
 		})
 	}
 
-	// Execute query via FlightSQL
-	results, err := h.flightService.Query(c.Request().Context(), sql)
+	fromNs, toNs := simpleSearchRangeNs(&req)
+	results, err := h.flightService.QueryWithRange(c.Request().Context(), sql, fromNs, toNs)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
 			"success": false,
@@ -473,7 +473,18 @@ func (h *SearchHandler) GetCallByID(c echo.Context) error {
 
 	slog.Info("GetCallByID query", "sql", sql, "callid", callID)
 
-	results, err := h.flightService.Query(c.Request().Context(), sql)
+	var fromNs, toNs int64
+	if fromTs != "" {
+		if ts, err := parseTimestamp(fromTs); err == nil {
+			fromNs = msToNs(ts)
+		}
+	}
+	if toTs != "" {
+		if ts, err := parseTimestamp(toTs); err == nil {
+			toNs = msToNs(ts)
+		}
+	}
+	results, err := h.flightService.QueryWithRange(c.Request().Context(), sql, fromNs, toNs)
 	if err != nil {
 		slog.Error("GetCallByID query failed", "error", err)
 		return c.JSON(http.StatusOK, map[string]interface{}{
@@ -541,6 +552,25 @@ func (h *SearchHandler) GetPayload(c echo.Context) error {
 		"success": false,
 		"error":   "Record not found",
 	})
+}
+
+// simpleSearchRangeNs converts SimpleSearchRequest from/to strings to epoch ns
+// for smart-routing pruning. Missing/invalid values stay 0 (no pruning).
+func simpleSearchRangeNs(req *SimpleSearchRequest) (fromNs, toNs int64) {
+	if req == nil {
+		return 0, 0
+	}
+	if req.From != "" {
+		if ts, err := parseTimestamp(req.From); err == nil {
+			fromNs = msToNs(ts)
+		}
+	}
+	if req.To != "" {
+		if ts, err := parseTimestamp(req.To); err == nil {
+			toNs = msToNs(ts)
+		}
+	}
+	return fromNs, toNs
 }
 
 // parseTimestamp parses ISO timestamp or unix milliseconds
@@ -642,7 +672,7 @@ func (h *SearchHandler) GetCallTransaction(c echo.Context) error {
 			table, sidCondition, tsCondition,
 		)
 
-		results, err := h.flightService.Query(c.Request().Context(), sql)
+		results, err := h.flightService.QueryWithRange(c.Request().Context(), sql, msToNs(req.Timestamp.From), msToNs(req.Timestamp.To))
 		if err != nil {
 			continue
 		}

--- a/src/coordinator/handlers/transactions_v4.go
+++ b/src/coordinator/handlers/transactions_v4.go
@@ -547,7 +547,8 @@ func (h *SearchHandler) V4TransactionsList(c echo.Context) error {
 	if err != nil {
 		return writeError(c, http.StatusBadRequest, "Bad Request", err.Error())
 	}
-	results, err := h.flightService.Query(c.Request().Context(), sql)
+	fromNs, toNs := simpleSearchRangeNs(&req)
+	results, err := h.flightService.QueryWithRange(c.Request().Context(), sql, fromNs, toNs)
 	if err != nil {
 		return writeError(c, http.StatusInternalServerError, "Server Error", "Query failed")
 	}
@@ -1228,7 +1229,7 @@ func (h *SearchHandler) executeTransactionMessagesSQL(ctx context.Context, table
 		return nil, fmt.Errorf("no session_id provided")
 	}
 	sql := transactionMessagesSelectSQL(table, sessionIDs, from, to)
-	return h.flightService.Query(ctx, sql)
+	return h.flightService.QueryWithRange(ctx, sql, msToNs(from), msToNs(to))
 }
 
 // mergeSessionIDs returns base ∪ extras with order preserved, whitespace
@@ -1345,7 +1346,7 @@ func (h *SearchHandler) V4MessageGet(c echo.Context) error {
 		where += fmt.Sprintf(" AND timestamp >= (to_timestamp(%d / 1000.0) AT TIME ZONE 'UTC') AND timestamp <= (to_timestamp(%d / 1000.0) AT TIME ZONE 'UTC')",
 			req.Timestamp.From, req.Timestamp.To)
 	}
-	results, err := h.queryMessageByUUIDAcrossTables(c.Request().Context(), protoType, eventType, where)
+	results, err := h.queryMessageByUUIDAcrossTables(c.Request().Context(), protoType, eventType, where, req.Timestamp.From, req.Timestamp.To)
 	if err != nil {
 		return writeError(c, http.StatusInternalServerError, "Server Error", "Query failed")
 	}
@@ -1365,12 +1366,13 @@ func (h *SearchHandler) V4MessageGet(c echo.Context) error {
 // when event_type is "all") until one produces a row. uuid is assigned once
 // per message at ingest, so at most one table is expected to match; trying
 // the rest costs one cheap indexed-column lookup each.
-func (h *SearchHandler) queryMessageByUUIDAcrossTables(ctx context.Context, protoType int, eventType, where string) ([]map[string]interface{}, error) {
+// fromMs/toMs (epoch ms) enable smart-routing pruning when both are set.
+func (h *SearchHandler) queryMessageByUUIDAcrossTables(ctx context.Context, protoType int, eventType, where string, fromMs, toMs int64) ([]map[string]interface{}, error) {
 	tables := resolveSearchTables(h.flightService.LakeName(), protoType, eventType)
 	var firstErr error
 	for _, table := range tables {
 		sql := fmt.Sprintf("SELECT * FROM %s WHERE %s LIMIT 1", table, where)
-		rows, err := h.flightService.Query(ctx, sql)
+		rows, err := h.flightService.QueryWithRange(ctx, sql, msToNs(fromMs), msToNs(toMs))
 		if err != nil {
 			if firstErr == nil {
 				firstErr = err
@@ -1409,7 +1411,7 @@ func (h *SearchHandler) V4MessageDecoded(c echo.Context) error {
 		where += fmt.Sprintf(" AND timestamp >= (to_timestamp(%d / 1000.0) AT TIME ZONE 'UTC') AND timestamp <= (to_timestamp(%d / 1000.0) AT TIME ZONE 'UTC')",
 			req.Timestamp.From, req.Timestamp.To)
 	}
-	results, err := h.queryMessageByUUIDAcrossTables(c.Request().Context(), protoType, eventType, where)
+	results, err := h.queryMessageByUUIDAcrossTables(c.Request().Context(), protoType, eventType, where, req.Timestamp.From, req.Timestamp.To)
 	if err != nil {
 		return writeError(c, http.StatusInternalServerError, "Server Error", "Query failed")
 	}
@@ -1446,7 +1448,8 @@ func (h *SearchHandler) V4TransactionQos(c echo.Context) error {
 		"SELECT * FROM %s WHERE %s%s ORDER BY timestamp ASC",
 		rtcpTable, sidCondition, tsCondition,
 	)
-	rtcpResults, rtcpErr := h.flightService.Query(c.Request().Context(), rtcpSQL)
+	fromNs, toNs := msToNs(req.Timestamp.From), msToNs(req.Timestamp.To)
+	rtcpResults, rtcpErr := h.flightService.QueryWithRange(c.Request().Context(), rtcpSQL, fromNs, toNs)
 	if rtcpErr != nil {
 		rtcpResults = []map[string]interface{}{}
 	}
@@ -1457,7 +1460,7 @@ func (h *SearchHandler) V4TransactionQos(c echo.Context) error {
 		"SELECT * FROM %s WHERE %s%s ORDER BY timestamp ASC",
 		rtpTable, sidCondition, tsCondition,
 	)
-	rtpResults, rtpErr := h.flightService.Query(c.Request().Context(), rtpSQL)
+	rtpResults, rtpErr := h.flightService.QueryWithRange(c.Request().Context(), rtpSQL, fromNs, toNs)
 	if rtpErr != nil {
 		rtpResults = []map[string]interface{}{}
 	}
@@ -1469,7 +1472,7 @@ func (h *SearchHandler) V4TransactionQos(c echo.Context) error {
 		"SELECT * FROM %s WHERE %s%s ORDER BY timestamp ASC",
 		vqrtcpTable, callidCondition, tsCondition,
 	)
-	vqrtcpResults, vqrtcpErr := h.flightService.Query(c.Request().Context(), vqrtcpSQL)
+	vqrtcpResults, vqrtcpErr := h.flightService.QueryWithRange(c.Request().Context(), vqrtcpSQL, fromNs, toNs)
 	if vqrtcpErr != nil {
 		vqrtcpResults = []map[string]interface{}{}
 	}
@@ -1526,6 +1529,7 @@ func (h *SearchHandler) V4TransactionCallInfo(c echo.Context) error {
 	}
 
 	var results []map[string]interface{}
+	fromNs, toNs := msToNs(req.Timestamp.From), msToNs(req.Timestamp.To)
 	if protoType == 1 && sipEvent == "call" {
 		detailSQL := fmt.Sprintf(
 			`SELECT session_id, timestamp, method, response_code, cseq_method, caller, callee,
@@ -1534,7 +1538,7 @@ func (h *SearchHandler) V4TransactionCallInfo(c echo.Context) error {
 			FROM %s WHERE %s%s ORDER BY timestamp ASC LIMIT %d`,
 			table, sessionWhere, tsFilter, callInfoMaxRows,
 		)
-		rows, err := h.flightService.Query(c.Request().Context(), detailSQL)
+		rows, err := h.flightService.QueryWithRange(c.Request().Context(), detailSQL, fromNs, toNs)
 		if err != nil {
 			return writeError(c, http.StatusInternalServerError, "Server Error", "Query failed")
 		}
@@ -1560,7 +1564,7 @@ func (h *SearchHandler) V4TransactionCallInfo(c echo.Context) error {
 	FROM %s WHERE %s%s GROUP BY session_id`,
 			table, sessionWhere, tsFilter)
 		var err error
-		results, err = h.flightService.Query(c.Request().Context(), sql)
+		results, err = h.flightService.QueryWithRange(c.Request().Context(), sql, fromNs, toNs)
 		if err != nil {
 			return writeError(c, http.StatusInternalServerError, "Server Error", "Query failed")
 		}
@@ -1593,7 +1597,7 @@ func (h *SearchHandler) V4TransactionEvents(c echo.Context) error {
 		)
 	}
 	sql := fmt.Sprintf("SELECT * FROM %s WHERE %s ORDER BY timestamp ASC LIMIT 5000", table, where)
-	results, err := h.flightService.Query(c.Request().Context(), sql)
+	results, err := h.flightService.QueryWithRange(c.Request().Context(), sql, msToNs(req.Timestamp.From), msToNs(req.Timestamp.To))
 	if err != nil {
 		return writeError(c, http.StatusInternalServerError, "Server Error", "Query failed")
 	}
@@ -1629,7 +1633,7 @@ func (h *SearchHandler) V4TransactionSub(c echo.Context) error {
 		"SELECT timestamp, src_ip, src_port, dst_ip, dst_port, method, response_code, caller, callee, node_id FROM %s WHERE %s ORDER BY timestamp ASC LIMIT 5000",
 		table, where,
 	)
-	results, err := h.flightService.Query(c.Request().Context(), sql)
+	results, err := h.flightService.QueryWithRange(c.Request().Context(), sql, msToNs(req.Timestamp.From), msToNs(req.Timestamp.To))
 	if err != nil {
 		return writeError(c, http.StatusInternalServerError, "Server Error", "Query failed")
 	}
@@ -1682,7 +1686,7 @@ func (h *SearchHandler) V4TransactionOtlpLogs(c echo.Context) error {
 
 	lake := h.flightService.LakeName()
 	sql := fmt.Sprintf("SELECT * FROM %s.otlp_logs WHERE %s ORDER BY timestamp ASC LIMIT %d", lake, where, maxOTLPLogsPerQuery)
-	results, err := h.flightService.Query(c.Request().Context(), sql)
+	results, err := h.flightService.QueryWithRange(c.Request().Context(), sql, msToNs(req.Timestamp.From), msToNs(req.Timestamp.To))
 	if err != nil {
 		return writeError(c, http.StatusInternalServerError, "Server Error", "Query failed")
 	}
@@ -1722,7 +1726,7 @@ func (h *SearchHandler) V4TransactionOtlpLogsTrace(c echo.Context) error {
 	where := strings.Join(whereParts, " AND ")
 	lake := h.flightService.LakeName()
 	sql := fmt.Sprintf("SELECT * FROM %s.otlp_logs WHERE %s ORDER BY timestamp ASC LIMIT %d", lake, where, maxOTLPLogsPerQuery)
-	results, err := h.flightService.Query(c.Request().Context(), sql)
+	results, err := h.flightService.QueryWithRange(c.Request().Context(), sql, msToNs(req.Timestamp.From), msToNs(req.Timestamp.To))
 	if err != nil {
 		return writeError(c, http.StatusInternalServerError, "Server Error", "Query failed")
 	}
@@ -1747,7 +1751,7 @@ func (h *SearchHandler) V4TransactionOtlpMetricNames(c echo.Context) error {
 	}
 	lake := h.flightService.LakeName()
 	sql := buildOTLPMetricNamesSQL(lake, req.Timestamp.From, req.Timestamp.To, req.ServiceName)
-	results, err := h.flightService.Query(c.Request().Context(), sql)
+	results, err := h.flightService.QueryWithRange(c.Request().Context(), sql, msToNs(req.Timestamp.From), msToNs(req.Timestamp.To))
 	if err != nil {
 		logger.Error(fmt.Sprintf("V4TransactionOtlpMetricNames: query error: %v", err))
 		return writeError(c, http.StatusInternalServerError, "Server Error", "Query failed")
@@ -1884,7 +1888,7 @@ func (h *SearchHandler) hasTransactionMessages(ctx context.Context, req *Transac
 	}
 	prefix := strings.Replace(sqlStr[:idx], "SELECT *", "SELECT 1", 1)
 	probeSQL := prefix + " LIMIT 1"
-	rows, err := h.flightService.Query(ctx, probeSQL)
+	rows, err := h.flightService.QueryWithRange(ctx, probeSQL, msToNs(req.Timestamp.From), msToNs(req.Timestamp.To))
 	if err != nil {
 		return false, err
 	}
@@ -1897,7 +1901,7 @@ func (h *SearchHandler) fetchTransactionRowsWithRequest(c echo.Context, req *Tra
 	if err != nil {
 		return nil, "", writeError(c, http.StatusBadRequest, "Bad Request", err.Error())
 	}
-	rows, err := h.flightService.Query(c.Request().Context(), sqlStr)
+	rows, err := h.flightService.QueryWithRange(c.Request().Context(), sqlStr, msToNs(req.Timestamp.From), msToNs(req.Timestamp.To))
 	if err != nil {
 		return nil, "", writeError(c, http.StatusInternalServerError, "Server Error", "Query failed")
 	}

--- a/src/coordinator/services/flight_service.go
+++ b/src/coordinator/services/flight_service.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"strings"
 	"sync"
@@ -22,6 +23,17 @@ import (
 	"github.com/sipcapture/homer-core/src/config"
 	logger "github.com/sipcapture/homer-core/src/utils/logging"
 )
+
+const (
+	nodeHealthInterval = 15 * time.Second
+	// Default DuckLake flush_interval_sec; used as an upper bound when treating
+	// cached max as possibly lagging buffered-but-unflushed rows.
+	smartRoutingFlushLag = 30 * time.Second
+)
+
+// smartRoutingMaxSlackNs widens cached max so flush lag + one stale health poll
+// cannot cause a false too-old skip on short query windows.
+var smartRoutingMaxSlackNs = int64(nodeHealthInterval + smartRoutingFlushLag)
 
 // FlightService manages connections to nodes via HTTP API
 type FlightService struct {
@@ -127,7 +139,7 @@ func (s *FlightService) ConnectAll() error {
 // healthCheckLoop periodically re-checks disconnected nodes and verifies
 // connected ones are still alive.
 func (s *FlightService) healthCheckLoop() {
-	ticker := time.NewTicker(15 * time.Second)
+	ticker := time.NewTicker(nodeHealthInterval)
 	defer ticker.Stop()
 
 	for {
@@ -291,8 +303,10 @@ func (s *FlightService) QueryFirstConnected(ctx context.Context, sql string) ([]
 
 // nodesForRange filters connected nodes to those whose cached timestamp range
 // may overlap the query window [fromNs, toNs]. A node is skipped only when its
-// cached range provably does not overlap the window in either direction:
-//   - too old: cached max is non-zero and strictly before fromNs.
+// cached range (with flush/health slack on max) provably does not overlap the
+// window in either direction:
+//   - too old: effectiveMax (cached max + smartRoutingMaxSlackNs) is non-zero
+//     basis and strictly before fromNs.
 //   - too new: cached min is non-zero and strictly after toNs.
 //
 // Unknown/uncached nodes, nodes with min/max == 0, and all nodes when smart
@@ -302,7 +316,8 @@ func (s *FlightService) QueryFirstConnected(ctx context.Context, sql string) ([]
 // This is staleness-safe: a node's data max only grows over time and its min
 // only rises as old data ages out, so a stale cache can only under-skip (keep a
 // node that could now be pruned) — it can never wrongly drop a node that holds
-// matching data.
+// matching data. The max slack covers buffered-but-unflushed rows and one stale
+// health poll on short UI windows.
 //
 // Callers must hold at least s.mu.RLock() because it reads s.rangeCache.
 func (s *FlightService) nodesForRange(connectedNodes []config.NodeEndpoint, fromNs, toNs int64) []config.NodeEndpoint {
@@ -312,22 +327,23 @@ func (s *FlightService) nodesForRange(connectedNodes []config.NodeEndpoint, from
 	kept := make([]config.NodeEndpoint, 0, len(connectedNodes))
 	for _, n := range connectedNodes {
 		rng, ok := s.rangeCache[n.Name]
-		// Too-old safety relies on the query window exceeding the node's
-		// persist/flush lag: buffered-but-unpersisted rows are excluded from
-		// min/max, so a "last N seconds" window with N < flush interval could
-		// skip a hot node holding only buffered rows. Typical UI windows
-		// (5/15/30 min) comfortably exceed the flush interval and are safe.
-		if ok && rng.max > 0 && rng.max < fromNs {
-			logger.Info("Hub: skipping node (data too old)", "node", n.Name, "node_max", rng.max, "query_from", fromNs)
-			continue
+		if ok && rng.max > 0 {
+			effectiveMax := rng.max
+			if smartRoutingMaxSlackNs > 0 && effectiveMax <= math.MaxInt64-smartRoutingMaxSlackNs {
+				effectiveMax += smartRoutingMaxSlackNs
+			}
+			if effectiveMax < fromNs {
+				logger.Info("Hub: skipping node (data too old)", "node", n.Name, "node_max", rng.max, "effective_max", effectiveMax, "query_from", fromNs)
+				continue
+			}
 		}
 		// Too-new direction assumes a node's min timestamp only rises (true for
 		// live capture + retention aging out old rows). Historical backfill
 		// (pcap import / replay ingesting rows OLDER than the cached min)
 		// violates this: for up to one health interval the stale-high cached min
-		// could skip a node that now holds matching old rows. The too-old
-		// direction has no such hazard. Operators doing historical import should
-		// keep smart_routing disabled or accept <=1 health-interval staleness.
+		// could skip a node that now holds matching old rows. Operators doing
+		// historical import should keep smart_routing disabled or accept ≤1
+		// health-interval staleness.
 		if ok && rng.min > 0 && rng.min > toNs {
 			logger.Info("Hub: skipping node (data too new)", "node", n.Name, "node_min", rng.min, "query_to", toNs)
 			continue

--- a/src/coordinator/services/flight_service_test.go
+++ b/src/coordinator/services/flight_service_test.go
@@ -101,23 +101,27 @@ func TestFetchNodeRangeParsesStats(t *testing.T) {
 
 func TestNodesForRangeSkipsNonOverlapping(t *testing.T) {
 	s := NewFlightService(nil, time.Second, true)
+	const fromNs int64 = 1_700_000_000_000_000_000
+	const toNs int64 = 1_700_000_900_000_000_000
+	slack := smartRoutingMaxSlackNs
 	s.rangeCache = map[string]tsRange{
-		"hot":    {min: 0, max: 1_000},     // overlaps window -> keep
-		"cold":   {min: 0, max: 100},       // max < from -> skip (too old)
-		"future": {min: 5_000, max: 6_000}, // min > to -> skip (too new)
-		"empty":  {min: 0, max: 0},         // unknown -> keep
+		"hot":    {min: fromNs - int64(time.Hour), max: fromNs + int64(time.Minute)}, // overlaps
+		"cold":   {min: 0, max: fromNs - slack - 1},                                  // too old even with slack
+		"near":   {min: 0, max: fromNs - slack/2},                                    // within slack -> keep
+		"future": {min: toNs + 1, max: toNs + int64(time.Hour)},                      // too new
+		"empty":  {min: 0, max: 0},                                                   // unknown -> keep
 	}
-	nodes := []config.NodeEndpoint{{Name: "hot"}, {Name: "cold"}, {Name: "future"}, {Name: "empty"}, {Name: "uncached"}}
-	got := s.nodesForRange(nodes, 500, 2_000) // query window [500, 2000]ns
+	nodes := []config.NodeEndpoint{{Name: "hot"}, {Name: "cold"}, {Name: "near"}, {Name: "future"}, {Name: "empty"}, {Name: "uncached"}}
+	got := s.nodesForRange(nodes, fromNs, toNs)
 	names := map[string]bool{}
 	for _, n := range got {
 		names[n.Name] = true
 	}
-	if !names["hot"] || !names["empty"] || !names["uncached"] {
-		t.Fatalf("hot/empty/uncached must be kept, got %v", names)
+	if !names["hot"] || !names["near"] || !names["empty"] || !names["uncached"] {
+		t.Fatalf("hot/near/empty/uncached must be kept, got %v", names)
 	}
 	if names["cold"] {
-		t.Fatalf("cold (max<from) must be skipped, got %v", names)
+		t.Fatalf("cold (effectiveMax<from) must be skipped, got %v", names)
 	}
 	if names["future"] {
 		t.Fatalf("future (min>to) must be skipped, got %v", names)
@@ -126,9 +130,13 @@ func TestNodesForRangeSkipsNonOverlapping(t *testing.T) {
 
 func TestNodesForRangeNeverEmpties(t *testing.T) {
 	s := NewFlightService(nil, time.Second, true)
-	s.rangeCache = map[string]tsRange{"a": {max: 100}, "b": {max: 200}}
+	from := int64(1_700_000_000_000_000_000)
+	s.rangeCache = map[string]tsRange{
+		"a": {max: from - smartRoutingMaxSlackNs - 10},
+		"b": {max: from - smartRoutingMaxSlackNs - 20},
+	}
 	nodes := []config.NodeEndpoint{{Name: "a"}, {Name: "b"}}
-	got := s.nodesForRange(nodes, 1_000, 2_000) // both too old
+	got := s.nodesForRange(nodes, from, from+int64(time.Hour))
 	if len(got) != 2 {
 		t.Fatalf("filter must not empty the set; want 2 got %d", len(got))
 	}
@@ -140,5 +148,16 @@ func TestNodesForRangeDisabledKeepsAll(t *testing.T) {
 	nodes := []config.NodeEndpoint{{Name: "a"}}
 	if len(s.nodesForRange(nodes, 1_000, 2_000)) != 1 {
 		t.Fatalf("disabled must keep all")
+	}
+}
+
+func TestNodesForRangeFlushSlackKeepsNearMax(t *testing.T) {
+	s := NewFlightService(nil, time.Second, true)
+	from := int64(1_700_000_000_000_000_000)
+	// max is before from, but within slack — must keep.
+	s.rangeCache = map[string]tsRange{"hot": {max: from - smartRoutingMaxSlackNs + 1}}
+	got := s.nodesForRange([]config.NodeEndpoint{{Name: "hot"}}, from, from+int64(time.Minute))
+	if len(got) != 1 {
+		t.Fatalf("node within flush/health slack must be kept")
 	}
 }

--- a/src/node/metadata.go
+++ b/src/node/metadata.go
@@ -14,6 +14,11 @@ import (
 	"strings"
 )
 
+// quoteIdent wraps a DuckDB identifier in double quotes, escaping embedded quotes.
+func quoteIdent(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}
+
 // nodeTimeRange returns the min/max timestamp (nanoseconds since epoch) across
 // all hep_proto_* tables visible to this node's DuckDB connection, spanning any
 // attached DuckLake volumes. Returns 0,0 when the node holds no data.
@@ -33,7 +38,7 @@ func nodeTimeRange(db *sql.DB) (minNs, maxNs int64, err error) {
 		if err := rows.Scan(&dbName, &schema, &table); err != nil {
 			return 0, 0, err
 		}
-		fqn := fmt.Sprintf(`"%s"."%s"."%s"`, dbName, schema, table)
+		fqn := quoteIdent(dbName) + "." + quoteIdent(schema) + "." + quoteIdent(table)
 		// Apply epoch_ns to the result of min/max (not min/max of epoch_ns):
 		// epoch_ns is monotonic so the values are identical, but min(timestamp)/
 		// max(timestamp) operate on the bare column, letting DuckDB answer from

--- a/src/node/metadata_test.go
+++ b/src/node/metadata_test.go
@@ -7,6 +7,15 @@ import (
 	_ "github.com/duckdb/duckdb-go/v2"
 )
 
+func TestQuoteIdent(t *testing.T) {
+	if got := quoteIdent(`abc`); got != `"abc"` {
+		t.Fatalf("got %q", got)
+	}
+	if got := quoteIdent(`a"b`); got != `"a""b"` {
+		t.Fatalf("got %q", got)
+	}
+}
+
 func TestNodeTimeRange(t *testing.T) {
 	db, err := sql.Open("duckdb", "")
 	if err != nil {

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.314"
+	VERSION_APPLICATION = "11.0.315"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Widen `QueryWithRange` beyond search/hydrate to transaction UI paths that carry a time window (messages, QoS, callinfo, events, sub, OTLP tabs, export, simple/v1 search).
- Add flush/health slack (`~45s`) on cached `max` so short windows and buffered-but-unflushed rows do not false-skip hot nodes.
- Safely quote DuckDB identifiers in `nodeTimeRange` (`"` → `""`).
- Docs update + bump to **11.0.315**.

Admin/raw SQL, schema discovery, dashboard unbounded counts, and UUID-only lookups still use unscoped `Query()`.

## Test plan
- [x] `go test ./node/ ./coordinator/services/ ./coordinator/handlers/`
- [x] `go vet ./node/ ./coordinator/...`
- [ ] Enable `coordinator.smart_routing.enable` on a hot/warm/cold cluster; open a call from recent Results and confirm cold node is not queried for QoS/callinfo/export
- [ ] Narrow window (~1–2 min) still returns rows from a live hot node (slack regression check)
- [ ] With `smart_routing.enable=false`, fan-out unchanged