### PR TITLE
chore: bump version to 11.0.323

### DIFF
--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.322"
+	VERSION_APPLICATION = "11.0.323"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Bump `VERSION_APPLICATION` to 11.0.323 for the QoS local-timezone fix and catalog backup/restore that landed after 11.0.321.

## Test plan
- [ ] Release `11.0.323` from `homer11` after merge