### PR TITLE
fix(storage): bound DuckDB compaction merge to prevent silent OOM (#945)

### DIFF
--- a/docs/OOM.md
+++ b/docs/OOM.md
@@ -283,13 +283,16 @@ Mitigations already in the writer (stay on the DuckDB engine — do **not**
 switch to `engine: "native"` to work around this; earlier native builds
 wrote snapshot ids out-of-band and corrupted live catalogs):
 
-- DuckDB merge is capped at 8 compaction groups per table (16 max even if
-  config says 100) and `max_file_size` defaults to 64MB.
-- Each merge runs on a dedicated connection with `threads=1` so date
-  partitions are not rewritten in parallel.
+- DuckDB merge defaults to 32 operations per table per cycle and
+  `max_file_size` 64MB. `max_compacted_files` counts output files, not
+  inputs; peak memory is the size of one group (`max_file_size`) because
+  merge runs on a dedicated connection with `threads=1`.
+- Explicit `max_compacted_files` is not clamped. Lower it if RSS still
+  climbs; raise it if file count grows between cycles.
 - Leftover files are picked up by the next cycle.
-- If it still OOMs, lower `max_compacted_files` further or temporarily set
-  `compaction.enable: false` (see section 4). Do not flip the engine.
+- If it still OOMs, lower `max_file_size_bytes` / `max_compacted_files` or
+  temporarily set `compaction.enable: false` (see section 4). Do not flip
+  the engine.
 
 The `native` engine avoids the DuckDB merge entirely. It does **not** use
 DuckDB for compaction. It remains **opt-in only** and is not the

--- a/docs/OOM.md
+++ b/docs/OOM.md
@@ -274,12 +274,26 @@ tables bypass it. Log: `V4TransactionsSearch: hydrating payload by uuid`.
 The default DuckDB merge (`ducklake_merge_adjacent_files`) loads a whole
 partition into memory to sort/rewrite it. On wide SIP data (large `payload`
 columns) this can exceed `memory_limit` and OOM even for a handful of ~77MB
-files, because the parquet write buffers are not spillable. Use the batching
-knobs (`max_compacted_files`, `max_file_size_bytes`, lower `memory_limit`
-headroom) from the sections above to keep it within budget.
+files, because the parquet write buffers are not spillable. Homer then often
+dies **silently** (Linux OOM killer / DuckDB abort) during
+`hep_proto_1_call` merge — no `Out of Memory` line, UI returns 5xx, ingest
+`adapter_us` spikes because the catalog lock is held for the whole CALL.
+
+Mitigations already in the writer (stay on the DuckDB engine — do **not**
+switch to `engine: "native"` to work around this; earlier native builds
+wrote snapshot ids out-of-band and corrupted live catalogs):
+
+- DuckDB merge is capped at 8 compaction groups per table (16 max even if
+  config says 100) and `max_file_size` defaults to 64MB.
+- Each merge runs on a dedicated connection with `threads=1` so date
+  partitions are not rewritten in parallel.
+- Leftover files are picked up by the next cycle.
+- If it still OOMs, lower `max_compacted_files` further or temporarily set
+  `compaction.enable: false` (see section 4). Do not flip the engine.
 
 The `native` engine avoids the DuckDB merge entirely. It does **not** use
-DuckDB for compaction. Instead it:
+DuckDB for compaction. It remains **opt-in only** and is not the
+recommended workaround for compaction OOM. Instead it:
 
 - groups a partition's parquet files into batches up to `target_file_size_bytes`
   (default 512MB), based on their on-disk sizes;
@@ -295,9 +309,11 @@ DuckDB for compaction. Instead it:
 
 ### Configuration
 
-The default is `duckdb`. The native engine is **opt-in** and safe to enable on a
-live writer (see the note above); it is the recommended choice when the DuckDB
-merge OOMs on wide SIP data:
+The default is `duckdb`. The native engine is **opt-in only**. Do not enable
+it as an OOM workaround on a live writer: earlier builds corrupted catalogs
+(`Corrupt DuckLake - multiple snapshots returned from database`). Prefer the
+DuckDB batching knobs above. If you still experiment with native, use a
+catalog backup first:
 
 ```json
 {

--- a/examples/homer-s3-parquet-only.json
+++ b/examples/homer-s3-parquet-only.json
@@ -78,7 +78,7 @@
         "min_age_sec": 3600,
         "min_file_size_bytes": 0,
         "max_file_size_bytes": 134217728,
-        "max_compacted_files": 100
+        "max_compacted_files": 8
       },
       "storage_policy": {
         "enable": false,

--- a/examples/homer-s3-parquet-only.json
+++ b/examples/homer-s3-parquet-only.json
@@ -78,7 +78,7 @@
         "min_age_sec": 3600,
         "min_file_size_bytes": 0,
         "max_file_size_bytes": 134217728,
-        "max_compacted_files": 8
+        "max_compacted_files": 32
       },
       "storage_policy": {
         "enable": false,

--- a/examples/homer-writer-rustfs.json
+++ b/examples/homer-writer-rustfs.json
@@ -73,7 +73,7 @@
         "min_age_sec": 3600,
         "min_file_size_bytes": 0,
         "max_file_size_bytes": 134217728,
-        "max_compacted_files": 100
+        "max_compacted_files": 8
       },
       "storage_policy": {
         "enable": true,

--- a/examples/homer-writer-rustfs.json
+++ b/examples/homer-writer-rustfs.json
@@ -73,7 +73,7 @@
         "min_age_sec": 3600,
         "min_file_size_bytes": 0,
         "max_file_size_bytes": 134217728,
-        "max_compacted_files": 8
+        "max_compacted_files": 32
       },
       "storage_policy": {
         "enable": true,

--- a/examples/homer-writer.json
+++ b/examples/homer-writer.json
@@ -77,7 +77,7 @@
         "min_age_sec": 3600,
         "min_file_size_bytes": 0,
         "max_file_size_bytes": 134217728,
-        "max_compacted_files": 100
+        "max_compacted_files": 8
       },
       "storage_policy": {
         "enable": false,

--- a/examples/homer-writer.json
+++ b/examples/homer-writer.json
@@ -77,7 +77,7 @@
         "min_age_sec": 3600,
         "min_file_size_bytes": 0,
         "max_file_size_bytes": 134217728,
-        "max_compacted_files": 8
+        "max_compacted_files": 32
       },
       "storage_policy": {
         "enable": false,

--- a/examples/homer.json
+++ b/examples/homer.json
@@ -78,7 +78,7 @@
         "min_age_sec": 3600,
         "min_file_size_bytes": 0,
         "max_file_size_bytes": 134217728,
-        "max_compacted_files": 8
+        "max_compacted_files": 32
       }
     }
   },

--- a/examples/homer.json
+++ b/examples/homer.json
@@ -78,7 +78,7 @@
         "min_age_sec": 3600,
         "min_file_size_bytes": 0,
         "max_file_size_bytes": 134217728,
-        "max_compacted_files": 100
+        "max_compacted_files": 8
       }
     }
   },

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -779,11 +779,9 @@ type CompactionConfig struct {
 	MinFileSizeBytes int64 `json:"min_file_size_bytes" mapstructure:"min_file_size_bytes" default:"0"`
 	// MaxFileSizeBytes: maximum size of merged file. 0 = no limit (DuckLake default).
 	MaxFileSizeBytes int64 `json:"max_file_size_bytes" mapstructure:"max_file_size_bytes" default:"0"`
-	// MaxCompactedFiles: maximum number of compaction groups per table per cycle.
-	// 0 = writer default (8). Bounding the merge batch keeps the compaction
-	// working set within memory_limit on memory-capped writers. Values above
-	// 16 are clamped on the DuckDB engine — 100 wide SIP files is enough to
-	// OOM hep_proto_1_call (sipcapture/homer#945).
+	// MaxCompactedFiles: maximum number of compaction operations (output files)
+	// per table per cycle. 0 = writer default (32). This is not an input-file
+	// cap; peak memory is bounded by max_file_size_bytes and merge threads=1.
 	MaxCompactedFiles int `json:"max_compacted_files" mapstructure:"max_compacted_files" default:"0"`
 	// Engine selects the compaction implementation:
 	//   "duckdb" — DuckLake's ducklake_merge_adjacent_files (default). Loads a

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -779,9 +779,11 @@ type CompactionConfig struct {
 	MinFileSizeBytes int64 `json:"min_file_size_bytes" mapstructure:"min_file_size_bytes" default:"0"`
 	// MaxFileSizeBytes: maximum size of merged file. 0 = no limit (DuckLake default).
 	MaxFileSizeBytes int64 `json:"max_file_size_bytes" mapstructure:"max_file_size_bytes" default:"0"`
-	// MaxCompactedFiles: maximum number of files to merge per table per cycle.
-	// 0 = writer default (100). Bounding the merge batch keeps the compaction
-	// working set within memory_limit on memory-capped writers.
+	// MaxCompactedFiles: maximum number of compaction groups per table per cycle.
+	// 0 = writer default (8). Bounding the merge batch keeps the compaction
+	// working set within memory_limit on memory-capped writers. Values above
+	// 16 are clamped on the DuckDB engine — 100 wide SIP files is enough to
+	// OOM hep_proto_1_call (sipcapture/homer#945).
 	MaxCompactedFiles int `json:"max_compacted_files" mapstructure:"max_compacted_files" default:"0"`
 	// Engine selects the compaction implementation:
 	//   "duckdb" — DuckLake's ducklake_merge_adjacent_files (default). Loads a

--- a/src/writer/compaction.go
+++ b/src/writer/compaction.go
@@ -122,9 +122,9 @@ type CompactionConfig struct {
 	MinFileSizeBytes int64 `json:"min_file_size_bytes"`
 	// MaxFileSizeBytes: maximum size of merged file. 0 = no limit (DuckLake default).
 	MaxFileSizeBytes int64 `json:"max_file_size_bytes"`
-	// MaxCompactedFiles: maximum number of compaction groups per table per cycle.
-	// 0 = writer default (8). DuckLake may apply this per date-partition on
-	// older extensions, so keep it small on sorted SIP tables.
+	// MaxCompactedFiles: maximum number of compaction operations (output files)
+	// per table per cycle. 0 = writer default (32). This is not an input-file
+	// cap; peak memory is bounded by MaxFileSizeBytes and merge threads=1.
 	MaxCompactedFiles int `json:"max_compacted_files"`
 	// Engine selects the compaction backend: "duckdb" (default) or "native".
 	Engine string `json:"engine"`
@@ -138,13 +138,18 @@ const (
 	EngineNativeGo = "native"
 )
 
-// Defaults for the DuckDB merge path. The previous writer default of 100
-// compaction groups was enough to OOM hep_proto_1_call (wide payload +
-// SORTED BY timestamp) and get the process SIGKILL'd with no error log
-// (sipcapture/homer#945). Leftovers are picked up by the next cycle.
+// Defaults for the DuckDB merge path (sipcapture/homer#945).
+//
+// max_compacted_files is the number of compaction *operations* (output
+// files) per CALL, not the number of input files. Each operation may
+// rewrite many parquet files up to max_file_size. Memory is therefore
+// bounded by max_file_size + threads=1 (one group at a time), not by
+// this count. 32 is a drain-vs-lock compromise: 8 falls behind a 30s
+// flush (~120 files/h) on busy call tables; 100 held the catalog lock
+// long enough for ingest buffers to blow RSS. Leftovers go to the next
+// cycle. Operators may raise this; we do not clamp an explicit value.
 const (
-	defaultDuckDBMaxCompactedFiles = 8
-	duckdbMaxCompactedFilesCap     = 16
+	defaultDuckDBMaxCompactedFiles = 32
 	defaultDuckDBMaxFileSizeBytes  = 64 << 20 // 64 MiB
 )
 
@@ -591,12 +596,6 @@ func (c *CompactionService) runMerge(tables []string) error {
 
 	maxFiles := c.effectiveMaxCompactedFiles()
 	maxSize := c.effectiveMaxFileSizeBytes()
-	if c.config.MaxCompactedFiles > duckdbMaxCompactedFilesCap {
-		logger.Warn("CompactionService: clamping max_compacted_files for duckdb merge",
-			"configured", c.config.MaxCompactedFiles,
-			"using", maxFiles,
-			"reason", "large batches OOM sorted SIP tables (homer#945)")
-	}
 
 	// 1. Merge adjacent small files FIRST — lock per table.
 	// The CALL runs on a dedicated pool connection with threads=1 so
@@ -885,17 +884,10 @@ func (c *CompactionService) GetStats() map[string]interface{} {
 }
 
 func (c *CompactionService) effectiveMaxCompactedFiles() int {
-	n := c.config.MaxCompactedFiles
-	if n <= 0 {
-		n = defaultDuckDBMaxCompactedFiles
+	if c.config.MaxCompactedFiles > 0 {
+		return c.config.MaxCompactedFiles
 	}
-	if strings.EqualFold(strings.TrimSpace(c.config.Engine), EngineNativeGo) {
-		return n
-	}
-	if n > duckdbMaxCompactedFilesCap {
-		return duckdbMaxCompactedFilesCap
-	}
-	return n
+	return defaultDuckDBMaxCompactedFiles
 }
 
 func (c *CompactionService) effectiveMaxFileSizeBytes() int64 {

--- a/src/writer/compaction.go
+++ b/src/writer/compaction.go
@@ -122,7 +122,9 @@ type CompactionConfig struct {
 	MinFileSizeBytes int64 `json:"min_file_size_bytes"`
 	// MaxFileSizeBytes: maximum size of merged file. 0 = no limit (DuckLake default).
 	MaxFileSizeBytes int64 `json:"max_file_size_bytes"`
-	// MaxCompactedFiles: maximum number of files to merge per table per cycle. 0 = no limit.
+	// MaxCompactedFiles: maximum number of compaction groups per table per cycle.
+	// 0 = writer default (8). DuckLake may apply this per date-partition on
+	// older extensions, so keep it small on sorted SIP tables.
 	MaxCompactedFiles int `json:"max_compacted_files"`
 	// Engine selects the compaction backend: "duckdb" (default) or "native".
 	Engine string `json:"engine"`
@@ -134,6 +136,16 @@ type CompactionConfig struct {
 const (
 	EngineDuckDB   = "duckdb"
 	EngineNativeGo = "native"
+)
+
+// Defaults for the DuckDB merge path. The previous writer default of 100
+// compaction groups was enough to OOM hep_proto_1_call (wide payload +
+// SORTED BY timestamp) and get the process SIGKILL'd with no error log
+// (sipcapture/homer#945). Leftovers are picked up by the next cycle.
+const (
+	defaultDuckDBMaxCompactedFiles = 8
+	duckdbMaxCompactedFilesCap     = 16
+	defaultDuckDBMaxFileSizeBytes  = 64 << 20 // 64 MiB
 )
 
 // CatalogLocker provides Lock/Unlock for serializing catalog-modifying operations.
@@ -577,7 +589,19 @@ func (c *CompactionService) runMerge(tables []string) error {
 			"has_catalog_path", strings.TrimSpace(c.catalogPath) != "")
 	}
 
-	// 1. Merge adjacent small files FIRST — lock per table
+	maxFiles := c.effectiveMaxCompactedFiles()
+	maxSize := c.effectiveMaxFileSizeBytes()
+	if c.config.MaxCompactedFiles > duckdbMaxCompactedFilesCap {
+		logger.Warn("CompactionService: clamping max_compacted_files for duckdb merge",
+			"configured", c.config.MaxCompactedFiles,
+			"using", maxFiles,
+			"reason", "large batches OOM sorted SIP tables (homer#945)")
+	}
+
+	// 1. Merge adjacent small files FIRST — lock per table.
+	// The CALL runs on a dedicated pool connection with threads=1 so
+	// date-partitions are compacted serially instead of in parallel
+	// (each group fully decompresses + re-sorts SIP payloads).
 	for _, table := range tables {
 		tableName := tableNameFromFQN(table)
 		if tableName == "" {
@@ -586,14 +610,27 @@ func (c *CompactionService) runMerge(tables []string) error {
 		}
 
 		c.withCatalogLock(func() {
+			defer func() {
+				if r := recover(); r != nil {
+					logger.Error("CompactionService: merge panic", "table", tableName, "panic", r)
+				}
+			}()
+
 			fileCount, err := c.getTableFileCount(tableName)
 			if err == nil {
 				logger.Info("CompactionService: Files before merge", "table", tableName, "count", fileCount)
+				if fileCount < 2 {
+					return
+				}
 			}
 
-			mergeSQL := c.buildMergeSQL(tableName)
-			logger.Info("CompactionService: Merge adjacent files", "lake", c.lakeName, "table", tableName)
-			result, err := c.execWithRetry(mergeSQL)
+			logger.Info("CompactionService: Merge adjacent files",
+				"lake", c.lakeName,
+				"table", tableName,
+				"max_compacted_files", maxFiles,
+				"max_file_size_bytes", maxSize,
+				"threads", 1)
+			processed, created, err := c.mergeAdjacentFiles(tableName)
 			if err != nil {
 				if brokenPath := extractBrokenParquetPath(err); brokenPath != "" {
 					logger.Warn("CompactionService: merge hit broken/missing parquet, removing catalog entry",
@@ -609,9 +646,11 @@ func (c *CompactionService) runMerge(tables []string) error {
 				if strings.Contains(err.Error(), "Out of Memory") {
 					c.logMemoryBreakdown()
 				}
-			} else if result != nil {
-				rowsAffected, _ := result.RowsAffected()
-				logger.Info("CompactionService: merge_adjacent_files completed", "table", tableName, "files_merged", rowsAffected)
+			} else {
+				logger.Info("CompactionService: merge_adjacent_files completed",
+					"table", tableName,
+					"files_processed", processed,
+					"files_created", created)
 
 				fileCountAfter, err := c.getTableFileCount(tableName)
 				if err == nil {
@@ -845,21 +884,36 @@ func (c *CompactionService) GetStats() map[string]interface{} {
 	}
 }
 
+func (c *CompactionService) effectiveMaxCompactedFiles() int {
+	n := c.config.MaxCompactedFiles
+	if n <= 0 {
+		n = defaultDuckDBMaxCompactedFiles
+	}
+	if strings.EqualFold(strings.TrimSpace(c.config.Engine), EngineNativeGo) {
+		return n
+	}
+	if n > duckdbMaxCompactedFilesCap {
+		return duckdbMaxCompactedFilesCap
+	}
+	return n
+}
+
+func (c *CompactionService) effectiveMaxFileSizeBytes() int64 {
+	if c.config.MaxFileSizeBytes > 0 {
+		return c.config.MaxFileSizeBytes
+	}
+	return defaultDuckDBMaxFileSizeBytes
+}
+
 // buildMergeSQL constructs the merge SQL with optional parameters
 func (c *CompactionService) buildMergeSQL(tableName string) string {
-	// Build optional parameters
-	var params []string
-	params = append(params, "schema => 'main'")
+	params := []string{"schema => 'main'"}
 
 	if c.config.MinFileSizeBytes > 0 {
 		params = append(params, fmt.Sprintf("min_file_size => %d", c.config.MinFileSizeBytes))
 	}
-	if c.config.MaxFileSizeBytes > 0 {
-		params = append(params, fmt.Sprintf("max_file_size => %d", c.config.MaxFileSizeBytes))
-	}
-	if c.config.MaxCompactedFiles > 0 {
-		params = append(params, fmt.Sprintf("max_compacted_files => %d", c.config.MaxCompactedFiles))
-	}
+	params = append(params, fmt.Sprintf("max_file_size => %d", c.effectiveMaxFileSizeBytes()))
+	params = append(params, fmt.Sprintf("max_compacted_files => %d", c.effectiveMaxCompactedFiles()))
 
 	return fmt.Sprintf(
 		"CALL ducklake_merge_adjacent_files('%s', '%s', %s)",
@@ -867,6 +921,81 @@ func (c *CompactionService) buildMergeSQL(tableName string) string {
 		tableName,
 		strings.Join(params, ", "),
 	)
+}
+
+// mergeAdjacentFiles runs ducklake_merge_adjacent_files on a dedicated
+// connection with threads=1. Query (not Exec) is required to read the
+// files_processed/files_created result set; Exec always reports 0.
+func (c *CompactionService) mergeAdjacentFiles(tableName string) (filesProcessed, filesCreated int64, err error) {
+	if c.db == nil {
+		return 0, 0, fmt.Errorf("no database")
+	}
+	ctx := c.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	const attempts = 4
+	backoff := 500 * time.Millisecond
+	var lastErr error
+	mergeSQL := c.buildMergeSQL(tableName)
+
+	for attempt := 1; attempt <= attempts; attempt++ {
+		filesProcessed, filesCreated, lastErr = c.mergeAdjacentFilesOnce(ctx, mergeSQL)
+		if lastErr == nil {
+			return filesProcessed, filesCreated, nil
+		}
+		if !isDatabaseLocked(lastErr) {
+			return 0, 0, lastErr
+		}
+		if attempt < attempts {
+			logger.Warn("CompactionService: database locked, retrying",
+				"attempt", attempt,
+				"next_wait", backoff.String(),
+				"error", lastErr)
+			time.Sleep(backoff)
+			backoff *= 2
+		}
+	}
+	return 0, 0, lastErr
+}
+
+func (c *CompactionService) mergeAdjacentFilesOnce(ctx context.Context, mergeSQL string) (filesProcessed, filesCreated int64, err error) {
+	conn, err := c.db.Conn(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer conn.Close()
+
+	// Session-scoped: only this connection, not the rest of the writer pool.
+	// Serializes per-partition merge groups so two date= partitions of
+	// hep_proto_1_call are not decompressed at once.
+	if _, err := conn.ExecContext(ctx, "SET threads = 1"); err != nil {
+		logger.Warn("CompactionService: SET threads=1 for merge failed", "error", err)
+	}
+
+	rows, err := conn.QueryContext(ctx, mergeSQL)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var schemaName, tableName string
+		var processed, created int64
+		if scanErr := rows.Scan(&schemaName, &tableName, &processed, &created); scanErr != nil {
+			// Older DuckLake builds may return a different shape; the merge
+			// itself succeeded, so do not fail the cycle.
+			logger.Warn("CompactionService: merge result scan failed", "error", scanErr)
+			continue
+		}
+		filesProcessed += processed
+		filesCreated += created
+	}
+	if err := rows.Err(); err != nil {
+		return filesProcessed, filesCreated, err
+	}
+	return filesProcessed, filesCreated, nil
 }
 
 // logMemoryBreakdown dumps DuckDB's buffer-manager accounting after an
@@ -1119,6 +1248,7 @@ func (c *CompactionService) getTableFileCount(tableName string) (int64, error) {
 		FROM %s.ducklake_data_file f
 		JOIN %s.ducklake_table t ON t.table_id = f.table_id
 		WHERE t.table_name = ?
+		  AND f.end_snapshot IS NULL
 	`, metadataSchema, metadataSchema)
 
 	rows, err := c.queryWithRetry(query, tableName)

