### PR TITLE
fix(ui): default theme to system preference

### DIFF
--- a/src/ui/src/App.test.tsx
+++ b/src/ui/src/App.test.tsx
@@ -69,4 +69,27 @@ describe('App smoke/integration', () => {
       expect(screen.getByText('No dashboards available. Create one above or reset to defaults.')).toBeInTheDocument()
     })
   })
+
+  it('defaults to system theme and follows prefers-color-scheme when storage is empty', async () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn((query: string) => ({
+        matches: String(query).includes('prefers-color-scheme: dark') ? false : false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    )
+
+    renderApp()
+    await waitFor(() => {
+      expect(screen.getByLabelText('Login')).toBeInTheDocument()
+    })
+    expect(document.documentElement.classList.contains('light')).toBe(true)
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
 })

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -584,7 +584,7 @@ function App() {
   }
 
   return (
-    <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
+    <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
       <LocaleProvider defaultLocale="auto" storageKey="vite-ui-locale">
       <div className="app">
         <main className="content">

--- a/src/ui/src/components/theme/theme-provider.test.tsx
+++ b/src/ui/src/components/theme/theme-provider.test.tsx
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ThemeProvider, useTheme } from './theme-provider'
+
+function ThemeProbe() {
+  const { theme } = useTheme()
+  return <span data-testid="theme">{theme}</span>
+}
+
+function stubPrefersColorScheme(dark: boolean) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((query: string) => ({
+      matches: String(query).includes('prefers-color-scheme: dark') ? dark : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  )
+}
+
+describe('ThemeProvider', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.classList.remove('light', 'dark')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    document.documentElement.classList.remove('light', 'dark')
+  })
+
+  it('defaults to system and applies light when OS prefers light', () => {
+    stubPrefersColorScheme(false)
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    )
+    expect(screen.getByTestId('theme')).toHaveTextContent('system')
+    expect(document.documentElement.classList.contains('light')).toBe(true)
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+
+  it('defaults to system and applies dark when OS prefers dark', () => {
+    stubPrefersColorScheme(true)
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    )
+    expect(screen.getByTestId('theme')).toHaveTextContent('system')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+    expect(document.documentElement.classList.contains('light')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
Fixes [#935](https://github.com/sipcapture/homer/issues/935): `App.tsx` mounted `ThemeProvider` with `defaultTheme="dark"`, so a fresh install always started in dark mode. The provider already implements `"system"` via `prefers-color-scheme`.

New users now follow the OS/browser theme. Existing `vite-ui-theme` / legacy `theme` localStorage values are unchanged.

No version bump — [#937](https://github.com/sipcapture/homer/pull/937) already owns **11.0.317**. This can land in the same release or as 11.0.318.

## Test plan
- [ ] `cd src/ui && npx vitest run src/App.test.tsx src/components/theme/theme-provider.test.tsx`
- [ ] Clear `vite-ui-theme` in localStorage, reload with OS light → light UI
- [ ] Same with OS dark → dark UI
- [ ] Explicit toggle still persists light/dark