### PR TITLE
feat(cli): add catalog backup and restore (11.0.322)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,19 @@ homer system --generate-example-config > homer.json
 homer system --reload
 ```
 
+### Catalog backup / restore
+
+The DuckLake SQLite catalog is metadata only (parquet is not copied). Backup is
+safe while Homer is running; restore requires the writer to be stopped.
+
+```bash
+homer catalog backup --config-path /etc/homer/homer.json
+homer catalog list --config-path /etc/homer/homer.json
+homer catalog restore --config-path /etc/homer/homer.json
+```
+
+See [docs/CATALOG.md](docs/CATALOG.md) for flags, `--out`, and when to use restore vs `--rebuild-catalog`.
+
 ### Wizard (Config Generator)
 
 Interactive wizard that generates a complete `homer.json` config:
@@ -293,6 +306,7 @@ python3 -m venv .venv-docs && .venv-docs/bin/pip install -r docs-requirements.tx
 ```
 
 - [Search CLI](docs/SEARCH.md) - Search from the command line (examples, formats, call flow)
+- [Catalog backup / restore](docs/CATALOG.md) - Snapshot and rewind the DuckLake SQLite catalog
 - [Config Wizard](docs/WIZARD.md) - Interactive config generator (TUI + presets)
 - [Ingest performance tuning](docs/INGEST_PERFORMANCE.md) - multicore, DuckLake batch size, Prometheus flush interval; **`scripts/profile_ingest_load.sh`** / **`make profile-ingest`** for repeatable CPU profiles
 - [Coordinator Module](docs/COORDINATOR.md) - REST API gateway