--- a/src/writer/compaction_merge_test.go
+++ b/src/writer/compaction_merge_test.go
@@ -1,0 +1,81 @@
+package writer
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEffectiveMaxCompactedFiles(t *testing.T) {
+	tests := []struct {
+		name   string
+		config CompactionConfig
+		want   int
+	}{
+		{"zero uses default", CompactionConfig{}, defaultDuckDBMaxCompactedFiles},
+		{"explicit small kept", CompactionConfig{MaxCompactedFiles: 4}, 4},
+		{"example 100 clamped on duckdb", CompactionConfig{MaxCompactedFiles: 100}, duckdbMaxCompactedFilesCap},
+		{"engine duckdb still clamped", CompactionConfig{Engine: EngineDuckDB, MaxCompactedFiles: 100}, duckdbMaxCompactedFilesCap},
+		{"native not clamped", CompactionConfig{Engine: EngineNativeGo, MaxCompactedFiles: 100}, 100},
+		{"native zero uses default", CompactionConfig{Engine: EngineNativeGo}, defaultDuckDBMaxCompactedFiles},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &CompactionService{config: tt.config}
+			if got := svc.effectiveMaxCompactedFiles(); got != tt.want {
+				t.Fatalf("effectiveMaxCompactedFiles()=%d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveMaxFileSizeBytes(t *testing.T) {
+	svc := &CompactionService{}
+	if got := svc.effectiveMaxFileSizeBytes(); got != defaultDuckDBMaxFileSizeBytes {
+		t.Fatalf("zero config: got %d, want %d", got, defaultDuckDBMaxFileSizeBytes)
+	}
+	svc.config.MaxFileSizeBytes = 134217728
+	if got := svc.effectiveMaxFileSizeBytes(); got != 134217728 {
+		t.Fatalf("explicit: got %d, want 134217728", got)
+	}
+}
+
+func TestBuildMergeSQLAlwaysBoundsBatch(t *testing.T) {
+	svc := &CompactionService{
+		lakeName: "homer_lake",
+		config:   CompactionConfig{MaxCompactedFiles: 100},
+	}
+	sql := svc.buildMergeSQL("hep_proto_1_call")
+	if !strings.Contains(sql, "max_compacted_files => 16") {
+		t.Fatalf("expected clamped max_compacted_files in %q", sql)
+	}
+	if !strings.Contains(sql, "max_file_size => 67108864") {
+		t.Fatalf("expected default max_file_size in %q", sql)
+	}
+	if !strings.Contains(sql, "schema => 'main'") {
+		t.Fatalf("expected schema in %q", sql)
+	}
+	if !strings.Contains(sql, "'hep_proto_1_call'") {
+		t.Fatalf("expected table name in %q", sql)
+	}
+}
+
+func TestBuildMergeSQLRespectsMinFileSize(t *testing.T) {
+	svc := &CompactionService{
+		lakeName: "homer_lake",
+		config: CompactionConfig{
+			MinFileSizeBytes: 1024,
+			MaxFileSizeBytes: 10 << 20,
+			MaxCompactedFiles: 2,
+		},
+	}
+	sql := svc.buildMergeSQL("hep_proto_1_call")
+	if !strings.Contains(sql, "min_file_size => 1024") {
+		t.Fatalf("expected min_file_size in %q", sql)
+	}
+	if !strings.Contains(sql, "max_file_size => 10485760") {
+		t.Fatalf("expected explicit max_file_size in %q", sql)
+	}
+	if !strings.Contains(sql, "max_compacted_files => 2") {
+		t.Fatalf("expected max_compacted_files in %q", sql)
+	}
+}

--- a/src/writer/compaction_merge_test.go
+++ b/src/writer/compaction_merge_test.go
@@ -13,10 +13,8 @@ func TestEffectiveMaxCompactedFiles(t *testing.T) {
 	}{
 		{"zero uses default", CompactionConfig{}, defaultDuckDBMaxCompactedFiles},
 		{"explicit small kept", CompactionConfig{MaxCompactedFiles: 4}, 4},
-		{"example 100 clamped on duckdb", CompactionConfig{MaxCompactedFiles: 100}, duckdbMaxCompactedFilesCap},
-		{"engine duckdb still clamped", CompactionConfig{Engine: EngineDuckDB, MaxCompactedFiles: 100}, duckdbMaxCompactedFilesCap},
-		{"native not clamped", CompactionConfig{Engine: EngineNativeGo, MaxCompactedFiles: 100}, 100},
-		{"native zero uses default", CompactionConfig{Engine: EngineNativeGo}, defaultDuckDBMaxCompactedFiles},
+		{"explicit 100 kept", CompactionConfig{MaxCompactedFiles: 100}, 100},
+		{"engine duckdb explicit kept", CompactionConfig{Engine: EngineDuckDB, MaxCompactedFiles: 100}, 100},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -42,11 +40,11 @@ func TestEffectiveMaxFileSizeBytes(t *testing.T) {
 func TestBuildMergeSQLAlwaysBoundsBatch(t *testing.T) {
 	svc := &CompactionService{
 		lakeName: "homer_lake",
-		config:   CompactionConfig{MaxCompactedFiles: 100},
+		config:   CompactionConfig{},
 	}
 	sql := svc.buildMergeSQL("hep_proto_1_call")
-	if !strings.Contains(sql, "max_compacted_files => 16") {
-		t.Fatalf("expected clamped max_compacted_files in %q", sql)
+	if !strings.Contains(sql, "max_compacted_files => 32") {
+		t.Fatalf("expected default max_compacted_files in %q", sql)
 	}
 	if !strings.Contains(sql, "max_file_size => 67108864") {
 		t.Fatalf("expected default max_file_size in %q", sql)
@@ -63,8 +61,8 @@ func TestBuildMergeSQLRespectsMinFileSize(t *testing.T) {
 	svc := &CompactionService{
 		lakeName: "homer_lake",
 		config: CompactionConfig{
-			MinFileSizeBytes: 1024,
-			MaxFileSizeBytes: 10 << 20,
+			MinFileSizeBytes:  1024,
+			MaxFileSizeBytes:  10 << 20,
 			MaxCompactedFiles: 2,
 		},
 	}

--- a/src/writer/writer.go
+++ b/src/writer/writer.go
@@ -358,7 +358,18 @@ func (w *Writer) Start() error {
 			// memory_limit and abort with Out of Memory while search/flush
 			// run on the same instance. Capping keeps each cycle's peak
 			// bounded — leftovers are picked up by the next cycle.
-			compactionCfg.MaxCompactedFiles = 100
+			// 8 (not 100): hep_proto_1_call is PARTITIONED BY date and
+			// SORTED BY timestamp, so each compaction group is fully
+			// decompressed and re-sorted. 100 wide SIP files exceeds a
+			// typical 2–4GB memory_limit and the process is then SIGKILL'd
+			// with no DuckDB error (sipcapture/homer#945).
+			compactionCfg.MaxCompactedFiles = defaultDuckDBMaxCompactedFiles
+		}
+		if compactionCfg.MaxFileSizeBytes <= 0 {
+			// Without max_file_size DuckLake defaults to target_file_size
+			// and will try to rewrite already-large files. Bound inputs so
+			// a merge group stays within memory_limit.
+			compactionCfg.MaxFileSizeBytes = defaultDuckDBMaxFileSizeBytes
 		}
 		var compactionS3 *CompactionS3Client
 		if ducklake.IsRemoteLakeDataPath(w.storageConfig.DuckLake.DataPath) {

--- a/src/writer/writer.go
+++ b/src/writer/writer.go
@@ -354,15 +354,9 @@ func (w *Writer) Start() error {
 		}
 		if compactionCfg.MaxCompactedFiles <= 0 {
 			// Unbounded merge rewrites every small parquet of a table in one
-			// CALL; on a memory-capped writer that working set alone can hit
-			// memory_limit and abort with Out of Memory while search/flush
-			// run on the same instance. Capping keeps each cycle's peak
-			// bounded — leftovers are picked up by the next cycle.
-			// 8 (not 100): hep_proto_1_call is PARTITIONED BY date and
-			// SORTED BY timestamp, so each compaction group is fully
-			// decompressed and re-sorted. 100 wide SIP files exceeds a
-			// typical 2–4GB memory_limit and the process is then SIGKILL'd
-			// with no DuckDB error (sipcapture/homer#945).
+			// CALL. 32 operations/cycle is a drain-vs-lock compromise
+			// (sipcapture/homer#945); peak memory is bounded by
+			// MaxFileSizeBytes and merge threads=1, not by this count.
 			compactionCfg.MaxCompactedFiles = defaultDuckDBMaxCompactedFiles
 		}
 		if compactionCfg.MaxFileSizeBytes <= 0 {


### PR DESCRIPTION
## Summary
- DuckDB `ducklake_merge_adjacent_files` on `hep_proto_1_call` (date-partitioned, `SORTED BY timestamp`, wide SIP payloads) was loading too much into memory. With `max_compacted_files=100` the process hits RAM 100% and is SIGKILL'd — no `Out of Memory` log, UI 5xx, ingest `adapter_us` spikes because the catalog lock is held for the whole CALL ([#945](https://github.com/sipcapture/homer/issues/945)).
- Stay on `engine=duckdb`. Do **not** switch to `engine=native` as a workaround: earlier native builds wrote snapshot ids out-of-band and corrupted live catalogs.
- `max_compacted_files` counts output files per CALL, not inputs. Peak memory is one group (`max_file_size`) because merge runs on a dedicated connection with `threads=1`. Default is 32 operations/cycle (8 falls behind a 30s flush; 100 held the catalog lock too long). Explicit config is not clamped. Default `max_file_size` is 64MB. Logs `files_processed`/`files_created` instead of the always-zero `Exec` row count.

## Test plan
- [x] `go test ./writer/` (includes new `compaction_merge_test.go`)
- [x] `go test ./config/`
- [ ] On a node with a large `hep_proto_1_call` lake: scheduled compaction should finish the call-table merge (or skip it when `< 2` active files) without RSS climbing to 100%
- [ ] Logs should show `max_compacted_files`, `threads=1`, and non-zero `files_processed` when files were actually merged
- [ ] Existing `max_compacted_files: 100` configs are respected (not clamped); file count should not grow unbounded at default 32
