### PR TITLE
fix(flightsql): encode timestamps in Arrow field units (11.0.316)

### DIFF
--- a/src/node/catalog.go
+++ b/src/node/catalog.go
@@ -541,6 +541,13 @@ func duckDBTypeToArrow(duckType string) arrow.DataType {
 		return arrow.PrimitiveTypes.Float32
 	case strings.HasPrefix(duckType, "BOOLEAN"), strings.HasPrefix(duckType, "BOOL"):
 		return arrow.FixedWidthTypes.Boolean
+	// More specific TIMESTAMP_* prefixes must be checked before TIMESTAMP.
+	case strings.HasPrefix(duckType, "TIMESTAMP_NS"):
+		return arrow.FixedWidthTypes.Timestamp_ns
+	case strings.HasPrefix(duckType, "TIMESTAMP_MS"):
+		return arrow.FixedWidthTypes.Timestamp_ms
+	case strings.HasPrefix(duckType, "TIMESTAMP_S"):
+		return arrow.FixedWidthTypes.Timestamp_s
 	case strings.HasPrefix(duckType, "TIMESTAMP"):
 		return arrow.FixedWidthTypes.Timestamp_us
 	case strings.HasPrefix(duckType, "DATE"):

--- a/src/node/fsql_arrow.go
+++ b/src/node/fsql_arrow.go
@@ -152,11 +152,11 @@ func appendFsqlValue(b array.Builder, dt arrow.DataType, val interface{}) {
 	case *array.TimestampBuilder:
 		switch v := val.(type) {
 		case time.Time:
-			bldr.Append(arrow.Timestamp(v.UnixNano()))
+			appendFsqlTimestamp(bldr, dt, v)
 		case string:
 			for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02 15:04:05", "2006-01-02T15:04:05"} {
 				if t, err := time.Parse(layout, v); err == nil {
-					bldr.Append(arrow.Timestamp(t.UnixNano()))
+					appendFsqlTimestamp(bldr, dt, t)
 					return
 				}
 			}
@@ -191,6 +191,25 @@ func appendFsqlValue(b array.Builder, dt arrow.DataType, val interface{}) {
 	default:
 		b.AppendNull()
 	}
+}
+
+// appendFsqlTimestamp writes t in the Arrow timestamp unit of the builder.
+// DuckDB TIMESTAMP is microseconds; Grafana FlightSQL (Influx) converts
+// timestamp[us] → ns with value*1000. Writing UnixNano() into timestamp[us]
+// overflows int64 and displays as ~1882 instead of the real capture time.
+func appendFsqlTimestamp(bldr *array.TimestampBuilder, dt arrow.DataType, t time.Time) {
+	unit := arrow.Microsecond
+	if tsType, ok := dt.(*arrow.TimestampType); ok {
+		unit = tsType.Unit
+	} else if tsType, ok := bldr.Type().(*arrow.TimestampType); ok {
+		unit = tsType.Unit
+	}
+	ts, err := arrow.TimestampFromTime(t.UTC(), unit)
+	if err != nil {
+		bldr.AppendNull()
+		return
+	}
+	bldr.Append(ts)
 }
 
 func toFsqlInt8(v interface{}) int8 {

--- a/src/node/fsql_arrow_test.go
+++ b/src/node/fsql_arrow_test.go
@@ -1,0 +1,92 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package node
+
+import (
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+func TestAppendFsqlTimestampUsesArrowUnit(t *testing.T) {
+	// 2026-08-12 20:34:30 UTC — the capture times that Grafana showed as 1882.
+	ts := time.Unix(1786566870, 123000).UTC()
+	dt := arrow.FixedWidthTypes.Timestamp_us
+	mem := memory.NewGoAllocator()
+	bldr := array.NewTimestampBuilder(mem, dt.(*arrow.TimestampType))
+	defer bldr.Release()
+
+	appendFsqlValue(bldr, dt, ts)
+	arr := bldr.NewArray().(*array.Timestamp)
+	defer arr.Release()
+	if arr.Len() != 1 || arr.IsNull(0) {
+		t.Fatal("expected one non-null timestamp")
+	}
+
+	got := arr.Value(0)
+	want := arrow.Timestamp(ts.UnixMicro())
+	if got != want {
+		t.Fatalf("timestamp[us] value: got %d want %d (unixnano=%d)", got, want, ts.UnixNano())
+	}
+
+	// Influx/Grafana FlightSQL converts timestamp[us] → ns with *1000.
+	// UnixNano written into timestamp[us] overflows here and becomes ~1882.
+	asNs := int64(got) * 1000
+	restored := time.Unix(0, asNs).UTC()
+	if restored.Year() != 2026 {
+		t.Fatalf("us*1000 as ns: got %s (year %d)", restored.Format(time.RFC3339Nano), restored.Year())
+	}
+}
+
+func TestUnixNanoInTimestampUsOverflowsTo1882(t *testing.T) {
+	ts := time.Unix(1786566870, 0).UTC()
+	overflowed := ts.UnixNano() * 1000 // the old FlightSQL write, then Influx us→ns
+	got := time.Unix(0, overflowed).UTC()
+	if got.Year() != 1882 {
+		t.Fatalf("expected the known 1882 overflow, got %s", got.Format(time.RFC3339Nano))
+	}
+}
+
+func TestAppendFsqlTimestampParsesDuckDBString(t *testing.T) {
+	dt := arrow.FixedWidthTypes.Timestamp_us
+	mem := memory.NewGoAllocator()
+	bldr := array.NewTimestampBuilder(mem, dt.(*arrow.TimestampType))
+	defer bldr.Release()
+
+	appendFsqlValue(bldr, dt, "2026-08-12 20:34:30")
+	arr := bldr.NewArray().(*array.Timestamp)
+	defer arr.Release()
+	got := arr.Value(0).ToTime(arrow.Microsecond)
+	if got.Year() != 2026 || got.Month() != time.August || got.Day() != 12 {
+		t.Fatalf("parsed timestamp: %s", got.Format(time.RFC3339Nano))
+	}
+}
+
+func TestDuckDBTypeToArrowTimestamps(t *testing.T) {
+	cases := []struct {
+		duck string
+		unit arrow.TimeUnit
+	}{
+		{"TIMESTAMP", arrow.Microsecond},
+		{"TIMESTAMP WITH TIME ZONE", arrow.Microsecond},
+		{"TIMESTAMP_TZ", arrow.Microsecond},
+		{"TIMESTAMP_NS", arrow.Nanosecond},
+		{"TIMESTAMP_MS", arrow.Millisecond},
+		{"TIMESTAMP_S", arrow.Second},
+	}
+	for _, tc := range cases {
+		got := duckDBTypeToArrow(tc.duck)
+		ts, ok := got.(*arrow.TimestampType)
+		if !ok {
+			t.Fatalf("%s: got %v, want timestamp", tc.duck, got)
+		}
+		if ts.Unit != tc.unit {
+			t.Fatalf("%s: unit got %s want %s", tc.duck, ts.Unit, tc.unit)
+		}
+	}
+}

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.315"
+	VERSION_APPLICATION = "11.0.316"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- FlightSQL wrote `UnixNano()` into Arrow `timestamp[us]`. Grafana/Influx converts us→ns with `value*1000`, which overflows int64 and displays capture times as **1882**.
- Encode values in the Arrow field unit (microseconds for DuckDB `TIMESTAMP`) so Grafana can use `timestamp` / `time_bucket(..., timestamp)` directly.
- Map DuckDB `TIMESTAMP_NS` / `_MS` / `_S` to the matching Arrow units.
- Bump version to **11.0.316**.

Stored DuckLake data is already correct; no migration.

## Test plan
- [x] `go test ./node/ -run 'TestAppendFsqlTimestamp|TestUnixNanoInTimestampUsOverflowsTo1882|TestDuckDBTypeToArrowTimestamps'`
- [x] `go vet ./node/`
- [x] Grafana FlightSQL table on `hep_proto_1_default` / `hep_proto_1_call`: `timestamp` shows 2026, not 1882
- [x] Graph panel: `SELECT time_bucket(INTERVAL '1 second', timestamp) AS time, count(*) ...` without `to_timestamp(epoch(timestamp))`