--- a/docs/CATALOG.md
+++ b/docs/CATALOG.md
@@ -1,0 +1,122 @@
+# Catalog backup and restore
+
+The `homer catalog` subcommand snapshots and restores the **DuckLake SQLite catalog** — the metadata file that lists tables, snapshots, and parquet paths. The catalog is small (kilobytes to a few megabytes). **Parquet data is not copied.**
+
+Native compaction already takes a rotating `VACUUM INTO` copy before each merge (last 3 files named `<catalog>.bak-<timestamp>`). This CLI is the same mechanism on demand, plus restore.
+
+## Quick start
+
+```bash
+# Online-safe snapshot next to the catalog (keeps the last 3 `.bak-*` copies)
+homer catalog backup --config-path /etc/homer/homer.json
+
+# Durable copy on another disk (not rotated)
+homer catalog backup --config-path /etc/homer/homer.json --out /backup/homer_catalog.sqlite
+
+# List rotating backups and pre-restore copies
+homer catalog list --config-path /etc/homer/homer.json
+
+# Rewind catalog metadata. Stop the Homer writer first.
+homer catalog restore --config-path /etc/homer/homer.json
+homer catalog restore --config-path /etc/homer/homer.json --from homer_catalog.sqlite.bak-20260818T100000Z
+```
+
+## Actions
+
+| Action    | Homer running? | Description |
+|-----------|----------------|-------------|
+| `backup`  | yes            | Consistent `VACUUM INTO` snapshot |
+| `list`    | yes            | List `.bak-*` copies and `.pre-restore-*` aside files |
+| `restore` | **no**         | Replace the live catalog from a backup |
+
+## Flags
+
+| Flag            | Default | Description |
+|-----------------|---------|-------------|
+| `--config-path` |         | Path to `homer.json` (or a directory containing it) |
+| `--keep`        | `3`     | Rotating `.bak-*` copies to retain (`backup` only; `0` = keep all) |
+| `--out`         |         | Write the snapshot to this path instead of a rotating `.bak-*` copy |
+| `--from`        | newest `.bak-*` | Backup to restore (`restore` only). Absolute path, path relative to cwd, or a basename next to the catalog |
+
+## What is backed up
+
+DuckLake splits storage in two:
+
+| Piece | Typical path | In the backup? |
+|-------|--------------|----------------|
+| SQLite catalog | `/data/homer/homer_catalog.sqlite` | yes |
+| Parquet files | `/data/homer/parquet/` | **no** |
+
+Use restore to **undo a bad metadata rewrite** (failed compaction cycle, botched catalog edit). It will not bring back parquet files that were deleted, compacted away, or expired.
+
+If the catalog is unreadable (`Corrupt DuckLake - multiple snapshots returned from database` and auto-repair cannot attach it), rebuild from parquet instead: `homer system --rebuild-catalog`. See [OOM — recovering a corrupted catalog](OOM.md#recovering-a-corrupted-catalog).
+
+## Backup
+
+`VACUUM INTO` runs inside a SQLite read transaction, so it is safe while DuckDB has the catalog attached. Compaction uses the same call and keeps 3 rotating copies; a CLI backup without `--out` shares that `.bak-*` pool (the next native merge will prune down to 3 unless you pass `--keep`).
+
+```bash
+homer catalog backup --config-path /etc/homer/homer.json
+# catalog backup: /data/homer/homer_catalog.sqlite.bak-20260818T100000Z
+```
+
+For a copy that compaction will not rotate away, use `--out`:
+
+```bash
+homer catalog backup --config-path /etc/homer/homer.json --out /backup/homer_catalog.sqlite
+```
+
+`--keep 0` disables pruning of the rotating `.bak-*` files for that run.
+
+## List
+
+```bash
+homer catalog list --config-path /etc/homer/homer.json
+```
+
+Output is tab-separated: path, size in bytes, UTC modification time, newest first.
+
+```
+/data/homer/homer_catalog.sqlite.bak-20260818T100000Z	184320	2026-08-18T10:00:00Z
+/data/homer/homer_catalog.sqlite.pre-restore-20260818T095500Z	183296	2026-08-18T09:55:00Z
+```
+
+`.pre-restore-*` files are the live catalog that `restore` moved aside. You can pass one to `--from` to undo a restore.
+
+## Restore
+
+Stop the Homer **writer** first. Restore takes the exclusive catalog lock (`<catalog>.lock`) and refuses if another writer still holds it. A read-only node with the catalog open will also fail (`catalog appears in use`).
+
+Without `--from`, restore picks the newest rotating `.bak-*` copy (not a `.pre-restore-*` file).
+
+```bash
+# Stop the writer, then:
+homer catalog restore --config-path /etc/homer/homer.json
+# catalog restore: /data/homer/homer_catalog.sqlite
+# previous catalog saved at: /data/homer/homer_catalog.sqlite.pre-restore-20260818T101500Z
+```
+
+What happens:
+
+1. Validates that `--from` looks like a DuckLake catalog (`ducklake_snapshot` / `ducklake_table` / `ducklake_data_file`).
+2. Takes the writer lock.
+3. Renames the live catalog plus `-wal`/`-shm` to `*.pre-restore-<timestamp>`.
+4. Writes the backup to the live path with `VACUUM INTO` (clean SQLite file, no WAL).
+5. If step 4 fails, the previous catalog is renamed back.
+
+Then start Homer again.
+
+## When to use what
+
+| Situation | Command |
+|-----------|---------|
+| About to run risky catalog maintenance | `homer catalog backup` (or `--out` off-box) |
+| Native merge left the catalog wrong, a `.bak-*` from before that cycle exists | `homer catalog restore` |
+| Catalog will not attach; parquet on disk is intact | `homer system --rebuild-catalog` |
+| Need the lake data itself off-box | Copy parquet (and the catalog) — this CLI is metadata only |
+
+## See also
+
+- [Storage layout](STORAGE_LAYOUT.md) — catalog file and parquet tree
+- [OOM / catalog recovery](OOM.md#recovering-a-corrupted-catalog) — auto-repair vs `--rebuild-catalog`
+- [Data retention](RETENTION.md) — snapshot expiration and compaction flags

--- a/docs/OOM.md
+++ b/docs/OOM.md
@@ -369,10 +369,17 @@ retention on. Only that partition is skipped — every other partition still
 compacts — and it becomes eligible again once the cutoff moves past it.
 
 Additionally, each native cycle takes a `VACUUM INTO` copy of the catalog first
-(keeping the last 3), and verifies afterwards that the catalog still has exactly
-one latest snapshot and no duplicate `snapshot_id`. If that check fails the
-native engine **switches itself off** until the process restarts and falls back
-to the DuckDB merge.
+(keeping the last 3 as `<catalog>.bak-<timestamp>`), and verifies afterwards that
+the catalog still has exactly one latest snapshot and no duplicate `snapshot_id`.
+If that check fails the native engine **switches itself off** until the process
+restarts and falls back to the DuckDB merge. To take an extra snapshot or rewind
+metadata from one of those copies, see [Catalog backup and restore](CATALOG.md):
+
+```bash
+homer catalog backup --config-path /etc/homer/config.json
+# stop the writer, then:
+homer catalog restore --config-path /etc/homer/config.json
+```
 
 ### Configuration
 
@@ -438,8 +445,18 @@ with:
 "storage": { "ducklake": { "auto_repair_catalog": false } }
 ```
 
-**If the autofix cannot recover it** (e.g. corruption beyond duplicate metadata
-rows), rebuild the catalog from disk. Stop the Homer writer, then run:
+**If a recent catalog snapshot is still valid** (compaction or `homer catalog backup`
+wrote a `.bak-*` copy before the bad cycle), stop the writer and restore it.
+See [Catalog backup and restore](CATALOG.md).
+
+```bash
+homer catalog list --config-path /etc/homer/config.json
+homer catalog restore --config-path /etc/homer/config.json --from homer_catalog.sqlite.bak-YYYYMMDDTHHMMSSZ
+```
+
+**If the autofix cannot recover it** and there is no usable backup (e.g. corruption
+beyond duplicate metadata rows), rebuild the catalog from disk. Stop the Homer
+writer, then run:
 
 ```bash
 homer system --config-path /etc/homer/config.json --rebuild-catalog

--- a/docs/STORAGE_LAYOUT.md
+++ b/docs/STORAGE_LAYOUT.md
@@ -69,6 +69,11 @@ SELECT column_name, partition_type FROM ducklake_partition_column WHERE table_id
 -- date, identity
 ```
 
+### Catalog backup and restore
+
+See **[Catalog backup and restore](CATALOG.md)** (`homer catalog backup` / `restore` / `list`).
+The catalog is metadata only; parquet is not copied.
+
 ## Tables by Protocol Type
 
 ### SIP (proto_type=1)
@@ -343,6 +348,7 @@ At 1000 SIP msg/sec:
 
 ## See Also
 
+- [Catalog backup and restore](CATALOG.md) — `homer catalog backup` / `restore` / `list`
 - [DuckLake README](../src/storage/ducklake/README.md) — DuckLake integration details
 - [STORAGE_ARCHITECTURE.md](STORAGE_ARCHITECTURE.md) — General architecture
 - [DuckLake Documentation](https://ducklake.select/docs/) — Official documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,11 +17,12 @@ ingest, DuckLake storage, Node (FlightSQL), and Coordinator (REST API).
 |-------|--------|
 | First-time setup | [Config wizard](WIZARD.md) |
 | CLI search | [Search CLI](SEARCH.md) |
+| Catalog backup / restore | [Catalog CLI](CATALOG.md) |
 | Dashboard search & mappings | [URL search](SEARCH_URL.md) · [External app Call-ID links](SEARCH_URL.md#external-apps) · [Mappings & fields](SEARCH_MAPPINGS_AND_FIELDS.md) |
 | REST API | [Coordinator](COORDINATOR.md) · [OpenAPI (Swagger)](swagger/index.html) |
 | Authentication & security | [Security hardening](SECURITY.md) · [LDAP & OAuth](AUTH_LDAP_AND_OAUTH.md) · [UI tokens](UI_COORDINATOR_AUTH_AND_TOKENS.md) |
 | Alerts & drill-down | [Dashboard alerts](ALERTS.md) · [URL search](SEARCH_URL.md) |
-| Storage | [Architecture](STORAGE_ARCHITECTURE.md) · [Policies](STORAGE_POLICIES.md) · [Retention](RETENTION.md) |
+| Storage | [Architecture](STORAGE_ARCHITECTURE.md) · [Layout](STORAGE_LAYOUT.md) · [Policies](STORAGE_POLICIES.md) · [Retention](RETENTION.md) · [Catalog backup](CATALOG.md) |
 | Performance | [Ingest tuning](INGEST_PERFORMANCE.md) · [DuckDB tuning](DUCKDB_TUNING.md) · [Troubleshooting](TROUBLESHOOTING.md) · [OOM](OOM.md) |
 | MCP / LLM | [MCP server](MCP.md) · [MCP UI guide](MCP_UI_GUIDE.md) |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
       - Config wizard: WIZARD.md
       - Environment variables: ENVIRONMENT_VARIABLES.md
       - Search CLI: SEARCH.md
+      - Catalog backup: CATALOG.md
       - Dashboard URL search: SEARCH_URL.md
       - Dashboard alerts: ALERTS.md
       - Search mappings & fields: SEARCH_MAPPINGS_AND_FIELDS.md

--- a/src/cli/catalog_cmd.go
+++ b/src/cli/catalog_cmd.go
@@ -1,0 +1,148 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sipcapture/homer-core/src/config"
+	"github.com/sipcapture/homer-core/src/storage/ducklake"
+)
+
+// CatalogFlags holds flags for the "homer catalog" subcommand.
+type CatalogFlags struct {
+	Action     string // backup | restore | list
+	ConfigPath string
+	Keep       int
+	Out        string
+	From       string
+}
+
+type catalogFlagRefs struct {
+	ConfigPath *string
+	Keep       *int
+	Out        *string
+	From       *string
+}
+
+// RegisterCatalogFlags creates a FlagSet for "homer catalog".
+func RegisterCatalogFlags() (*flag.FlagSet, *catalogFlagRefs) {
+	fs := flag.NewFlagSet("catalog", flag.ExitOnError)
+	refs := &catalogFlagRefs{}
+
+	refs.ConfigPath = fs.String("config-path", "", "path to config file or directory")
+	refs.Keep = fs.Int("keep", ducklake.DefaultCatalogBackupKeep,
+		"rotating `.bak-*` copies to retain (backup only; 0 = keep all)")
+	refs.Out = fs.String("out", "", "write backup to this path instead of a rotating `.bak-*` copy (backup only)")
+	refs.From = fs.String("from", "", "backup file to restore (restore only; default: newest copy next to the catalog)")
+
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `homer catalog [action] [flags]
+
+Snapshot and restore the DuckLake SQLite catalog (metadata only — parquet is not copied).
+
+Actions:
+  backup    Consistent VACUUM INTO snapshot (safe while Homer is running)
+  restore   Replace the live catalog from a backup (stop Homer first)
+  list      List rotating backups and pre-restore copies next to the catalog
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+	return fs, refs
+}
+
+// ParseCatalogFlags extracts CatalogFlags from parsed flag refs.
+func ParseCatalogFlags(refs *catalogFlagRefs) CatalogFlags {
+	return CatalogFlags{
+		ConfigPath: *refs.ConfigPath,
+		Keep:       *refs.Keep,
+		Out:        *refs.Out,
+		From:       *refs.From,
+	}
+}
+
+// RunCatalogCmd dispatches catalog backup / restore / list.
+func RunCatalogCmd(f CatalogFlags) error {
+	switch strings.ToLower(strings.TrimSpace(f.Action)) {
+	case "backup":
+		return runCatalogBackup(f)
+	case "restore":
+		return runCatalogRestore(f)
+	case "list":
+		return runCatalogList(f)
+	case "":
+		return fmt.Errorf("no catalog action specified; use backup, restore, or list")
+	default:
+		return fmt.Errorf("unknown catalog action %q; use backup, restore, or list", f.Action)
+	}
+}
+
+func catalogPathFromConfig(configPath string) (string, error) {
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to load config: %w", err)
+	}
+	path := strings.TrimSpace(duckLakeConfigFromModular(cfg).CatalogPath)
+	if path == "" {
+		return "", fmt.Errorf("no sqlite catalog_path in config")
+	}
+	return path, nil
+}
+
+func runCatalogBackup(f CatalogFlags) error {
+	catalogPath, err := catalogPathFromConfig(f.ConfigPath)
+	if err != nil {
+		return err
+	}
+
+	var dest string
+	if strings.TrimSpace(f.Out) != "" {
+		dest, err = ducklake.BackupCatalogTo(catalogPath, f.Out)
+	} else {
+		dest, err = ducklake.BackupCatalog(catalogPath, f.Keep)
+	}
+	if err != nil {
+		return err
+	}
+	fmt.Printf("catalog backup: %s\n", dest)
+	return nil
+}
+
+func runCatalogRestore(f CatalogFlags) error {
+	catalogPath, err := catalogPathFromConfig(f.ConfigPath)
+	if err != nil {
+		return err
+	}
+	previous, err := ducklake.RestoreCatalog(catalogPath, f.From)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("catalog restore: %s\n", catalogPath)
+	if previous != "" {
+		fmt.Printf("previous catalog saved at: %s\n", previous)
+	}
+	return nil
+}
+
+func runCatalogList(f CatalogFlags) error {
+	catalogPath, err := catalogPathFromConfig(f.ConfigPath)
+	if err != nil {
+		return err
+	}
+	list, err := ducklake.ListCatalogBackups(catalogPath)
+	if err != nil {
+		return err
+	}
+	if len(list) == 0 {
+		fmt.Printf("no catalog backups next to %s\n", catalogPath)
+		return nil
+	}
+	for _, b := range list {
+		fmt.Printf("%s\t%d\t%s\n", b.Path, b.Size, b.ModTime.UTC().Format(time.RFC3339))
+	}
+	return nil
+}

