### PR TITLE
feat(storage): support hours as a retention unit alongside days

### DIFF
--- a/examples/homer.json
+++ b/examples/homer.json
@@ -71,6 +71,7 @@
         "enable": true,
         "check_interval_sec": 1800,
         "retention_days": 30,
+        "retention_unit": "days",
         "retention_days_by_table": {
           "hep_proto_1_registration": 14
         },

--- a/src/cli/system_cmd.go
+++ b/src/cli/system_cmd.go
@@ -85,6 +85,7 @@ type SystemFlags struct {
 	CompactionExpireSnapshots bool
 	CompactionExpireOlderThan string
 	CompactionRetentionDays   int
+	CompactionRetentionUnit   string
 	CompactionMergeList       bool
 	CompactionMergeListLimit  int
 	RebuildCatalog            bool
@@ -105,6 +106,7 @@ type systemFlagRefs struct {
 	CompactionExpireSnapshots *bool
 	CompactionExpireOlderThan *string
 	CompactionRetentionDays   *int
+	CompactionRetentionUnit   *string
 	CompactionMergeList       *bool
 	CompactionMergeListLimit  *int
 	RebuildCatalog            *bool
@@ -129,6 +131,7 @@ func RegisterSystemFlags() (*flag.FlagSet, *systemFlagRefs) {
 	refs.CompactionExpireSnapshots = fs.Bool("compaction-expire-snapshots", false, "expire DuckLake snapshots and exit")
 	refs.CompactionExpireOlderThan = fs.String("compaction-expire-older-than", "1h", "age threshold for snapshot expiration (e.g., 30m, 2h, 3600s)")
 	refs.CompactionRetentionDays = fs.Int("compaction-retention-days", 0, "delete data older than N days and exit")
+	refs.CompactionRetentionUnit = fs.String("compaction-retention-unit", "days", "unit for --compaction-retention-days: \"days\" or \"hours\"")
 	refs.CompactionMergeList = fs.Bool("compaction-merge-list", false, "list smallest DuckLake files before/after merge")
 	refs.CompactionMergeListLimit = fs.Int("compaction-merge-list-limit", 50, "limit for compaction-merge-list output")
 	refs.RebuildCatalog = fs.Bool("rebuild-catalog", false, "fix a corrupt catalog: back up the existing catalog and rebuild it by registering the on-disk parquet files in place (no rewrite), then exit")
@@ -153,6 +156,7 @@ func ParseSystemFlags(refs *systemFlagRefs) SystemFlags {
 		CompactionExpireSnapshots: *refs.CompactionExpireSnapshots,
 		CompactionExpireOlderThan: *refs.CompactionExpireOlderThan,
 		CompactionRetentionDays:   *refs.CompactionRetentionDays,
+		CompactionRetentionUnit:   *refs.CompactionRetentionUnit,
 		CompactionMergeList:       *refs.CompactionMergeList,
 		CompactionMergeListLimit:  *refs.CompactionMergeListLimit,
 		RebuildCatalog:            *refs.RebuildCatalog,
@@ -226,12 +230,17 @@ func runCompaction(f SystemFlags) error {
 
 	// Retention
 	if f.CompactionRetentionDays > 0 {
+		unit, err := config.NormalizeRetentionUnit(f.CompactionRetentionUnit)
+		if err != nil {
+			return fmt.Errorf("--compaction-retention-unit: %w", err)
+		}
+
 		tables, err := discoverDuckLakeTables(db, lakeName)
 		if err != nil {
 			return fmt.Errorf("failed to discover DuckLake tables: %w", err)
 		}
 
-		cutoff := time.Now().AddDate(0, 0, -f.CompactionRetentionDays)
+		cutoff := config.RetentionCutoff(time.Now(), f.CompactionRetentionDays, unit)
 		cutoffStr := cutoff.UTC().Format("2006-01-02 15:04:05")
 		var totalRowsDeleted int64
 		for _, table := range tables {
@@ -247,7 +256,7 @@ func runCompaction(f SystemFlags) error {
 				totalRowsDeleted += rowsAffected
 			}
 		}
-		logger.Info("Retention completed", "total_rows_deleted", totalRowsDeleted)
+		logger.Info("Retention completed", "total_rows_deleted", totalRowsDeleted, "retention_unit", unit)
 	}
 
 	// Expire duration

--- a/src/cli/wizard_cmd.go
+++ b/src/cli/wizard_cmd.go
@@ -250,6 +250,7 @@ const (
 	wfCatalogPath
 	wfDataPath
 	wfRetentionDays
+	wfRetentionUnit
 	wfBatchSize
 
 	// Node step
@@ -294,7 +295,7 @@ type wizardModel struct {
 var stepFields = [wizNumSteps][]int{
 	wizStepProfile:     {wfProfile},
 	wizStepIngest:      {wfIngestEnable, wfUDPPort, wfTCPEnable, wfHTTPPort, wfWorkerCount, wfQueueSize},
-	wizStepStorage:     {wfStorageEnable, wfCatalogPath, wfDataPath, wfRetentionDays, wfBatchSize},
+	wizStepStorage:     {wfStorageEnable, wfCatalogPath, wfDataPath, wfRetentionDays, wfRetentionUnit, wfBatchSize},
 	wizStepNode:        {wfNodeEnable, wfFlightPort, wfAuthToken},
 	wizStepCoordinator: {wfCoordEnable, wfCoordPort, wfNodeHost, wfNodePort, wfJWTSecret, wfAdminUser, wfAdminPass, wfSettingsDB},
 	wizStepSystem:      {wfLogLevel, wfPrometheusEnable, wfPrometheusPort},
@@ -374,6 +375,10 @@ func newWizardModel(outputPath string) wizardModel {
 	inputs[wfRetentionDays].Prompt = "Retention Days:  "
 	inputs[wfRetentionDays].Placeholder = "30 (0 = unlimited)"
 	inputs[wfRetentionDays].SetValue("30")
+
+	inputs[wfRetentionUnit].Prompt = "Retention Unit:  "
+	inputs[wfRetentionUnit].Placeholder = "days or hours"
+	inputs[wfRetentionUnit].SetValue("days")
 
 	inputs[wfBatchSize].Prompt = "Batch Size:      "
 	inputs[wfBatchSize].Placeholder = "10000"
@@ -704,6 +709,7 @@ func (m wizardModel) buildConfigFromInputs() config.Config {
 	queueSize := parseInt(m.inputs[wfQueueSize].Value(), 80000)
 	batchSize := parseInt(m.inputs[wfBatchSize].Value(), 10000)
 	retentionDays := parseInt(m.inputs[wfRetentionDays].Value(), 30)
+	retentionUnit := parseRetentionUnit(m.inputs[wfRetentionUnit].Value())
 	flightPort := parseInt(m.inputs[wfFlightPort].Value(), 50051)
 	coordPort := parseInt(m.inputs[wfCoordPort].Value(), 8080)
 	nodePort := parseInt(m.inputs[wfNodePort].Value(), 50051)
@@ -784,6 +790,7 @@ func (m wizardModel) buildConfigFromInputs() config.Config {
 					Enable:              true,
 					CheckIntervalSec:    1800,
 					RetentionDays:       retentionDays,
+					RetentionUnit:       retentionUnit,
 					Engine:              "native",
 					TargetFileSizeBytes: 536870912, // 512MB
 				},
@@ -891,6 +898,17 @@ func parseInt(s string, def int) int {
 		return def
 	}
 	return v
+}
+
+// parseRetentionUnit is deliberately permissive — unlike config-file loading,
+// the interactive wizard shouldn't hard-fail on a typo; it falls back to the
+// safe default "days". config.Load()'s strict validation is the backstop.
+func parseRetentionUnit(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "hours" || s == "hour" || s == "h" {
+		return config.RetentionUnitHours
+	}
+	return config.RetentionUnitDays
 }
 
 func randomHex(n int) string {

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -771,6 +771,12 @@ type CompactionConfig struct {
 	// of 0 disables TTL for that table. When RetentionDays is 0, positive
 	// overrides still run retention for the listed tables only.
 	RetentionDaysByTable map[string]int `json:"retention_days_by_table" mapstructure:"retention_days_by_table"`
+	// RetentionUnit selects how RetentionDays / RetentionDaysByTable values
+	// are interpreted: "days" (default) uses calendar-day arithmetic
+	// (matches legacy behavior exactly); "hours" reinterprets the same
+	// integer fields as hours. Applies globally to both the default and
+	// every per-table override.
+	RetentionUnit string `json:"retention_unit" mapstructure:"retention_unit" default:"days"`
 	// SnapshotExpireIntervalSec controls how long to keep DuckLake snapshots (seconds).
 	SnapshotExpireIntervalSec int `json:"snapshot_expire_interval_sec" mapstructure:"snapshot_expire_interval_sec" default:"3600"`
 	// MinAgeSec controls how old data must be before compaction runs.
@@ -1261,6 +1267,10 @@ func Load(configPath string) (*Config, error) {
 		return nil, err
 	}
 
+	if err := validateRetentionUnits(&cfg); err != nil {
+		return nil, err
+	}
+
 	MainConfig = &cfg
 	return &cfg, nil
 }
@@ -1336,6 +1346,18 @@ func validateDuckLakeCatalogTypes(cfg *Config) error {
 		if err := check(fmt.Sprintf("node.ducklake.volumes[%d].catalog_type", i), v.CatalogType); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// validateRetentionUnits fails fast on an unrecognized retention_unit so a
+// typo doesn't silently reinterpret retention windows.
+func validateRetentionUnits(cfg *Config) error {
+	if _, err := NormalizeRetentionUnit(cfg.Storage.DuckLake.Compaction.RetentionUnit); err != nil {
+		return fmt.Errorf("storage.ducklake.compaction.retention_unit: %w", err)
+	}
+	if _, err := NormalizeRetentionUnit(cfg.Node.DuckLake.Compaction.RetentionUnit); err != nil {
+		return fmt.Errorf("node.ducklake.compaction.retention_unit: %w", err)
 	}
 	return nil
 }

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -791,6 +791,15 @@ func TestLoad_CoordinatorAuthObjectTypeInvalid(t *testing.T) {
 	}
 }
 
+func TestLoad_InvalidRetentionUnit(t *testing.T) {
+	path := writeTmpConfig(t, `{
+  "storage": { "ducklake": { "compaction": { "retention_unit": "fortnights" } } }
+}`)
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected error for invalid storage.ducklake.compaction.retention_unit")
+	}
+}
+
 func TestLoad_CoordinatorAuthObjectWithoutTypeDefaultsToInternal(t *testing.T) {
 	path := writeTmpConfig(t, `{
   "coordinator": {

--- a/src/config/env_test.go
+++ b/src/config/env_test.go
@@ -68,6 +68,7 @@ func TestLoad_EnvScalars_AllSections(t *testing.T) {
 		"HOMER_STORAGE_DUCKLAKE_COMPACTION_ENABLE":                       "true",
 		"HOMER_STORAGE_DUCKLAKE_COMPACTION_CHECK_INTERVAL_SEC":           "1800",
 		"HOMER_STORAGE_DUCKLAKE_COMPACTION_RETENTION_DAYS":               "30",
+		"HOMER_STORAGE_DUCKLAKE_COMPACTION_RETENTION_UNIT":               "days",
 		"HOMER_STORAGE_DUCKLAKE_COMPACTION_SNAPSHOT_EXPIRE_INTERVAL_SEC": "3600",
 		"HOMER_STORAGE_DUCKLAKE_COMPACTION_MIN_AGE_SEC":                  "3600",
 		"HOMER_STORAGE_DUCKLAKE_COMPACTION_MIN_FILE_SIZE_BYTES":          "0",
@@ -161,6 +162,7 @@ func TestLoad_EnvScalars_AllSections(t *testing.T) {
 		{"Compaction.Enable", cfg.Storage.DuckLake.Compaction.Enable, true},
 		{"Compaction.CheckIntervalSec", cfg.Storage.DuckLake.Compaction.CheckIntervalSec, 1800},
 		{"Compaction.RetentionDays", cfg.Storage.DuckLake.Compaction.RetentionDays, 30},
+		{"Compaction.RetentionUnit", cfg.Storage.DuckLake.Compaction.RetentionUnit, "days"},
 		{"Compaction.MaxFileSizeBytes", cfg.Storage.DuckLake.Compaction.MaxFileSizeBytes, int64(134217728)},
 		{"Compaction.MaxCompactedFiles", cfg.Storage.DuckLake.Compaction.MaxCompactedFiles, 100},
 

--- a/src/config/retention.go
+++ b/src/config/retention.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Retention unit values for CompactionConfig.RetentionUnit. "days" is the
+// default and preserves legacy calendar-day semantics byte-for-byte.
+const (
+	RetentionUnitDays  = "days"
+	RetentionUnitHours = "hours"
+)
+
+// NormalizeRetentionUnit validates and lower-cases a retention_unit value.
+// "" is treated as RetentionUnitDays (the pre-existing default behavior).
+func NormalizeRetentionUnit(unit string) (string, error) {
+	u := strings.ToLower(strings.TrimSpace(unit))
+	if u == "" {
+		return RetentionUnitDays, nil
+	}
+	if u != RetentionUnitDays && u != RetentionUnitHours {
+		return "", fmt.Errorf("invalid retention_unit %q: must be %q or %q", unit, RetentionUnitDays, RetentionUnitHours)
+	}
+	return u, nil
+}
+
+// RetentionCutoff returns the timestamp before which rows are eligible for
+// deletion, given a raw retention value (as stored in retention_days /
+// retention_days_by_table) and its unit. "days" (including "", defensively)
+// uses calendar-day arithmetic (time.AddDate) to match the pre-existing
+// behavior exactly (DST-correct, not a fixed 24h*N). "hours" uses a fixed
+// time.Duration.
+func RetentionCutoff(now time.Time, value int, unit string) time.Time {
+	if strings.EqualFold(unit, RetentionUnitHours) {
+		return now.Add(-time.Duration(value) * time.Hour)
+	}
+	return now.AddDate(0, 0, -value)
+}

--- a/src/config/retention_test.go
+++ b/src/config/retention_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNormalizeRetentionUnit(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"empty defaults to days", "", RetentionUnitDays, false},
+		{"days", "days", RetentionUnitDays, false},
+		{"Days mixed case", "Days", RetentionUnitDays, false},
+		{"days with whitespace", "  DAYS  ", RetentionUnitDays, false},
+		{"hours", "hours", RetentionUnitHours, false},
+		{"Hours mixed case", "Hours", RetentionUnitHours, false},
+		{"invalid unit", "weeks", "", true},
+		{"invalid abbreviation", "d", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeRetentionUnit(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("NormalizeRetentionUnit(%q) = %q, want error", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NormalizeRetentionUnit(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("NormalizeRetentionUnit(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetentionCutoff(t *testing.T) {
+	now := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+
+	daysCutoff := RetentionCutoff(now, 30, RetentionUnitDays)
+	wantDays := now.AddDate(0, 0, -30)
+	if !daysCutoff.Equal(wantDays) {
+		t.Fatalf("RetentionCutoff(days) = %v, want %v", daysCutoff, wantDays)
+	}
+
+	hoursCutoff := RetentionCutoff(now, 24, RetentionUnitHours)
+	wantHours := now.Add(-24 * time.Hour)
+	if !hoursCutoff.Equal(wantHours) {
+		t.Fatalf("RetentionCutoff(hours) = %v, want %v", hoursCutoff, wantHours)
+	}
+
+	defaultCutoff := RetentionCutoff(now, 30, "")
+	if !defaultCutoff.Equal(wantDays) {
+		t.Fatalf("RetentionCutoff(\"\") = %v, want %v (days default)", defaultCutoff, wantDays)
+	}
+}

--- a/src/main.go
+++ b/src/main.go
@@ -181,6 +181,7 @@ system -- System operations:
   --compaction-expire-snapshots Expire DuckLake snapshots
   --compaction-expire-older-than <dur>  Age threshold (default: 1h)
   --compaction-retention-days <n>       Delete data older than N days
+  --compaction-retention-unit <unit>    Unit for retention: days|hours (default: days)
   --compaction-merge-list       List smallest files before/after merge
   --compaction-merge-list-limit <n>     Limit for merge list (default: 50)
   --install-extensions          Install DuckDB extensions (ducklake, sqlite)

--- a/src/writer/compaction.go
+++ b/src/writer/compaction.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sipcapture/homer-core/src/config"
 	"github.com/sipcapture/homer-core/src/storage/ducklake"
 	"github.com/sipcapture/homer-core/src/storage/ducklake/compactor"
 	logger "github.com/sipcapture/homer-core/src/utils/logging"
@@ -114,6 +115,9 @@ type CompactionConfig struct {
 	// RetentionDaysByTable overrides RetentionDays per bare table name
 	// (e.g. "hep_proto_1_registration"). Override 0 disables TTL for that table.
 	RetentionDaysByTable map[string]int `json:"retention_days_by_table"`
+	// RetentionUnit selects how RetentionDays / RetentionDaysByTable are
+	// interpreted: "days" (default) or "hours". See config.RetentionUnit*.
+	RetentionUnit string `json:"retention_unit"`
 	// SnapshotExpireIntervalSec controls how long to keep DuckLake snapshots (seconds).
 	SnapshotExpireIntervalSec int `json:"snapshot_expire_interval_sec"`
 	// MinAgeSec controls how old data must be before compaction runs.
@@ -434,16 +438,16 @@ func (c *CompactionService) runCompaction() {
 	// Lock per table so flush is not blocked for the whole cycle.
 	if c.retentionEnabled() {
 		for _, table := range c.tables {
-			days := c.retentionDaysForTable(table)
-			if days <= 0 {
+			value := c.retentionValueForTable(table)
+			if value <= 0 {
 				continue
 			}
 			c.withCatalogLock(func() {
-				deleted, err := c.runRetention(table, days)
+				deleted, err := c.runRetention(table, value)
 				if err != nil {
-					logger.Error("CompactionService: Retention failed", "table", table, "retention_days", days, "error", err)
+					logger.Error("CompactionService: Retention failed", "table", table, "retention_value", value, "retention_unit", c.config.RetentionUnit, "error", err)
 				} else if deleted > 0 {
-					logger.Info("CompactionService: Retention completed", "table", table, "retention_days", days, "rows_deleted", deleted)
+					logger.Info("CompactionService: Retention completed", "table", table, "retention_value", value, "retention_unit", c.config.RetentionUnit, "rows_deleted", deleted)
 					totalRowsDeleted += deleted
 				}
 			})
@@ -517,10 +521,11 @@ func (c *CompactionService) retentionEnabled() bool {
 	return false
 }
 
-// retentionDaysForTable returns the TTL in days for a catalog table.
-// Bare table names in RetentionDaysByTable win over the global RetentionDays.
-// An explicit override of 0 disables TTL for that table.
-func (c *CompactionService) retentionDaysForTable(table string) int {
+// retentionValueForTable returns the raw TTL value for a catalog table, in
+// whatever unit c.config.RetentionUnit specifies. Bare table names in
+// RetentionDaysByTable win over the global RetentionDays. An explicit
+// override of 0 disables TTL for that table.
+func (c *CompactionService) retentionValueForTable(table string) int {
 	name := tableNameFromFQN(table)
 	if name == "" {
 		name = table
@@ -531,14 +536,15 @@ func (c *CompactionService) retentionDaysForTable(table string) int {
 	return c.config.RetentionDays
 }
 
-// runRetention deletes data older than retentionDays for one table.
-// Missing parquet files are silently skipped — they will be cleaned up
-// by ducklake_delete_orphaned_files in the maintenance phase.
-func (c *CompactionService) runRetention(table string, retentionDays int) (int64, error) {
-	if retentionDays <= 0 {
+// runRetention deletes data older than retentionValue (interpreted per
+// c.config.RetentionUnit) for one table. Missing parquet files are silently
+// skipped — they will be cleaned up by ducklake_delete_orphaned_files in the
+// maintenance phase.
+func (c *CompactionService) runRetention(table string, retentionValue int) (int64, error) {
+	if retentionValue <= 0 {
 		return 0, nil
 	}
-	cutoff := time.Now().AddDate(0, 0, -retentionDays)
+	cutoff := config.RetentionCutoff(time.Now(), retentionValue, c.config.RetentionUnit)
 	cutoffStr := cutoff.UTC().Format("2006-01-02 15:04:05")
 
 	query := fmt.Sprintf(`DELETE FROM %s WHERE timestamp < TIMESTAMP '%s'`,

--- a/src/writer/retention_days_test.go
+++ b/src/writer/retention_days_test.go
@@ -28,8 +28,8 @@ func TestRetentionDaysForTable(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := svc.retentionDaysForTable(tt.table); got != tt.want {
-				t.Fatalf("retentionDaysForTable(%q)=%d, want %d", tt.table, got, tt.want)
+			if got := svc.retentionValueForTable(tt.table); got != tt.want {
+				t.Fatalf("retentionValueForTable(%q)=%d, want %d", tt.table, got, tt.want)
 			}
 		})
 	}

--- a/src/writer/retention_exec_test.go
+++ b/src/writer/retention_exec_test.go
@@ -1,0 +1,80 @@
+package writer
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+)
+
+// TestRunRetentionRespectsUnit exercises runRetention against a real
+// in-memory DuckDB connection to confirm the "hours" unit actually deletes
+// on an hours-based cutoff rather than days, and that the default ("days")
+// behavior is unchanged.
+func TestRunRetentionRespectsUnit(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Skipf("duckdb unavailable: %v", err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+
+	if _, err := db.Exec(`CREATE TABLE t (id INTEGER, timestamp TIMESTAMP)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	// One row 10 hours old (older than a 4h retention, newer than a 1-day retention),
+	// one row 10 days old (older than both).
+	if _, err := db.Exec(`INSERT INTO t VALUES
+		(1, now() - INTERVAL 10 HOUR),
+		(2, now() - INTERVAL 10 DAY),
+		(3, now())`); err != nil {
+		t.Fatalf("insert rows: %v", err)
+	}
+
+	svc := &CompactionService{db: db, config: CompactionConfig{RetentionUnit: "hours"}}
+	deleted, err := svc.runRetention("t", 4)
+	if err != nil {
+		t.Fatalf("runRetention(hours) failed: %v", err)
+	}
+	if deleted != 2 {
+		t.Fatalf("runRetention(4 hours) deleted %d rows, want 2", deleted)
+	}
+
+	var remaining int
+	if err := db.QueryRow(`SELECT count(*) FROM t`).Scan(&remaining); err != nil {
+		t.Fatalf("count remaining: %v", err)
+	}
+	if remaining != 1 {
+		t.Fatalf("remaining rows = %d, want 1", remaining)
+	}
+}
+
+// TestRunRetentionDefaultUnitIsDays confirms omitting RetentionUnit (empty
+// string) still behaves like "days", matching pre-existing behavior.
+func TestRunRetentionDefaultUnitIsDays(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Skipf("duckdb unavailable: %v", err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+
+	if _, err := db.Exec(`CREATE TABLE t (id INTEGER, timestamp TIMESTAMP)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO t VALUES
+		(1, now() - INTERVAL 10 HOUR),
+		(2, now() - INTERVAL 10 DAY)`); err != nil {
+		t.Fatalf("insert rows: %v", err)
+	}
+
+	svc := &CompactionService{db: db, config: CompactionConfig{}}
+	deleted, err := svc.runRetention("t", 4)
+	if err != nil {
+		t.Fatalf("runRetention(default) failed: %v", err)
+	}
+	// A 4-day cutoff only catches the 10-day-old row, not the 10-hour-old one.
+	if deleted != 1 {
+		t.Fatalf("runRetention(4, default unit) deleted %d rows, want 1", deleted)
+	}
+}

--- a/src/writer/writer.go
+++ b/src/writer/writer.go
@@ -331,6 +331,7 @@ func (w *Writer) Start() error {
 			CheckIntervalSec:          w.storageConfig.DuckLake.Compaction.CheckIntervalSec,
 			RetentionDays:             w.storageConfig.DuckLake.Compaction.RetentionDays,
 			RetentionDaysByTable:      w.storageConfig.DuckLake.Compaction.RetentionDaysByTable,
+			RetentionUnit:             w.storageConfig.DuckLake.Compaction.RetentionUnit,
 			SnapshotExpireIntervalSec: w.storageConfig.DuckLake.Compaction.SnapshotExpireIntervalSec,
 			MinAgeSec:                 w.storageConfig.DuckLake.Compaction.MinAgeSec,
 			MinFileSizeBytes:          w.storageConfig.DuckLake.Compaction.MinFileSizeBytes,


### PR DESCRIPTION
## Summary
- Adds a `retention_unit` config field (`"days"` default, or `"hours"`) that reinterprets the existing `retention_days` / `retention_days_by_table` values as hours instead of calendar days, so operators can express sub-day retention windows (e.g. 4h for registration data, 16h for call data) without changing the shape of the existing config fields.
- Introduces `src/config/retention.go` as a single shared source of truth for unit validation and cutoff math, used by both the background `CompactionService` and the one-shot `homer system --compaction-retention-days` CLI path — these previously duplicated day-only cutoff logic independently.
- Adds a matching `--compaction-retention-unit` CLI flag and a prompt in the interactive setup wizard.
- Config validation fails fast on an invalid `retention_unit` value.
- Default behavior (no `retention_unit` set) is unchanged — verified with a regression test asserting the default cutoff is byte-for-byte identical to the pre-existing days-only calculation.

## Example

```json
"compaction": {
  "retention_unit": "hours",
  "retention_days": 24,
  "retention_days_by_table": {
    "hep_proto_1_registration": 4,
    "hep_proto_1_call": 16
  }
}
```

## Test plan
- [x] `go build ./config/... ./writer/... ./cli/...`
- [x] `go test ./config/... ./writer/... ./cli/...` — all passing, including new tests:
  - `src/config/retention_test.go`: unit normalization + cutoff math (days/hours/default)
  - `src/config/config_test.go`: `Load()` rejects an invalid `retention_unit`
  - `src/config/env_test.go`: `HOMER_STORAGE_DUCKLAKE_COMPACTION_RETENTION_UNIT` env var wiring
  - `src/writer/retention_exec_test.go`: real in-memory DuckDB test proving hours-based deletion actually deletes on an hours cutoff, and that the default unit still matches days-based behavior
  - `src/writer/retention_days_test.go`: updated for the `retentionDaysForTable` → `retentionValueForTable` rename (semantics unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)