### PR TITLE
feat(ui): show RTCP reports inline in the Call Flow ladder

### DIFF
--- a/src/ui/src/dashboard/TransactionModal.tsx
+++ b/src/ui/src/dashboard/TransactionModal.tsx
@@ -35,6 +35,7 @@ import { useLocale } from '@/components/locale/locale-provider'
 import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react'
 import { getMethodColor } from './flow-utils'
 import { resolveTimeRange } from './utils/resolveTimeRange'
+import { hepProtoTypeOf, mergeFlowMessagesByTimestamp, tagHepProtoType } from './flow/hep-proto'
 
 /** SIP / transaction message row: DuckLake uses method + response_code, not `event`. */
 function messageCallId(row) {
@@ -620,6 +621,7 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
   const [messageModals, setMessageModals] = React.useState([])
   const [msgSortCol, setMsgSortCol] = React.useState(null)
   const [msgSortDir, setMsgSortDir] = React.useState('asc')
+  const [rtcpItems, setRtcpItems] = React.useState([])
 
   // reset per-tab state whenever a new transaction is opened
   React.useEffect(() => {
@@ -632,6 +634,7 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
     setMessageModals([])
     setMsgSortCol(null)
     setMsgSortDir('asc')
+    setRtcpItems([])
   }, [modal?.modalKey])
 
   React.useEffect(() => {
@@ -647,6 +650,33 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
   const sessionIdsForApi = (Array.isArray(sessionIds) && sessionIds.length)
     ? sessionIds.map((s) => String(s).trim()).filter(Boolean)
     : (primaryId ? [String(primaryId).trim()] : [])
+
+  const sipProtoType = Number(modal?.protoType || 1) || 1
+  const sessionKey = sessionIdsForApi.join('\0')
+
+  React.useEffect(() => {
+    if (sipProtoType !== 1 || loading || !sessionKey) return
+    let cancelled = false
+    ;(async () => {
+      try {
+        const body = buildTransactionTabBody(sessionIdsForApi, items, timeRange, timeZone, {
+          proto_type: 5,
+          event_type: 'default',
+        })
+        const data = await apiPost('/transactions/messages', body)
+        if (!cancelled) setRtcpItems(data?.data?.items || [])
+      } catch {
+        if (!cancelled) setRtcpItems([])
+      }
+    })()
+    return () => { cancelled = true }
+  }, [modalKey, loading, sipProtoType, items, timeRange, timeZone, sessionKey])
+
+  const flowItems = React.useMemo(() => {
+    const sipTagged = tagHepProtoType(items || [], sipProtoType)
+    if (sipProtoType !== 1) return sipTagged
+    return mergeFlowMessagesByTimestamp(sipTagged, tagHepProtoType(rtcpItems, 5))
+  }, [items, rtcpItems, sipProtoType])
 
   const messageRowsIndexed = React.useMemo(
     () => (items || []).map((row, orig) => ({ row, orig })),
@@ -758,9 +788,11 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
       : (flowItem.captureId != null && String(flowItem.captureId).trim() !== ''
         ? String(flowItem.captureId).trim()
         : undefined)
+    const protoType = hepProtoTypeOf(raw) || 1
+    const eventType = protoType === 1 ? 'call' : 'default'
     const messageContext = {
-      proto_type: 1,
-      event_type: 'call',
+      proto_type: protoType,
+      event_type: eventType,
       timestamp: (() => {
         const ts = resolveTimeRange(timeRange, timeZone)
         return ts ? { from: ts.from, to: ts.to } : undefined
@@ -777,7 +809,7 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
     }
     setMessageModals(prev => [...prev, { modalKey: nestedKey, uuid, loading: true, data: null, error: null, messageContext }])
     try {
-      const body = { uuid, proto_type: 1, event_type: 'call' }
+      const body = { uuid, proto_type: protoType, event_type: eventType }
       if (messageContext.timestamp) body.timestamp = messageContext.timestamp
       const result = await apiPost('/messages', body)
       update({ modalKey: nestedKey, uuid, loading: false, data: result?.data || raw, error: null, messageContext })
@@ -916,7 +948,7 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
 
               <TabsContent value="flow" className="min-h-0 min-w-0 flex-1 overflow-hidden px-4 pb-4">
                 <div className="h-full w-full min-w-0 overflow-auto border border-border bg-card/40">
-                  <CallFlow items={items} timeZone={timeZone} onClickMessage={handleFlowMessageClick} />
+                  <CallFlow items={flowItems} timeZone={timeZone} onClickMessage={handleFlowMessageClick} />
                 </div>
               </TabsContent>
 

--- a/src/ui/src/dashboard/flow-utils.ts
+++ b/src/ui/src/dashboard/flow-utils.ts
@@ -98,6 +98,8 @@ export function getMethodColor(str: unknown): string {
     color = 'hsla(227.5, 82.4%, 51%, 1)'
   } else if (raw === 'BYE' || raw === 'CANCEL') {
     color = 'hsla(120, 100%, 25%, 1)'
+  } else if (raw.startsWith('RTCP')) {
+    color = 'hsla(187, 72%, 38%, 1)'
   } else {
     const code = Number(raw)
     if (Number.isFinite(code)) {

--- a/src/ui/src/dashboard/flow/FilterPanel.tsx
+++ b/src/ui/src/dashboard/flow/FilterPanel.tsx
@@ -96,6 +96,14 @@ export function FilterPanel({
                   onCheckedChange={(v) => setFilters((p) => ({ ...p, isHighContrast: !!v }))}
                 />
               </div>
+              <div className="callflow-filter-row">
+                <Label htmlFor="flow-rtcp">RTCP</Label>
+                <Switch
+                  id="flow-rtcp"
+                  checked={filters.showRtcp}
+                  onCheckedChange={(v) => setFilters((p) => ({ ...p, showRtcp: !!v }))}
+                />
+              </div>
               {canConsolidateCaptureIds ? (
                 <>
                   <div className="callflow-filter-row">

--- a/src/ui/src/dashboard/flow/flow-data.test.ts
+++ b/src/ui/src/dashboard/flow/flow-data.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   buildFlow, buildHosts, endpointAlias, hostKey, hostKeyFromMessage,
   runtimeFingerprintOf, captureIdOf, consolidateFlowItems, canConsolidateFlowItems,
+  payloadTypeOf,
 } from './flow-data'
 import type { FlowItemData, RawMessage } from './flow-data'
 
@@ -235,5 +236,49 @@ describe('canConsolidateFlowItems', () => {
       makeFlowItem({ id: 'a', captureId: '', runtimeFingerprint: 'fp1' }),
       makeFlowItem({ id: 'b', captureId: '1002', runtimeFingerprint: '' }),
     ])).toBe(false)
+  })
+})
+
+describe('payloadTypeOf', () => {
+  it('treats untagged UDP SIP (IP protocol 17) as SIP', () => {
+    expect(payloadTypeOf({ protocol: 17, method: 'INVITE' })).toBe('SIP')
+  })
+
+  it('classifies HEP proto 5 as RTCP even when protocol is UDP 17', () => {
+    expect(payloadTypeOf({ protocol: 17, hep_proto_type: 5 })).toBe('RTCP')
+  })
+
+  it('reads proto_type from data_extra', () => {
+    expect(payloadTypeOf({ protocol: 17, data_extra: { proto_type: 5 } })).toBe('RTCP')
+  })
+})
+
+describe('buildFlow RTCP rows', () => {
+  it('uses compact RTCP labels and a dotted arrow', () => {
+    const { flowItems } = buildFlow(
+      [
+        {
+          uuid: 'sr1',
+          src_ip: '10.0.0.1',
+          dst_ip: '10.0.0.2',
+          src_port: 4000,
+          dst_port: 4001,
+          protocol: 17,
+          session_id: 'c1',
+          timestamp: new Date('2026-01-01T12:00:00.000Z').getTime(),
+          hep_proto_type: 5,
+          payload: JSON.stringify({
+            type: 200,
+            report_blocks: [{ ia_jitter: 9, fraction_lost: 0 }],
+          }),
+        },
+      ],
+      { grouping: 'ungrouped' },
+    )
+    expect(flowItems).toHaveLength(1)
+    expect(flowItems[0].method).toBe('RTCP SR')
+    expect(flowItems[0].description).toBe('jitter=9 loss=0%')
+    expect(flowItems[0].payloadType).toBe('RTCP')
+    expect(flowItems[0].arrowStyleSolid).toBe(false)
   })
 })

--- a/src/ui/src/dashboard/flow/flow-data.ts
+++ b/src/ui/src/dashboard/flow/flow-data.ts
@@ -7,6 +7,8 @@ import {
   displaySrcIp,
   qosRouteArrow,
 } from '@/lib/ipAliasDisplay'
+import { hepProtoTypeOf } from './hep-proto'
+import { computeRtcpFlowLabels } from './rtcp-flow-label'
 import { computeSipFlowLabels } from './sip-flow-label'
 
 export interface RawMessage {
@@ -170,18 +172,20 @@ export function protoLabelOf(proto: string | number | undefined): string {
   return ''
 }
 
+/**
+ * Ladder payload kind from HEP proto_type (tagged `hep_proto_type` / data_extra).
+ * The `protocol` column is IP transport (UDP=17) and must not be used here.
+ * Untagged rows default to SIP so existing SIP-only ladders keep working.
+ */
 export function payloadTypeOf(msg: RawMessage): string {
-  const p = String(msg.protocol ?? '')
-  if (p === '1' || p === 'sip' || p === 'SIP' || p === '17') return 'SIP'
-  if (p === '6' || p === '2') return 'TCP'
-  if (p === '3') return 'WSS'
-  if (p === '22') return 'TLS'
-  if (p === '5') return 'RTP'
-  if (p === '34' || p === '35') return 'RTCP'
-  if (p === '38') return 'DTMF'
-  if (p === '100') return 'LOG'
-  if (msg.sip_method || msg.method) return 'SIP'
-  return 'OTHER'
+  const hep = hepProtoTypeOf(msg)
+  if (hep === 5 || hep === 34) return 'RTCP'
+  if (hep === 35) return 'RTP'
+  if (hep === 38) return 'DTMF'
+  if (hep === 100) return 'LOG'
+  if (hep === 1) return 'SIP'
+  if (hep != null) return 'OTHER'
+  return 'SIP'
 }
 
 function parseJSONLike(value: unknown): Record<string, unknown> | null {
@@ -559,6 +563,7 @@ export function buildFlow(items: RawMessage[] | null | undefined, opts: BuildOpt
 
     let method = msg.sip_method || msg.method || msg.event || ''
     const proto = msg.protocol
+    const payloadType = payloadTypeOf(msg)
 
     const srcIdx = indexOfHost(hosts, msg, 'src', grouping)
     const dstIdx = indexOfHost(hosts, msg, 'dst', grouping)
@@ -574,10 +579,7 @@ export function buildFlow(items: RawMessage[] | null | undefined, opts: BuildOpt
     const direction = isLastHost || a > b
     const rightEnd = singleHost ? 0 : hosts.length - 1 - Math.max(a, b)
 
-    const protoStr = String(proto ?? '')
-    const isSIP =
-      !protoStr || protoStr === '1' || protoStr === '17' || protoStr === 'sip' || protoStr === 'SIP'
-    const arrowStyleSolid = isSIP
+    const arrowStyleSolid = payloadType === 'SIP'
 
     const date = parseTs(msg.timestamp ?? msg.create_ts)
     const ts = date ? date.getTime() : 0
@@ -593,7 +595,11 @@ export function buildFlow(items: RawMessage[] | null | undefined, opts: BuildOpt
       qosRouteArrow(msg as Record<string, unknown>) ||
       `${displaySrcIp(msg as Record<string, unknown>)} \u2192 ${displayDstIp(msg as Record<string, unknown>)}`
 
-    if (payloadTypeOf(msg) === 'SIP') {
+    if (payloadType === 'RTCP') {
+      const rtcpLabels = computeRtcpFlowLabels(msg)
+      method = rtcpLabels.method
+      description = rtcpLabels.description
+    } else if (payloadType === 'SIP') {
       const sipLabels = computeSipFlowLabels(msg as Record<string, unknown>)
       if (sipLabels) {
         method = sipLabels.method
@@ -617,7 +623,7 @@ export function buildFlow(items: RawMessage[] | null | undefined, opts: BuildOpt
       fullDateStr,
       diffStr,
       protoLabel: protoLabelOf(proto),
-      payloadType: payloadTypeOf(msg),
+      payloadType,
       start,
       middle,
       rightEnd,

--- a/src/ui/src/dashboard/flow/flowFilterPrefs.test.ts
+++ b/src/ui/src/dashboard/flow/flowFilterPrefs.test.ts
@@ -27,6 +27,7 @@ describe('flowFilterPrefs', () => {
       isHighContrast: true,
       isConsolidateCaptureIds: false,
       consolidationTimeThresholdMs: 500,
+      showRtcp: false,
     })
   })
 
@@ -67,5 +68,21 @@ describe('flowFilterPrefs', () => {
   it('ignores non-finite consolidationTimeThresholdMs', () => {
     localStorage.setItem(FLOW_FILTER_PREFS_LS_KEY, JSON.stringify({ consolidationTimeThresholdMs: null }))
     expect(loadStoredFlowPrefs().consolidationTimeThresholdMs).toBeUndefined()
+  })
+
+  it('round-trips showRtcp', () => {
+    saveStoredFlowPrefs({ ...DEFAULT_FILTERS, showRtcp: true })
+    expect(loadStoredFlowPrefs()).toMatchObject({ showRtcp: true })
+    expect(initialFlowFilters().showRtcp).toBe(true)
+  })
+
+  it('defaults showRtcp to false', () => {
+    expect(DEFAULT_FILTERS.showRtcp).toBe(false)
+    expect(initialFlowFilters().showRtcp).toBe(false)
+  })
+
+  it('ignores non-boolean showRtcp', () => {
+    localStorage.setItem(FLOW_FILTER_PREFS_LS_KEY, JSON.stringify({ showRtcp: 'yes' }))
+    expect(loadStoredFlowPrefs().showRtcp).toBeUndefined()
   })
 })

--- a/src/ui/src/dashboard/flow/flowFilterPrefs.ts
+++ b/src/ui/src/dashboard/flow/flowFilterPrefs.ts
@@ -10,6 +10,7 @@ export interface FlowFilters {
   isHighContrast: boolean
   isConsolidateCaptureIds: boolean
   consolidationTimeThresholdMs: number
+  showRtcp: boolean
   hostGrouping: HostGrouping
   ipExcluded: Set<string>
   methodExcluded: Set<string>
@@ -23,6 +24,7 @@ export const DEFAULT_FILTERS: FlowFilters = {
   isHighContrast: false,
   isConsolidateCaptureIds: false,
   consolidationTimeThresholdMs: 500,
+  showRtcp: false,
   hostGrouping: 'ungrouped',
   ipExcluded: new Set(),
   methodExcluded: new Set(),
@@ -37,6 +39,7 @@ export interface StoredFlowPrefs {
   isHighContrast?: boolean
   isConsolidateCaptureIds?: boolean
   consolidationTimeThresholdMs?: number
+  showRtcp?: boolean
 }
 
 export function isHostGrouping(value: unknown): value is HostGrouping {
@@ -58,6 +61,7 @@ export function loadStoredFlowPrefs(): StoredFlowPrefs {
     if (typeof parsed.isConsolidateCaptureIds === 'boolean') {
       out.isConsolidateCaptureIds = parsed.isConsolidateCaptureIds
     }
+    if (typeof parsed.showRtcp === 'boolean') out.showRtcp = parsed.showRtcp
     if (
       typeof parsed.consolidationTimeThresholdMs === 'number' &&
       Number.isFinite(parsed.consolidationTimeThresholdMs)
@@ -79,6 +83,7 @@ export function saveStoredFlowPrefs(filters: FlowFilters): void {
     isHighContrast: filters.isHighContrast,
     isConsolidateCaptureIds: filters.isConsolidateCaptureIds,
     consolidationTimeThresholdMs: filters.consolidationTimeThresholdMs,
+    showRtcp: filters.showRtcp,
   }
   try {
     localStorage.setItem(FLOW_FILTER_PREFS_LS_KEY, JSON.stringify(payload))

--- a/src/ui/src/dashboard/flow/hep-proto.test.ts
+++ b/src/ui/src/dashboard/flow/hep-proto.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { hepProtoTypeOf, mergeFlowMessagesByTimestamp, tagHepProtoType } from './hep-proto'
+import type { RawMessage } from './flow-data'
+
+describe('hepProtoTypeOf', () => {
+  it('reads a tagged hep_proto_type field', () => {
+    expect(hepProtoTypeOf({ hep_proto_type: 5 })).toBe(5)
+  })
+
+  it('reads proto_type from data_extra JSON', () => {
+    expect(hepProtoTypeOf({ data_extra: '{"version":3,"proto_type":5}' })).toBe(5)
+  })
+
+  it('returns null when no HEP type is present', () => {
+    expect(hepProtoTypeOf({ protocol: 17 })).toBeNull()
+  })
+})
+
+describe('tagHepProtoType', () => {
+  it('stamps every row', () => {
+    const tagged = tagHepProtoType([{ uuid: 'a' }, { uuid: 'b' }], 5)
+    expect(tagged.map((m) => m.hep_proto_type)).toEqual([5, 5])
+  })
+})
+
+describe('mergeFlowMessagesByTimestamp', () => {
+  it('interleaves SIP and RTCP in capture-time order', () => {
+    const sip: RawMessage[] = [
+      { uuid: 'invite', method: 'INVITE', timestamp: 1_000 },
+      { uuid: 'bye', method: 'BYE', timestamp: 3_000 },
+    ]
+    const rtcp: RawMessage[] = [{ uuid: 'sr', timestamp: 2_000, hep_proto_type: 5 }]
+    expect(mergeFlowMessagesByTimestamp(sip, rtcp).map((m) => m.uuid)).toEqual([
+      'invite',
+      'sr',
+      'bye',
+    ])
+  })
+})

--- a/src/ui/src/dashboard/flow/hep-proto.ts
+++ b/src/ui/src/dashboard/flow/hep-proto.ts
@@ -1,0 +1,70 @@
+import type { RawMessage } from './flow-data'
+
+function parseJSONLike(value: unknown): Record<string, unknown> | null {
+  if (!value) return null
+  if (typeof value === 'object' && !Array.isArray(value)) return value as Record<string, unknown>
+  if (typeof value !== 'string') return null
+  try {
+    const parsed = JSON.parse(value)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null
+  } catch {
+    return null
+  }
+}
+
+function positiveInt(value: unknown): number | null {
+  if (value === undefined || value === null || value === '') return null
+  const n = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(n) || n <= 0) return null
+  return n
+}
+
+/** HEP proto_type from a tagged row or data_extra — not the IP `protocol` column. */
+export function hepProtoTypeOf(msg: RawMessage): number | null {
+  const direct = positiveInt(msg.hep_proto_type ?? msg.proto_type)
+  if (direct != null) return direct
+  const extra = parseJSONLike(msg.data_extra)
+  if (!extra) return null
+  return positiveInt(extra.proto_type ?? extra.hep_proto_type)
+}
+
+export function tagHepProtoType(items: RawMessage[] | null | undefined, protoType: number): RawMessage[] {
+  return (items ?? []).map((m) => ({ ...m, hep_proto_type: protoType }))
+}
+
+function timestampMsOf(msg: RawMessage): number {
+  const value = msg.timestamp ?? msg.create_ts
+  if (value === undefined || value === null || value === '') return 0
+  if (value instanceof Date) {
+    const t = value.getTime()
+    return Number.isFinite(t) ? t : 0
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return 0
+    if (value > 1e15) return Math.round(value / 1e6)
+    if (value > 1e12) return Math.round(value)
+    if (value > 1e9) return Math.round(value * 1000)
+    return value
+  }
+  if (typeof value === 'string') {
+    let s = value.trim()
+    if (/^\d{4}-\d{2}-\d{2}$/.test(s)) s = `${s}T00:00:00Z`
+    else if (s.includes(' ') && !s.includes('T')) s = s.replace(' ', 'T')
+    if (!/[zZ]|[+-]\d{2}:?\d{2}$/.test(s)) s = `${s}Z`
+    const d = new Date(s)
+    return Number.isNaN(d.getTime()) ? 0 : d.getTime()
+  }
+  return 0
+}
+
+/** Merge two already-tagged message lists into capture-time order. */
+export function mergeFlowMessagesByTimestamp(
+  primary: RawMessage[] | null | undefined,
+  extra: RawMessage[] | null | undefined,
+): RawMessage[] {
+  const merged = [...(primary ?? []), ...(extra ?? [])]
+  merged.sort((a, b) => timestampMsOf(a) - timestampMsOf(b))
+  return merged
+}

--- a/src/ui/src/dashboard/flow/rtcp-flow-label.test.ts
+++ b/src/ui/src/dashboard/flow/rtcp-flow-label.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { computeRtcpFlowLabels } from './rtcp-flow-label'
+
+const base = {
+  src_ip: '10.0.0.1',
+  dst_ip: '10.0.0.2',
+  src_port: 4000,
+  dst_port: 4001,
+}
+
+describe('computeRtcpFlowLabels', () => {
+  it('labels SR with jitter and fraction-lost percent', () => {
+    const labels = computeRtcpFlowLabels({
+      ...base,
+      payload: JSON.stringify({
+        type: 200,
+        report_blocks: [{ ia_jitter: 12, fraction_lost: 1, packets_lost: 3 }],
+      }),
+    })
+    expect(labels.method).toBe('RTCP SR')
+    expect(labels.description).toBe('jitter=12 loss=0.4%')
+  })
+
+  it('labels RR and uses packets_lost when fraction_lost is missing', () => {
+    const labels = computeRtcpFlowLabels({
+      ...base,
+      payload: {
+        type: 201,
+        report_blocks: [{ ia_jitter: 4, packets_lost: 7 }],
+      },
+    })
+    expect(labels.method).toBe('RTCP RR')
+    expect(labels.description).toBe('jitter=4 loss=7')
+  })
+
+  it('labels XR reports', () => {
+    expect(
+      computeRtcpFlowLabels({
+        ...base,
+        payload: JSON.stringify({ type: 207, report_blocks: [] }),
+      }).method,
+    ).toBe('RTCP XR')
+  })
+
+  it('falls back to RTCP and a route description when payload is invalid', () => {
+    const labels = computeRtcpFlowLabels({ ...base, payload: 'not-json' })
+    expect(labels.method).toBe('RTCP')
+    expect(labels.description).toContain('10.0.0.1')
+    expect(labels.description).toContain('10.0.0.2')
+  })
+})

--- a/src/ui/src/dashboard/flow/rtcp-flow-label.ts
+++ b/src/ui/src/dashboard/flow/rtcp-flow-label.ts
@@ -1,0 +1,82 @@
+import { displayDstIp, displaySrcIp, qosRouteArrow } from '@/lib/ipAliasDisplay'
+import type { RawMessage } from './flow-data'
+
+const RTCP_TYPE_NAMES: Record<number, string> = {
+  200: 'SR',
+  201: 'RR',
+  202: 'SDES',
+  204: 'APP',
+  205: 'FIR',
+  206: 'NACK',
+  207: 'XR',
+}
+
+function parsePayload(raw: unknown): Record<string, unknown> | null {
+  if (!raw) return null
+  if (typeof raw === 'object' && !Array.isArray(raw)) return raw as Record<string, unknown>
+  if (typeof raw !== 'string') return null
+  try {
+    const parsed = JSON.parse(raw.replaceAll('\u0010', ''))
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null
+  } catch {
+    return null
+  }
+}
+
+function routeDescription(msg: RawMessage): string {
+  const row = msg as Record<string, unknown>
+  return qosRouteArrow(row) || `${displaySrcIp(row)} \u2192 ${displayDstIp(row)}`
+}
+
+function fractionLostPercent(fractionLost: unknown): number | null {
+  if (fractionLost == null || fractionLost === '') return null
+  const fl = Number(fractionLost)
+  if (!Number.isFinite(fl)) return null
+  if (fl <= 0) return 0
+  if (fl > 256) return 100
+  return (fl / 256) * 100
+}
+
+function formatLoss(block: Record<string, unknown>): string {
+  const pct = fractionLostPercent(block.fraction_lost)
+  if (pct != null) {
+    const digits = Number.isInteger(pct) || Math.abs(pct - Math.round(pct)) < 0.05 ? 0 : 1
+    return `loss=${pct.toFixed(digits)}%`
+  }
+  if (block.packets_lost != null && block.packets_lost !== '') {
+    return `loss=${block.packets_lost}`
+  }
+  return ''
+}
+
+/** Compact Call Flow label for an RTCP JSON report (HEP proto 5). */
+export function computeRtcpFlowLabels(msg: RawMessage): { method: string; description: string } {
+  const payload = parsePayload(msg.payload ?? msg.raw ?? msg.data_extra)
+  if (!payload) {
+    return { method: 'RTCP', description: routeDescription(msg) }
+  }
+
+  const type = Number(payload.type) || 0
+  const typeName = RTCP_TYPE_NAMES[type]
+  const method = typeName ? `RTCP ${typeName}` : 'RTCP'
+
+  const blocks = payload.report_blocks
+  const block =
+    Array.isArray(blocks) && blocks[0] && typeof blocks[0] === 'object'
+      ? (blocks[0] as Record<string, unknown>)
+      : {}
+
+  const parts: string[] = []
+  if (block.ia_jitter != null && block.ia_jitter !== '') {
+    parts.push(`jitter=${block.ia_jitter}`)
+  }
+  const loss = formatLoss(block)
+  if (loss) parts.push(loss)
+
+  return {
+    method,
+    description: parts.length > 0 ? parts.join(' ') : routeDescription(msg),
+  }
+}

--- a/src/ui/src/dashboard/flow/useFlowFilters.test.ts
+++ b/src/ui/src/dashboard/flow/useFlowFilters.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_FILTERS } from './flowFilterPrefs'
+import { applyFlowFilters } from './useFlowFilters'
+import type { RawMessage } from './flow-data'
+
+const sip: RawMessage = {
+  uuid: 'sip1',
+  src_ip: '10.0.0.1',
+  dst_ip: '10.0.0.2',
+  method: 'INVITE',
+  session_id: 'c1',
+  hep_proto_type: 1,
+}
+
+const rtcp: RawMessage = {
+  uuid: 'rtcp1',
+  src_ip: '10.0.0.1',
+  dst_ip: '10.0.0.2',
+  session_id: 'c1',
+  protocol: 17,
+  hep_proto_type: 5,
+}
+
+describe('applyFlowFilters showRtcp', () => {
+  it('hides RTCP when showRtcp is false and keeps SIP', () => {
+    const out = applyFlowFilters([sip, rtcp], { ...DEFAULT_FILTERS, showRtcp: false })
+    expect(out.map((m) => m.uuid)).toEqual(['sip1'])
+  })
+
+  it('shows RTCP when showRtcp is true', () => {
+    const out = applyFlowFilters([sip, rtcp], { ...DEFAULT_FILTERS, showRtcp: true })
+    expect(out.map((m) => m.uuid)).toEqual(['sip1', 'rtcp1'])
+  })
+})

--- a/src/ui/src/dashboard/flow/useFlowFilters.ts
+++ b/src/ui/src/dashboard/flow/useFlowFilters.ts
@@ -50,6 +50,34 @@ export interface UseFlowFiltersResult {
   filteredItems: RawMessage[]
 }
 
+export function applyFlowFilters(items: RawMessage[], filters: FlowFilters): RawMessage[] {
+  return items.filter((m) => {
+    const payloadType = payloadTypeOf(m)
+    if (!filters.showRtcp && payloadType === 'RTCP') return false
+
+    const src = m.src_ip || ''
+    const dst = m.dst_ip || ''
+    if (filters.ipExcluded.size > 0 && filters.ipExcluded.has(src) && filters.ipExcluded.has(dst))
+      return false
+    if (
+      filters.ipExcluded.size > 0 &&
+      (filters.ipExcluded.has(src) || filters.ipExcluded.has(dst))
+    )
+      return false
+
+    const method =
+      (m.sip_method as string) || (m.method as string) || (m.event as string) || ''
+    if (filters.methodExcluded.has(method)) return false
+
+    if (filters.payloadTypeExcluded.has(payloadType)) return false
+
+    const callid = (m.session_id as string) || (m.cid as string) || ''
+    if (filters.callIdExcluded.has(callid)) return false
+
+    return true
+  })
+}
+
 export function useFlowFilters(items: RawMessage[] | null | undefined): UseFlowFiltersResult {
   const [filters, setFilters] = useState<FlowFilters>(initialFlowFilters)
 
@@ -62,41 +90,20 @@ export function useFlowFilters(items: RawMessage[] | null | undefined): UseFlowF
     filters.isHighContrast,
     filters.isConsolidateCaptureIds,
     filters.consolidationTimeThresholdMs,
+    filters.showRtcp,
   ])
 
   const { filterIP, filterMethod, filterPayloadType, filterCallId, filteredItems } = useMemo(() => {
     const safe = items ?? []
-    const ips = collectUnique(safe, (m) => [m.src_ip || '', m.dst_ip || ''])
-    const methods = collectUnique(safe, (m) => [
+    const filteredItems = applyFlowFilters(safe, filters)
+    const ips = collectUnique(filteredItems, (m) => [m.src_ip || '', m.dst_ip || ''])
+    const methods = collectUnique(filteredItems, (m) => [
       (m.sip_method as string) || (m.method as string) || (m.event as string) || '',
     ])
-    const payloadTypes = collectUnique(safe, (m) => [payloadTypeOf(m)])
-    const callIds = collectUnique(safe, (m) => [
+    const payloadTypes = collectUnique(filteredItems, (m) => [payloadTypeOf(m)])
+    const callIds = collectUnique(filteredItems, (m) => [
       (m.session_id as string) || (m.cid as string) || '',
     ])
-
-    const filteredItems = safe.filter((m) => {
-      const src = m.src_ip || ''
-      const dst = m.dst_ip || ''
-      if (filters.ipExcluded.size > 0 && filters.ipExcluded.has(src) && filters.ipExcluded.has(dst))
-        return false
-      if (
-        filters.ipExcluded.size > 0 &&
-        (filters.ipExcluded.has(src) || filters.ipExcluded.has(dst))
-      )
-        return false
-
-      const method =
-        (m.sip_method as string) || (m.method as string) || (m.event as string) || ''
-      if (filters.methodExcluded.has(method)) return false
-
-      if (filters.payloadTypeExcluded.has(payloadTypeOf(m))) return false
-
-      const callid = (m.session_id as string) || (m.cid as string) || ''
-      if (filters.callIdExcluded.has(callid)) return false
-
-      return true
-    })
 
     return {
       filterIP: toTokens(ips, filters.ipExcluded),

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.323"
+	VERSION_APPLICATION = "11.0.324"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Mix HEP proto 5 (RTCP) with SIP in the transaction Call Flow ladder, merged by timestamp, so media quality changes can be seen next to signaling ([#955](https://github.com/sipcapture/homer/issues/955)).
- Gate visibility with an RTCP toggle in the Call Flow filter panel (off by default, persisted in `homer_callflow_prefs`), matching Homer 7. Messages tab stays SIP-only.
- Render compact labels (`RTCP SR` / `RR` / `XR` with jitter/loss), dotted arrows, and open the message modal with `proto_type: 5`. Bump version to 11.0.324.

## Test plan
- [ ] Open a SIP transaction that has RTCP (heplify `-m SIPRTCP` or equivalent); Call Flow is SIP-only until the RTCP filter toggle is enabled.
- [ ] Enable RTCP: reports appear inline by timestamp with compact `RTCP SR/RR/XR` labels and jitter/loss; extra media endpoints may add host columns.
- [ ] Click an RTCP row: message modal shows the report JSON (`proto_type: 5`).
- [ ] Toggle preference survives a page reload; Messages tab still lists only SIP.
- [ ] `cd src/ui && vitest run` (or `pnpm test`) — flow-data, flowFilterPrefs, rtcp-flow-label, hep-proto, useFlowFilters.