--- a/src/cli/catalog_cmd_test.go
+++ b/src/cli/catalog_cmd_test.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func writeCatalogTestConfig(t *testing.T, catalogPath string) string {
+	t.Helper()
+	cfg := filepath.Join(filepath.Dir(catalogPath), "homer.json")
+	body := `{
+  "storage": {
+    "enable": true,
+    "ducklake": {
+      "catalog_path": "` + catalogPath + `"
+    }
+  }
+}
+`
+	if err := os.WriteFile(cfg, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return cfg
+}
+
+func seedCLICatalog(t *testing.T, path string, rows int) {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE ducklake_snapshot(snapshot_id BIGINT PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < rows; i++ {
+		if _, err := db.Exec(`INSERT INTO ducklake_snapshot VALUES (?)`, i); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func countCLISnapshots(t *testing.T, path string) int {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM ducklake_snapshot`).Scan(&n); err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return n
+}
+
+func TestRunCatalogCmdBackupRestoreList(t *testing.T) {
+	dir := t.TempDir()
+	catalog := filepath.Join(dir, "homer_catalog.sqlite")
+	seedCLICatalog(t, catalog, 5)
+	cfg := writeCatalogTestConfig(t, catalog)
+
+	if err := RunCatalogCmd(CatalogFlags{Action: "backup", ConfigPath: cfg, Keep: 3}); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+
+	db, err := sql.Open("sqlite", "file:"+catalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO ducklake_snapshot VALUES (99)`); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+	if got := countCLISnapshots(t, catalog); got != 6 {
+		t.Fatalf("mutated catalog has %d rows, want 6", got)
+	}
+
+	if err := RunCatalogCmd(CatalogFlags{Action: "restore", ConfigPath: cfg}); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if got := countCLISnapshots(t, catalog); got != 5 {
+		t.Fatalf("restored catalog has %d rows, want 5", got)
+	}
+
+	if err := RunCatalogCmd(CatalogFlags{Action: "list", ConfigPath: cfg}); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+}
+
+func TestRunCatalogCmdBackupToOut(t *testing.T) {
+	dir := t.TempDir()
+	catalog := filepath.Join(dir, "homer_catalog.sqlite")
+	seedCLICatalog(t, catalog, 2)
+	cfg := writeCatalogTestConfig(t, catalog)
+	out := filepath.Join(dir, "offsite", "catalog.sqlite")
+
+	if err := RunCatalogCmd(CatalogFlags{Action: "backup", ConfigPath: cfg, Out: out}); err != nil {
+		t.Fatalf("backup --out: %v", err)
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Fatalf("expected --out file: %v", err)
+	}
+	if got := countCLISnapshots(t, out); got != 2 {
+		t.Fatalf("out catalog has %d rows, want 2", got)
+	}
+}
+
+func TestRunCatalogCmdUnknownAction(t *testing.T) {
+	err := RunCatalogCmd(CatalogFlags{Action: "explode"})
+	if err == nil || !strings.Contains(err.Error(), "unknown catalog action") {
+		t.Fatalf("got %v", err)
+	}
+	err = RunCatalogCmd(CatalogFlags{})
+	if err == nil || !strings.Contains(err.Error(), "no catalog action") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestParseCatalogFlags(t *testing.T) {
+	fs, refs := RegisterCatalogFlags()
+	if err := fs.Parse([]string{"--config-path", "/etc/homer/homer.json", "--keep", "0", "--from", "snap.sqlite"}); err != nil {
+		t.Fatal(err)
+	}
+	f := ParseCatalogFlags(refs)
+	if f.ConfigPath != "/etc/homer/homer.json" || f.Keep != 0 || f.From != "snap.sqlite" {
+		t.Fatalf("parsed flags: %+v", f)
+	}
+}

--- a/src/main.go
+++ b/src/main.go
@@ -41,13 +41,13 @@ import (
 	"github.com/sipcapture/homer-core/src/node"
 	"github.com/sipcapture/homer-core/src/otlpreceiver"
 	otlpsink "github.com/sipcapture/homer-core/src/otlpreceiver/sink"
-	"github.com/sipcapture/homer-core/src/siprecreceiver"
-	"github.com/sipcapture/homer-core/src/vqrtcpreceiver"
 	input "github.com/sipcapture/homer-core/src/server"
+	"github.com/sipcapture/homer-core/src/siprecreceiver"
 	"github.com/sipcapture/homer-core/src/storage/ducklake"
 	"github.com/sipcapture/homer-core/src/stream/hepstream"
 	logger "github.com/sipcapture/homer-core/src/utils/logging"
 	"github.com/sipcapture/homer-core/src/utils/metrics"
+	"github.com/sipcapture/homer-core/src/vqrtcpreceiver"
 	"github.com/sipcapture/homer-core/src/writer"
 
 	_ "net/http/pprof" // register /debug/pprof on DefaultServeMux when --pprof is set
@@ -121,6 +121,8 @@ func printUsage() {
 
 Usage:
   homer                         Run the server (default)
+  homer catalog [action] [flags]
+                                DuckLake catalog snapshot / restore / list
   homer search [flags]          Search Homer data via coordinator API
   homer cli [flags]             Interactive DuckLake SQL shell
   homer system [flags]          System operations (compaction, extensions, reload)
@@ -169,6 +171,15 @@ search -- Search Homer data via coordinator API:
   --exclude <pattern>           Post-filter: exclude rows matching pattern (e.g. "100,183")
   --interactive                 Launch interactive TUI mode
   --debug                       Print request/response to stderr
+
+catalog -- Snapshot / restore the DuckLake SQLite catalog (metadata only):
+  backup                        Consistent VACUUM INTO snapshot (safe while Homer is running)
+  restore                       Replace the live catalog from a backup (stop Homer first)
+  list                          List rotating backups and pre-restore copies
+  --config-path <path>          Path to config file or directory
+  --keep <n>                    Rotating `.bak-*` copies to retain (backup; default: 3; 0 = all)
+  --out <path>                  Write backup to this path instead of a rotating copy
+  --from <path>                 Backup to restore (default: newest copy next to the catalog)
 
 cli -- Interactive DuckLake SQL shell:
   --config-path <path>          Path to config file or directory
@@ -398,6 +409,22 @@ func main() {
 		sf := cli.ParseSearchFlags(refs)
 		if err := cli.RunSearch(sf); err != nil {
 			fmt.Fprintf(os.Stderr, "Search error: %v\n", err)
+			os.Exit(1)
+		}
+
+	case "catalog":
+		action := ""
+		args := os.Args[2:]
+		if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+			action = args[0]
+			args = args[1:]
+		}
+		fs, refs := cli.RegisterCatalogFlags()
+		fs.Parse(args)
+		cf := cli.ParseCatalogFlags(refs)
+		cf.Action = action
+		if err := cli.RunCatalogCmd(cf); err != nil {
+			fmt.Fprintf(os.Stderr, "Catalog error: %v\n", err)
 			os.Exit(1)
 		}
 

--- a/src/storage/ducklake/backup.go
+++ b/src/storage/ducklake/backup.go
@@ -17,18 +17,49 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-// catalogBackupSuffix marks the copies BackupCatalog creates.
+// catalogBackupSuffix marks the rotating copies BackupCatalog creates.
 const catalogBackupSuffix = ".bak-"
+
+// catalogPreRestoreSuffix marks the live catalog moved aside by RestoreCatalog.
+const catalogPreRestoreSuffix = ".pre-restore-"
+
+// DefaultCatalogBackupKeep is how many rotating VACUUM INTO copies to retain.
+// Used by native compaction and by `homer catalog backup` when --keep is omitted.
+const DefaultCatalogBackupKeep = 3
+
+// CatalogBackup describes one catalog snapshot next to the live catalog file.
+type CatalogBackup struct {
+	Path    string
+	Size    int64
+	ModTime time.Time
+}
 
 // BackupCatalog writes a consistent snapshot of the DuckLake SQLite catalog with
 // VACUUM INTO and keeps only the newest keep copies. VACUUM INTO runs inside a
 // read transaction, so it is safe while DuckDB has the catalog attached and does
 // not block writers on a WAL database.
 //
+// keep <= 0 disables pruning. Otherwise all but the newest keep `.bak-*` copies
+// next to the catalog are deleted.
+//
 // It is a cheap insurance policy for maintenance that rewrites catalog rows: the
 // catalog is metadata only (kilobytes to a few megabytes), while the parquet it
 // describes is not copied.
 func BackupCatalog(catalogPath string, keep int) (string, error) {
+	return backupCatalog(catalogPath, "", keep)
+}
+
+// BackupCatalogTo writes a consistent snapshot to dest (VACUUM INTO). dest is
+// not rotated with the `.bak-*` copies.
+func BackupCatalogTo(catalogPath, dest string) (string, error) {
+	dest = strings.TrimSpace(dest)
+	if dest == "" {
+		return "", fmt.Errorf("no backup destination")
+	}
+	return backupCatalog(catalogPath, dest, 0)
+}
+
+func backupCatalog(catalogPath, dest string, keep int) (string, error) {
 	if strings.TrimSpace(catalogPath) == "" {
 		return "", fmt.Errorf("no catalog path")
 	}
@@ -44,7 +75,17 @@ func BackupCatalog(catalogPath string, keep int) (string, error) {
 	db.SetMaxOpenConns(1)
 	defer db.Close()
 
-	dest := catalogPath + catalogBackupSuffix + time.Now().UTC().Format("20060102T150405Z")
+	prune := dest == ""
+	if dest == "" {
+		dest = catalogPath + catalogBackupSuffix + time.Now().UTC().Format("20060102T150405Z")
+	} else {
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return "", fmt.Errorf("create backup directory: %w", err)
+		}
+		if abs, err := filepath.Abs(dest); err == nil {
+			dest = abs
+		}
+	}
 	// VACUUM INTO refuses to overwrite, so a stale file from the same second
 	// would fail the backup.
 	_ = os.Remove(dest)
@@ -52,7 +93,9 @@ func BackupCatalog(catalogPath string, keep int) (string, error) {
 		return "", fmt.Errorf("vacuum into %s: %w", dest, err)
 	}
 
-	pruneCatalogBackups(catalogPath, keep)
+	if prune {
+		pruneCatalogBackups(catalogPath, keep)
+	}
 	return dest, nil
 }
 
@@ -63,9 +106,10 @@ func sqliteQuoteLiteral(s string) string {
 
 // pruneCatalogBackups deletes all but the newest keep backups of a catalog.
 // Names embed a sortable UTC timestamp, so lexical order is chronological.
+// keep <= 0 leaves every `.bak-*` copy in place.
 func pruneCatalogBackups(catalogPath string, keep int) {
 	if keep < 1 {
-		keep = 1
+		return
 	}
 	dir := filepath.Dir(catalogPath)
 	prefix := filepath.Base(catalogPath) + catalogBackupSuffix
@@ -86,4 +130,232 @@ func pruneCatalogBackups(catalogPath string, keep int) {
 	for _, name := range backups[:len(backups)-keep] {
 		_ = os.Remove(filepath.Join(dir, name))
 	}
+}
+
+// ListCatalogBackups returns rotating `.bak-*` copies and `.pre-restore-*`
+// aside files next to catalogPath, newest first.
+func ListCatalogBackups(catalogPath string) ([]CatalogBackup, error) {
+	if strings.TrimSpace(catalogPath) == "" {
+		return nil, fmt.Errorf("no catalog path")
+	}
+	dir := filepath.Dir(catalogPath)
+	if dir == "" {
+		dir = "."
+	}
+	base := filepath.Base(catalogPath)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []CatalogBackup
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasPrefix(name, base+catalogBackupSuffix) &&
+			!strings.HasPrefix(name, base+catalogPreRestoreSuffix) {
+			continue
+		}
+		// Sidecars of the aside file (-wal/-shm) are not restore sources.
+		if strings.HasSuffix(name, "-wal") || strings.HasSuffix(name, "-shm") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		out = append(out, CatalogBackup{
+			Path:    filepath.Join(dir, name),
+			Size:    info.Size(),
+			ModTime: info.ModTime(),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].ModTime.Equal(out[j].ModTime) {
+			return out[i].ModTime.After(out[j].ModTime)
+		}
+		return out[i].Path > out[j].Path
+	})
+	return out, nil
+}
+
+// RestoreCatalog replaces the live SQLite catalog with backupPath (VACUUM INTO).
+// The writer must be stopped: this takes the exclusive catalog lock and refuses
+// if another homer writer holds it. The previous catalog (plus -wal/-shm) is
+// renamed to `<catalog>.pre-restore-<timestamp>` so the restore is reversible.
+//
+// backupPath may be absolute, relative to the current directory, or a basename
+// next to the live catalog. An empty backupPath selects the newest listed copy.
+//
+// Parquet data is not copied; restore only rewinds catalog metadata.
+func RestoreCatalog(catalogPath, backupPath string) (previous string, err error) {
+	if strings.TrimSpace(catalogPath) == "" {
+		return "", fmt.Errorf("no catalog path")
+	}
+	backupPath, err = resolveCatalogBackupPath(catalogPath, backupPath)
+	if err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(backupPath); err != nil {
+		return "", fmt.Errorf("stat backup: %w", err)
+	}
+	if samePath(catalogPath, backupPath) {
+		return "", fmt.Errorf("backup path %q is the live catalog; refuse to restore a file onto itself", backupPath)
+	}
+	if err := validateDuckLakeCatalogFile(backupPath); err != nil {
+		return "", err
+	}
+
+	lock, err := acquireCatalogWriterLock(catalogPath)
+	if err != nil {
+		return "", fmt.Errorf("restore: %w", err)
+	}
+	defer releaseCatalogWriterLock(lock)
+
+	if err := assertCatalogIdle(catalogPath); err != nil {
+		return "", err
+	}
+
+	renamed, err := asideCatalogFiles(catalogPath, catalogPreRestoreSuffix)
+	if err != nil {
+		return "", fmt.Errorf("move live catalog aside: %w", err)
+	}
+	for _, pair := range renamed {
+		if pair[0] == catalogPath {
+			previous = pair[1]
+			break
+		}
+	}
+
+	if err := vacuumCatalogInto(backupPath, catalogPath); err != nil {
+		undoCatalogRenames(renamed)
+		return "", fmt.Errorf("restore catalog (previous catalog put back): %w", err)
+	}
+	return previous, nil
+}
+
+func resolveCatalogBackupPath(catalogPath, from string) (string, error) {
+	from = strings.TrimSpace(from)
+	if from == "" {
+		list, err := ListCatalogBackups(catalogPath)
+		if err != nil {
+			return "", err
+		}
+		prefix := filepath.Base(catalogPath) + catalogBackupSuffix
+		for _, b := range list {
+			if strings.HasPrefix(filepath.Base(b.Path), prefix) {
+				return b.Path, nil
+			}
+		}
+		return "", fmt.Errorf("no catalog backups next to %s; run `homer catalog backup` first or pass --from", catalogPath)
+	}
+	if filepath.IsAbs(from) {
+		return from, nil
+	}
+	if _, err := os.Stat(from); err == nil {
+		if abs, err := filepath.Abs(from); err == nil {
+			return abs, nil
+		}
+		return from, nil
+	}
+	candidate := filepath.Join(filepath.Dir(catalogPath), from)
+	if _, err := os.Stat(candidate); err == nil {
+		return candidate, nil
+	}
+	return "", fmt.Errorf("backup not found: %s", from)
+}
+
+func validateDuckLakeCatalogFile(path string) error {
+	dsn := fmt.Sprintf("file:%s?mode=ro", path)
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return fmt.Errorf("open backup: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	defer db.Close()
+
+	var n int
+	q := `SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name IN ('ducklake_snapshot','ducklake_table','ducklake_data_file')`
+	if err := db.QueryRow(q).Scan(&n); err != nil {
+		return fmt.Errorf("read backup %s: %w", path, err)
+	}
+	if n == 0 {
+		return fmt.Errorf("%s does not look like a DuckLake catalog (missing ducklake_* tables)", path)
+	}
+	return nil
+}
+
+func assertCatalogIdle(catalogPath string) error {
+	if _, err := os.Stat(catalogPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat catalog: %w", err)
+	}
+	dsn := fmt.Sprintf("file:%s?_pragma=busy_timeout(2000)", catalogPath)
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return fmt.Errorf("open catalog: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	defer db.Close()
+	if _, err := db.Exec("BEGIN EXCLUSIVE"); err != nil {
+		return fmt.Errorf("catalog appears in use (stop homer-core first): %w", err)
+	}
+	_, _ = db.Exec("ROLLBACK")
+	return nil
+}
+
+func vacuumCatalogInto(src, dest string) error {
+	dsn := fmt.Sprintf("file:%s?mode=ro", src)
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return fmt.Errorf("open backup: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	defer db.Close()
+	_ = os.Remove(dest)
+	if _, err := db.Exec(fmt.Sprintf("VACUUM INTO %s", sqliteQuoteLiteral(dest))); err != nil {
+		return fmt.Errorf("vacuum into %s: %w", dest, err)
+	}
+	return nil
+}
+
+// asideCatalogFiles renames the catalog and its -wal/-shm sidecars to
+// `<path><suffix><timestamp>`. Returns src→dst pairs that were moved.
+func asideCatalogFiles(catalogPath, suffix string) ([][2]string, error) {
+	tag := suffix + time.Now().UTC().Format("20060102T150405Z")
+	var renamed [][2]string
+	for _, ext := range []string{"", "-wal", "-shm"} {
+		src := catalogPath + ext
+		if _, err := os.Stat(src); err != nil {
+			continue
+		}
+		dst := catalogPath + tag + ext
+		if err := os.Rename(src, dst); err != nil {
+			undoCatalogRenames(renamed)
+			return nil, fmt.Errorf("rename %s -> %s: %w", src, dst, err)
+		}
+		renamed = append(renamed, [2]string{src, dst})
+	}
+	return renamed, nil
+}
+
+func undoCatalogRenames(renamed [][2]string) {
+	for i := len(renamed) - 1; i >= 0; i-- {
+		_ = os.Rename(renamed[i][1], renamed[i][0])
+	}
+}
+
+func samePath(a, b string) bool {
+	absA, errA := filepath.Abs(a)
+	absB, errB := filepath.Abs(b)
+	if errA != nil || errB != nil {
+		return filepath.Clean(a) == filepath.Clean(b)
+	}
+	return absA == absB
 }

--- a/src/storage/ducklake/backup_test.go
+++ b/src/storage/ducklake/backup_test.go
@@ -100,3 +100,182 @@ func TestBackupCatalogMissingFile(t *testing.T) {
 		t.Error("expected an error for an empty path")
 	}
 }
+
+func TestBackupCatalogKeepZeroRetainsAll(t *testing.T) {
+	dir := t.TempDir()
+	catalog := filepath.Join(dir, "catalog.sqlite")
+	newTestCatalog(t, catalog, 2)
+
+	for i := 0; i < 3; i++ {
+		dest, err := BackupCatalog(catalog, 0)
+		if err != nil {
+			t.Fatalf("BackupCatalog #%d: %v", i, err)
+		}
+		renameForDistinctTimestamp(t, dest, i)
+	}
+	list, err := ListCatalogBackups(catalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 3 {
+		t.Fatalf("keep=0 retained %d backups, want 3", len(list))
+	}
+}
+
+func TestBackupCatalogToCustomPath(t *testing.T) {
+	dir := t.TempDir()
+	catalog := filepath.Join(dir, "catalog.sqlite")
+	newTestCatalog(t, catalog, 4)
+	dest := filepath.Join(dir, "copies", "manual.sqlite")
+	got, err := BackupCatalogTo(catalog, dest)
+	if err != nil {
+		t.Fatalf("BackupCatalogTo: %v", err)
+	}
+	if got != dest {
+		if abs, _ := filepath.Abs(dest); got != abs {
+			t.Fatalf("dest = %q, want %q", got, dest)
+		}
+	}
+	assertSnapshotCount(t, got, 4)
+}
+
+func TestRestoreCatalogRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	catalog := filepath.Join(dir, "catalog.sqlite")
+	newTestCatalog(t, catalog, 7)
+
+	backup, err := BackupCatalog(catalog, 3)
+	if err != nil {
+		t.Fatalf("BackupCatalog: %v", err)
+	}
+
+	// Mutate the live catalog after the snapshot.
+	db, err := sql.Open("sqlite", "file:"+catalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO ducklake_snapshot VALUES (99)`); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+	assertSnapshotCount(t, catalog, 8)
+
+	previous, err := RestoreCatalog(catalog, backup)
+	if err != nil {
+		t.Fatalf("RestoreCatalog: %v", err)
+	}
+	if previous == "" {
+		t.Fatal("expected previous catalog path")
+	}
+	assertSnapshotCount(t, catalog, 7)
+	assertSnapshotCount(t, previous, 8)
+}
+
+func TestRestoreCatalogNewestWhenFromEmpty(t *testing.T) {
+	dir := t.TempDir()
+	catalog := filepath.Join(dir, "catalog.sqlite")
+	newTestCatalog(t, catalog, 1)
+	if _, err := BackupCatalog(catalog, 3); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", "file:"+catalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO ducklake_snapshot VALUES (1)`); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+
+	if _, err := RestoreCatalog(catalog, ""); err != nil {
+		t.Fatalf("RestoreCatalog newest: %v", err)
+	}
+	assertSnapshotCount(t, catalog, 1)
+}
+
+func TestRestoreCatalogRejectsNonCatalog(t *testing.T) {
+	dir := t.TempDir()
+	catalog := filepath.Join(dir, "catalog.sqlite")
+	newTestCatalog(t, catalog, 1)
+	junk := filepath.Join(dir, "junk.sqlite")
+	db, err := sql.Open("sqlite", "file:"+junk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE t(x INT)`); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+
+	if _, err := RestoreCatalog(catalog, junk); err == nil {
+		t.Fatal("expected error for a non-DuckLake sqlite file")
+	}
+	assertSnapshotCount(t, catalog, 1)
+}
+
+func TestRestoreCatalogRefusesWriterLock(t *testing.T) {
+	dir := t.TempDir()
+	catalog := filepath.Join(dir, "catalog.sqlite")
+	newTestCatalog(t, catalog, 1)
+	backup, err := BackupCatalog(catalog, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lock, err := acquireCatalogWriterLock(catalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseCatalogWriterLock(lock)
+
+	if _, err := RestoreCatalog(catalog, backup); err == nil {
+		t.Fatal("expected error while the writer lock is held")
+	}
+}
+
+func TestRestoreCatalogRefusesLivePath(t *testing.T) {
+	dir := t.TempDir()
+	catalog := filepath.Join(dir, "catalog.sqlite")
+	newTestCatalog(t, catalog, 1)
+	if _, err := RestoreCatalog(catalog, catalog); err == nil {
+		t.Fatal("expected error restoring the live catalog onto itself")
+	}
+}
+
+func TestListCatalogBackupsNewestFirst(t *testing.T) {
+	dir := t.TempDir()
+	catalog := filepath.Join(dir, "catalog.sqlite")
+	newTestCatalog(t, catalog, 1)
+	for i := 0; i < 2; i++ {
+		dest, err := BackupCatalog(catalog, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		renameForDistinctTimestamp(t, dest, i)
+	}
+	list, err := ListCatalogBackups(catalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("got %d backups, want 2", len(list))
+	}
+	if list[0].Path < list[1].Path {
+		t.Fatalf("expected newest-first order: %q then %q", list[0].Path, list[1].Path)
+	}
+}
+
+func assertSnapshotCount(t *testing.T, path string, want int) {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM ducklake_snapshot`).Scan(&n); err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if n != want {
+		t.Fatalf("%s holds %d snapshot rows, want %d", path, n, want)
+	}
+}

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.321"
+	VERSION_APPLICATION = "11.0.322"
 
 	// BuildDate is the build date
 	BuildDate = ""

--- a/src/writer/compaction.go
+++ b/src/writer/compaction.go
@@ -169,10 +169,6 @@ type CatalogLocker interface {
 	CatalogUnlock()
 }
 
-// nativeCatalogBackupsKept is how many VACUUM INTO copies of the catalog the
-// native engine retains before each cycle.
-const nativeCatalogBackupsKept = 3
-
 // CompactionS3Client holds DuckDB httpfs S3 settings for maintenance calls that
 // read s3:// objects (ducklake_cleanup_old_files / ducklake_delete_orphaned_files).
 // Some DuckLake versions appear to evaluate read_blob without inheriting prior
@@ -802,7 +798,7 @@ func (c *CompactionService) runNativeMerge(tables []string) error {
 	// metadata only, so a copy costs little and makes a bad cycle recoverable.
 	if path := strings.TrimSpace(c.catalogPath); path != "" {
 		c.withCatalogLock(func() {
-			dest, err := ducklake.BackupCatalog(path, nativeCatalogBackupsKept)
+			dest, err := ducklake.BackupCatalog(path, ducklake.DefaultCatalogBackupKeep)
 			if err != nil {
 				logger.Warn("CompactionService: catalog backup before native merge failed",
 					"lake", c.lakeName, "error", err)


### PR DESCRIPTION
## Summary
- Add `homer catalog backup` / `restore` / `list` for the DuckLake SQLite catalog (metadata only; parquet is not copied).
- Backup uses the same online-safe `VACUUM INTO` path as native compaction; restore takes the writer lock, moves the live catalog aside as `.pre-restore-*`, and refuses if Homer is still attached.
- Document the CLI in `docs/CATALOG.md` and bump `VERSION_APPLICATION` to **11.0.322**.

## Test plan
- [x] `go test ./src/storage/ducklake/ ./src/cli/ ./src/writer/`
- [x] `homer catalog backup --config-path …` while the writer is running; confirm a `.bak-*` file appears
- [x] `homer catalog list --config-path …`
- [x] Stop the writer, `homer catalog restore --config-path …`, start again and query the lake
- [x] Confirm restore refuses while Homer still holds `<catalog>.lock`
- [x] `homer catalog --help` / `homer help` show the new subcommand