### PR TITLE
Fix QoS RTP/RTCP axis time formatting when dashboard timezone is set to local.

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -177,7 +177,7 @@ catalog -- Snapshot / restore the DuckLake SQLite catalog (metadata only):
   restore                       Replace the live catalog from a backup (stop Homer first)
   list                          List rotating backups and pre-restore copies
   --config-path <path>          Path to config file or directory
-  --keep <n>                    Rotating `.bak-*` copies to retain (backup; default: 3; 0 = all)
+  --keep <n>                    Rotating .bak-* copies to retain (backup; default: 3; 0 = all)
   --out <path>                  Write backup to this path instead of a rotating copy
   --from <path>                 Backup to restore (default: newest copy next to the catalog)
 

--- a/src/ui/src/dashboard/QosPanel.test.ts
+++ b/src/ui/src/dashboard/QosPanel.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { formatAxisTime } from './QosPanel'
+
+const axisOptions = {
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+} satisfies Intl.DateTimeFormatOptions
+
+describe('formatAxisTime', () => {
+  it('uses the browser/runtime timezone when local is selected', () => {
+    const date = new Date('2026-08-17T11:30:04Z')
+    const unixSec = date.getTime() / 1000
+
+    expect(formatAxisTime(unixSec, 'local', 'fr-FR')).toBe(
+      new Intl.DateTimeFormat('fr-FR', axisOptions).format(date),
+    )
+  })
+
+  it('uses an explicit timezone when one is selected', () => {
+    const date = new Date('2026-08-17T11:30:04Z')
+    const unixSec = date.getTime() / 1000
+
+    expect(formatAxisTime(unixSec, 'UTC', 'fr-FR')).toBe(
+      new Intl.DateTimeFormat('fr-FR', { ...axisOptions, timeZone: 'UTC' }).format(date),
+    )
+  })
+})

--- a/src/ui/src/dashboard/QosPanel.tsx
+++ b/src/ui/src/dashboard/QosPanel.tsx
@@ -7,6 +7,7 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { cn } from '@/lib/utils'
 import { qosRouteArrow } from '@/lib/ipAliasDisplay'
 import { useLocale } from '@/components/locale/locale-provider'
+import { makeDateTimeFormatter } from '@/lib/datetime'
 
 const METRIC_COLORS_RTCP = {
   packets:       { bg: 'rgba(244, 67, 54, 0.5)',  border: 'rgba(244, 67, 54, 1)' },
@@ -110,7 +111,7 @@ function eventTimeMs(row) {
   return 0
 }
 
-function formatAxisTime(unixSec, timeZone, locale) {
+export function formatAxisTime(unixSec, timeZone, locale) {
   const ms = unixSec * 1000
   if (!Number.isFinite(ms)) return '—'
   const opts = {
@@ -119,11 +120,7 @@ function formatAxisTime(unixSec, timeZone, locale) {
     second: 'numeric',
   }
   try {
-    if (timeZone && timeZone !== 'local') {
-      return new Intl.DateTimeFormat(locale, { ...opts, timeZone }).format(new Date(ms))
-    }
-    const d = new Date(ms)
-    return `${String(d.getUTCHours()).padStart(2, '0')}:${String(d.getUTCMinutes()).padStart(2, '0')}:${String(d.getUTCSeconds()).padStart(2, '0')}`
+    return makeDateTimeFormatter(locale, opts, timeZone).format(new Date(ms))
   } catch {
     return '—'
   }


### PR DESCRIPTION
QoS was showing UTC time instead of the browser’s local time. It now uses the same date formatting logic as Messages.