### PR TITLE
fix(dashboards): seed default IDs per user (11.0.317)

### DIFF
--- a/src/coordinator/services/dashboard_service.go
+++ b/src/coordinator/services/dashboard_service.go
@@ -97,7 +97,8 @@ func (s *DashboardService) CreateDashboard(ctx context.Context, username, dashbo
 
 	sqlCheck := fmt.Sprintf(
 		`SELECT username FROM dashboard_settings
-		 WHERE dashboard_id = '%s' LIMIT 1`,
+		 WHERE username = '%s' AND dashboard_id = '%s' LIMIT 1`,
+		escapeSQL(username),
 		escapeSQL(dashboardID),
 	)
 	row := s.db.QueryRowContext(ctx, sqlCheck)
@@ -105,8 +106,8 @@ func (s *DashboardService) CreateDashboard(ctx context.Context, username, dashbo
 	if err := row.Scan(&owner); err != nil && err != sql.ErrNoRows {
 		return "", err
 	}
-	if owner.Valid && !strings.EqualFold(owner.String, username) {
-		return "", fmt.Errorf("dashboard is owned by another user")
+	if owner.Valid {
+		return "", fmt.Errorf("dashboard already exists")
 	}
 
 	guid := newGUID()

--- a/src/coordinator/services/dashboard_service_test.go
+++ b/src/coordinator/services/dashboard_service_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/sipcapture/homer-core/src/config"
@@ -169,6 +170,88 @@ func TestResetDashboards_IsIdempotent(t *testing.T) {
 
 	if len(first) != len(second) {
 		t.Fatalf("dashboard count drifted: first=%d second=%d", len(first), len(second))
+	}
+}
+
+// TestResetDashboards_SeedsIndependentDefaultsPerUser is issue #936: default
+// IDs (home, smartsearch, …) are per-user, not globally unique. Seeding for
+// alice must not block bob's auto-seed or reset.
+func TestResetDashboards_SeedsIndependentDefaultsPerUser(t *testing.T) {
+	dir := t.TempDir()
+	db, err := OpenSettingsDB(filepath.Join(dir, "settings.duckdb"))
+	if err != nil {
+		t.Fatalf("OpenSettingsDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := EnsureSettingsSchema(db); err != nil {
+		t.Fatalf("EnsureSettingsSchema: %v", err)
+	}
+
+	svc := NewDashboardService(db, config.DefaultWidgetControl())
+	ctx := context.Background()
+
+	if err := svc.ResetDashboards(ctx, "alice"); err != nil {
+		t.Fatalf("ResetDashboards alice: %v", err)
+	}
+	if err := svc.ResetDashboards(ctx, "bob"); err != nil {
+		t.Fatalf("ResetDashboards bob: %v", err)
+	}
+
+	for _, user := range []string{"alice", "bob"} {
+		settings, err := svc.ListDashboards(ctx, user)
+		if err != nil {
+			t.Fatalf("ListDashboards %s: %v", user, err)
+		}
+		byParam := make(map[string]string, len(settings))
+		for _, s := range settings {
+			byParam[s.Param] = s.UserName
+		}
+		for _, id := range []string{"home", "smartsearch", "games", "netgames"} {
+			owner, ok := byParam[id]
+			if !ok {
+				t.Fatalf("%s missing default dashboard %q; got %v", user, id, keys(byParam))
+			}
+			if !strings.EqualFold(owner, user) {
+				t.Errorf("%s listed %q owned by %q", user, id, owner)
+			}
+		}
+
+		got, err := svc.GetDashboard(ctx, user, "home")
+		if err != nil {
+			t.Fatalf("GetDashboard %s/home: %v", user, err)
+		}
+		if got == nil {
+			t.Fatalf("GetDashboard %s/home: nil", user)
+		}
+		if !strings.EqualFold(got.UserName, user) {
+			t.Errorf("GetDashboard %s/home owner=%q", user, got.UserName)
+		}
+	}
+}
+
+func TestCreateDashboard_AllowsSameIDForDifferentUsers(t *testing.T) {
+	dir := t.TempDir()
+	db, err := OpenSettingsDB(filepath.Join(dir, "settings.duckdb"))
+	if err != nil {
+		t.Fatalf("OpenSettingsDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := EnsureSettingsSchema(db); err != nil {
+		t.Fatalf("EnsureSettingsSchema: %v", err)
+	}
+
+	svc := NewDashboardService(db, config.DefaultWidgetControl())
+	ctx := context.Background()
+	payload := json.RawMessage(`{"name":"Custom","param":"custom","shared":false}`)
+
+	if _, err := svc.CreateDashboard(ctx, "alice", "custom", payload); err != nil {
+		t.Fatalf("CreateDashboard alice: %v", err)
+	}
+	if _, err := svc.CreateDashboard(ctx, "bob", "custom", payload); err != nil {
+		t.Fatalf("CreateDashboard bob: %v", err)
+	}
+	if _, err := svc.CreateDashboard(ctx, "alice", "custom", payload); err == nil {
+		t.Fatal("expected error creating duplicate dashboard for same user")
 	}
 }
 

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.316"
+	VERSION_APPLICATION = "11.0.317"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
Fixes [#936](https://github.com/sipcapture/homer/issues/936): default dashboard IDs (`home`, `smartsearch`, `games`, `netgames`) were treated as globally unique. The first user to seed (or reset) claimed those IDs, and every later user got 500 `"dashboard is owned by another user"` on `GET /api/v4/dashboards` and `POST /api/v4/dashboards/reset`.

`CreateDashboard` now uniqueness-checks `(username, dashboard_id)`. Each user can have their own `home` / `smartsearch` / etc. Same-user duplicate create returns `"dashboard already exists"`.

Version **11.0.317**.

## Test plan
- [ ] `go test ./coordinator/services/ -run 'Dashboard|ResetDashboards|CreateDashboard'`
- [ ] Two real users: first login / OAuth user still gets defaults after an admin already seeded
- [ ] `POST /api/v4/dashboards/reset` as the second user succeeds