### PR TITLE
feat(cli): add homer config show (#945)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ homer search [flags]          Search Homer data via coordinator API
 homer cli [flags]             Interactive DuckLake SQL shell
 homer system [flags]          System operations (compaction, extensions, reload)
 homer wizard [flags]          Interactive config generator wizard
+homer show-running-config [flags]
+                              Print effective config (file + env + defaults)
 homer mcp [flags]             Start MCP stdio server
 homer version                 Show version
 homer help                    Show full help with all flags
@@ -259,6 +261,27 @@ homer catalog restore --config-path /etc/homer/homer.json
 ```
 
 See [docs/CATALOG.md](docs/CATALOG.md) for flags, `--out`, and when to use restore vs `--rebuild-catalog`.
+
+### Show running config
+
+Print the **effective** config Homer would start with (JSON file + `HOMER_*`
+environment variables + struct defaults). This does not attach to a live
+process. Secrets (passwords, tokens, keys) are redacted unless
+`--include-secrets` is set.
+
+```bash
+homer show-running-config --config-path /etc/homer/homer.json
+homer show-running-config --config-path /etc/homer/homer.json --section storage.ducklake.compaction
+```
+
+| Flag | Description |
+|------|-------------|
+| `--config-path <path>` | Path to config file or directory |
+| `--section <path>` | Dotted JSON path only |
+| `--include-secrets` | Do not redact credentials |
+| `--compact` | Single-line JSON |
+
+`show-config` is an alias for the same command.
 
 ### Wizard (Config Generator)
 

--- a/README.md
+++ b/README.md
@@ -164,8 +164,7 @@ homer search [flags]          Search Homer data via coordinator API
 homer cli [flags]             Interactive DuckLake SQL shell
 homer system [flags]          System operations (compaction, extensions, reload)
 homer wizard [flags]          Interactive config generator wizard
-homer show-running-config [flags]
-                              Print effective config (file + env + defaults)
+homer config [show] [flags]   Print effective config (file + env + defaults)
 homer mcp [flags]             Start MCP stdio server
 homer version                 Show version
 homer help                    Show full help with all flags
@@ -262,7 +261,7 @@ homer catalog restore --config-path /etc/homer/homer.json
 
 See [docs/CATALOG.md](docs/CATALOG.md) for flags, `--out`, and when to use restore vs `--rebuild-catalog`.
 
-### Show running config
+### Config show
 
 Print the **effective** config Homer would start with (JSON file + `HOMER_*`
 environment variables + struct defaults). This does not attach to a live
@@ -270,9 +269,11 @@ process. Secrets (passwords, tokens, keys) are redacted unless
 `--include-secrets` is set.
 
 ```bash
-homer show-running-config --config-path /etc/homer/homer.json
-homer show-running-config --config-path /etc/homer/homer.json --section storage.ducklake.compaction
+homer config show --config-path /etc/homer/homer.json
+homer config show --config-path /etc/homer/homer.json --section storage.ducklake.compaction
 ```
+
+`homer config` without an action is the same as `show`.
 
 | Flag | Description |
 |------|-------------|
@@ -280,8 +281,6 @@ homer show-running-config --config-path /etc/homer/homer.json --section storage.
 | `--section <path>` | Dotted JSON path only |
 | `--include-secrets` | Do not redact credentials |
 | `--compact` | Single-line JSON |
-
-`show-config` is an alias for the same command.
 
 ### Wizard (Config Generator)
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ homer search [flags]          Search Homer data via coordinator API
 homer cli [flags]             Interactive DuckLake SQL shell
 homer system [flags]          System operations (compaction, extensions, reload)
 homer wizard [flags]          Interactive config generator wizard
-homer config [show] [flags]   Print effective config (file + env + defaults)
+homer config show [flags]     Print effective config (file + env + defaults)
 homer mcp [flags]             Start MCP stdio server
 homer version                 Show version
 homer help                    Show full help with all flags
@@ -272,8 +272,6 @@ process. Secrets (passwords, tokens, keys) are redacted unless
 homer config show --config-path /etc/homer/homer.json
 homer config show --config-path /etc/homer/homer.json --section storage.ducklake.compaction
 ```
-
-`homer config` without an action is the same as `show`.
 
 | Flag | Description |
 |------|-------------|

--- a/src/cli/show_config.go
+++ b/src/cli/show_config.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sipcapture/homer-core/src/config"
+)
+
+const redactedSecret = "********"
+
+// secretJSONKeys are exact JSON object keys that must not appear in
+// show-running-config output unless --include-secrets is set.
+var secretJSONKeys = map[string]struct{}{
+	"admin_password_hash":  {},
+	"access_key_id":        {},
+	"api_key":              {},
+	"auth_token":           {},
+	"bind_password":        {},
+	"client_secret":        {},
+	"homer_token":          {},
+	"key":                  {},
+	"pass":                 {},
+	"password":             {},
+	"s3_access_key_id":     {},
+	"s3_secret_access_key": {},
+	"secret":               {},
+	"secret_access_key":    {},
+	"token":                {},
+}
+
+// ShowConfigFlags holds flags for "homer show-running-config".
+type ShowConfigFlags struct {
+	ConfigPath     string
+	Section        string
+	IncludeSecrets bool
+	Compact        bool
+}
+
+type showConfigFlagRefs struct {
+	ConfigPath     *string
+	Section        *string
+	IncludeSecrets *bool
+	Compact        *bool
+}
+
+// RegisterShowConfigFlags creates a FlagSet for "homer show-running-config".
+func RegisterShowConfigFlags() (*flag.FlagSet, *showConfigFlagRefs) {
+	fs := flag.NewFlagSet("show-running-config", flag.ExitOnError)
+	refs := &showConfigFlagRefs{}
+	refs.ConfigPath = fs.String("config-path", "", "path to config file or directory (same as the server)")
+	refs.Section = fs.String("section", "", "print a dotted JSON path only, e.g. storage.ducklake.compaction")
+	refs.IncludeSecrets = fs.Bool("include-secrets", false, "do not redact passwords, tokens, and keys")
+	refs.Compact = fs.Bool("compact", false, "emit a single-line JSON object")
+	return fs, refs
+}
+
+// ParseShowConfigFlags extracts ShowConfigFlags from parsed flag refs.
+func ParseShowConfigFlags(refs *showConfigFlagRefs) ShowConfigFlags {
+	return ShowConfigFlags{
+		ConfigPath:     *refs.ConfigPath,
+		Section:        *refs.Section,
+		IncludeSecrets: *refs.IncludeSecrets,
+		Compact:        *refs.Compact,
+	}
+}
+
+// RunShowConfigCmd prints the effective config after file + env + defaults.
+// This is not attached to a live process: it is what Homer would start with.
+func RunShowConfigCmd(f ShowConfigFlags) error {
+	cfg, err := config.Load(f.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+	out, err := formatRunningConfig(cfg, f)
+	if err != nil {
+		return err
+	}
+	if f.IncludeSecrets {
+		fmt.Fprintln(os.Stderr, "warning: --include-secrets prints credentials")
+	}
+	_, err = os.Stdout.Write(append(out, '\n'))
+	return err
+}
+
+func formatRunningConfig(cfg *config.Config, f ShowConfigFlags) ([]byte, error) {
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshal config: %w", err)
+	}
+	var root any
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return nil, fmt.Errorf("decode config json: %w", err)
+	}
+	if section := strings.TrimSpace(f.Section); section != "" {
+		root, err = lookupJSONSection(root, section)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if !f.IncludeSecrets {
+		redactJSONSecrets(root)
+	}
+	if f.Compact {
+		return json.Marshal(root)
+	}
+	return json.MarshalIndent(root, "", "  ")
+}
+
+func lookupJSONSection(root any, path string) (any, error) {
+	cur := root
+	for _, part := range strings.Split(path, ".") {
+		if part == "" {
+			return nil, fmt.Errorf("invalid --section %q", path)
+		}
+		obj, ok := cur.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("section %q is not an object", path)
+		}
+		next, ok := obj[part]
+		if !ok {
+			return nil, fmt.Errorf("section %q not found", path)
+		}
+		cur = next
+	}
+	return cur, nil
+}
+
+func redactJSONSecrets(v any) {
+	switch n := v.(type) {
+	case map[string]any:
+		for k, child := range n {
+			if isSecretJSONKey(k) {
+				if s, ok := child.(string); ok && s != "" {
+					n[k] = redactedSecret
+					continue
+				}
+			}
+			redactJSONSecrets(child)
+		}
+	case []any:
+		for _, child := range n {
+			redactJSONSecrets(child)
+		}
+	}
+}
+
+func isSecretJSONKey(key string) bool {
+	_, ok := secretJSONKeys[strings.ToLower(key)]
+	return ok
+}

--- a/src/cli/show_config.go
+++ b/src/cli/show_config.go
@@ -13,7 +13,7 @@ import (
 const redactedSecret = "********"
 
 // secretJSONKeys are exact JSON object keys that must not appear in
-// show-running-config output unless --include-secrets is set.
+// `homer config show` output unless --include-secrets is set.
 var secretJSONKeys = map[string]struct{}{
 	"admin_password_hash":  {},
 	"access_key_id":        {},
@@ -32,8 +32,9 @@ var secretJSONKeys = map[string]struct{}{
 	"token":                {},
 }
 
-// ShowConfigFlags holds flags for "homer show-running-config".
+// ShowConfigFlags holds flags for "homer config show".
 type ShowConfigFlags struct {
+	Action         string
 	ConfigPath     string
 	Section        string
 	IncludeSecrets bool
@@ -47,9 +48,9 @@ type showConfigFlagRefs struct {
 	Compact        *bool
 }
 
-// RegisterShowConfigFlags creates a FlagSet for "homer show-running-config".
+// RegisterShowConfigFlags creates a FlagSet for "homer config show".
 func RegisterShowConfigFlags() (*flag.FlagSet, *showConfigFlagRefs) {
-	fs := flag.NewFlagSet("show-running-config", flag.ExitOnError)
+	fs := flag.NewFlagSet("config", flag.ExitOnError)
 	refs := &showConfigFlagRefs{}
 	refs.ConfigPath = fs.String("config-path", "", "path to config file or directory (same as the server)")
 	refs.Section = fs.String("section", "", "print a dotted JSON path only, e.g. storage.ducklake.compaction")
@@ -71,6 +72,15 @@ func ParseShowConfigFlags(refs *showConfigFlagRefs) ShowConfigFlags {
 // RunShowConfigCmd prints the effective config after file + env + defaults.
 // This is not attached to a live process: it is what Homer would start with.
 func RunShowConfigCmd(f ShowConfigFlags) error {
+	action := strings.TrimSpace(f.Action)
+	if action == "" {
+		action = "show"
+	}
+	switch action {
+	case "show":
+	default:
+		return fmt.Errorf("unknown config action %q (supported: show)", action)
+	}
 	cfg, err := config.Load(f.ConfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)

--- a/src/cli/show_config.go
+++ b/src/cli/show_config.go
@@ -72,14 +72,12 @@ func ParseShowConfigFlags(refs *showConfigFlagRefs) ShowConfigFlags {
 // RunShowConfigCmd prints the effective config after file + env + defaults.
 // This is not attached to a live process: it is what Homer would start with.
 func RunShowConfigCmd(f ShowConfigFlags) error {
-	action := strings.TrimSpace(f.Action)
-	if action == "" {
-		action = "show"
-	}
-	switch action {
+	switch strings.ToLower(strings.TrimSpace(f.Action)) {
 	case "show":
+	case "":
+		return fmt.Errorf("no config action specified; use show")
 	default:
-		return fmt.Errorf("unknown config action %q (supported: show)", action)
+		return fmt.Errorf("unknown config action %q (supported: show)", f.Action)
 	}
 	cfg, err := config.Load(f.ConfigPath)
 	if err != nil {

--- a/src/cli/show_config_test.go
+++ b/src/cli/show_config_test.go
@@ -17,6 +17,13 @@ func TestRunShowConfigCmd_unknownAction(t *testing.T) {
 	}
 }
 
+func TestRunShowConfigCmd_missingAction(t *testing.T) {
+	err := RunShowConfigCmd(ShowConfigFlags{})
+	if err == nil || !strings.Contains(err.Error(), "no config action specified") {
+		t.Fatalf("got %v", err)
+	}
+}
+
 func TestIsSecretJSONKey(t *testing.T) {
 	if !isSecretJSONKey("secret_access_key") {
 		t.Fatal("secret_access_key should be redacted")

--- a/src/cli/show_config_test.go
+++ b/src/cli/show_config_test.go
@@ -10,6 +10,13 @@ import (
 	"github.com/sipcapture/homer-core/src/config"
 )
 
+func TestRunShowConfigCmd_unknownAction(t *testing.T) {
+	err := RunShowConfigCmd(ShowConfigFlags{Action: "dump"})
+	if err == nil || !strings.Contains(err.Error(), `unknown config action "dump"`) {
+		t.Fatalf("got %v", err)
+	}
+}
+
 func TestIsSecretJSONKey(t *testing.T) {
 	if !isSecretJSONKey("secret_access_key") {
 		t.Fatal("secret_access_key should be redacted")

--- a/src/cli/show_config_test.go
+++ b/src/cli/show_config_test.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sipcapture/homer-core/src/config"
+)
+
+func TestIsSecretJSONKey(t *testing.T) {
+	if !isSecretJSONKey("secret_access_key") {
+		t.Fatal("secret_access_key should be redacted")
+	}
+	if isSecretJSONKey("max_tokens") {
+		t.Fatal("max_tokens is not a secret")
+	}
+	if isSecretJSONKey("token_url") {
+		t.Fatal("token_url is not a secret")
+	}
+	if isSecretJSONKey("engine") {
+		t.Fatal("engine is not a secret")
+	}
+}
+
+func TestRedactJSONSecrets_nested(t *testing.T) {
+	root := map[string]any{
+		"coordinator": map[string]any{
+			"jwt": map[string]any{"secret": "super-secret", "expire": 3600},
+		},
+		"storage": map[string]any{
+			"ducklake": map[string]any{
+				"s3": map[string]any{
+					"access_key_id":     "AKIA",
+					"secret_access_key": "sk",
+					"endpoint":          "http://127.0.0.1:9000",
+				},
+			},
+		},
+		"mcp": map[string]any{"max_tokens": 400},
+	}
+	redactJSONSecrets(root)
+	jwt := root["coordinator"].(map[string]any)["jwt"].(map[string]any)
+	if jwt["secret"] != redactedSecret {
+		t.Fatalf("jwt.secret=%v", jwt["secret"])
+	}
+	if jwt["expire"] != 3600 {
+		t.Fatal("non-secret jwt field changed")
+	}
+	s3 := root["storage"].(map[string]any)["ducklake"].(map[string]any)["s3"].(map[string]any)
+	if s3["secret_access_key"] != redactedSecret || s3["access_key_id"] != redactedSecret {
+		t.Fatalf("s3 keys not redacted: %#v", s3)
+	}
+	if s3["endpoint"] != "http://127.0.0.1:9000" {
+		t.Fatal("s3 endpoint changed")
+	}
+	if root["mcp"].(map[string]any)["max_tokens"] != 400 {
+		t.Fatal("max_tokens changed")
+	}
+}
+
+func TestLookupJSONSection(t *testing.T) {
+	root := map[string]any{
+		"storage": map[string]any{
+			"ducklake": map[string]any{
+				"compaction": map[string]any{"engine": "duckdb"},
+			},
+		},
+	}
+	got, err := lookupJSONSection(root, "storage.ducklake.compaction")
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, ok := got.(map[string]any)
+	if !ok || obj["engine"] != "duckdb" {
+		t.Fatalf("got %#v", got)
+	}
+	if _, err := lookupJSONSection(root, "storage.missing"); err == nil {
+		t.Fatal("expected missing section error")
+	}
+}
+
+func TestFormatRunningConfig_defaultsEngineAndRedactsJWT(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "homer.json")
+	body := `{
+  "storage": { "enable": true, "ducklake": { "compaction": { "enable": true } } },
+  "coordinator": { "enable": true, "jwt": { "secret": "live-secret" } }
+}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := formatRunningConfig(cfg, ShowConfigFlags{Section: "storage.ducklake.compaction"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var compaction map[string]any
+	if err := json.Unmarshal(out, &compaction); err != nil {
+		t.Fatal(err)
+	}
+	if compaction["engine"] != "duckdb" {
+		t.Fatalf("unset engine should default to duckdb, got %#v", compaction["engine"])
+	}
+	if compaction["enable"] != true {
+		t.Fatalf("enable=%v", compaction["enable"])
+	}
+
+	full, err := formatRunningConfig(cfg, ShowConfigFlags{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(full), "live-secret") {
+		t.Fatal("jwt secret leaked")
+	}
+	if !strings.Contains(string(full), redactedSecret) {
+		t.Fatal("expected redacted placeholder")
+	}
+
+	leaked, err := formatRunningConfig(cfg, ShowConfigFlags{IncludeSecrets: true, Compact: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(leaked), "live-secret") {
+		t.Fatal("include-secrets should keep jwt secret")
+	}
+}

--- a/src/main.go
+++ b/src/main.go
@@ -128,7 +128,7 @@ Usage:
   homer system [flags]          System operations (compaction, extensions, reload)
   homer agent [action] [flags]  Query heplify agent API (stats, health, watch)
   homer wizard [flags]          Interactive config generator wizard
-  homer config [show] [flags]   Print effective config (file + env + defaults)
+  homer config show [flags]     Print effective config (file + env + defaults)
   homer mcp [flags]             Start MCP stdio server
   homer migrate [action] [flags]
                                 Migrate data from Homer 7 (homer-app PostgreSQL).
@@ -217,7 +217,7 @@ wizard -- Interactive config generator:
   --profile <name>              Non-interactive preset: all-in-one, writer, edge, coordinator, node
 
 config show -- Print effective config after file + env + defaults.
-  Not attached to a live process. `homer config` defaults to show.
+  Not attached to a live process.
   --config-path <path>          Path to config file or directory
   --section <path>              Dotted JSON path, e.g. storage.ducklake.compaction
   --include-secrets             Do not redact passwords, tokens, and keys
@@ -480,7 +480,7 @@ func main() {
 		}
 
 	case "config":
-		action := "show"
+		action := ""
 		args := os.Args[2:]
 		if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
 			action = args[0]

--- a/src/main.go
+++ b/src/main.go
@@ -128,8 +128,7 @@ Usage:
   homer system [flags]          System operations (compaction, extensions, reload)
   homer agent [action] [flags]  Query heplify agent API (stats, health, watch)
   homer wizard [flags]          Interactive config generator wizard
-  homer show-running-config [flags]
-                                Print effective config (file + env + defaults)
+  homer config [show] [flags]   Print effective config (file + env + defaults)
   homer mcp [flags]             Start MCP stdio server
   homer migrate [action] [flags]
                                 Migrate data from Homer 7 (homer-app PostgreSQL).
@@ -217,8 +216,8 @@ wizard -- Interactive config generator:
   --output <path>               Output file path (default: homer.json)
   --profile <name>              Non-interactive preset: all-in-one, writer, edge, coordinator, node
 
-show-running-config -- Print effective config after file + env + defaults
-  (alias: show-config). Not attached to a live process.
+config show -- Print effective config after file + env + defaults.
+  Not attached to a live process. `homer config` defaults to show.
   --config-path <path>          Path to config file or directory
   --section <path>              Dotted JSON path, e.g. storage.ducklake.compaction
   --include-secrets             Do not redact passwords, tokens, and keys
@@ -480,12 +479,19 @@ func main() {
 			os.Exit(1)
 		}
 
-	case "show-running-config", "show-config":
+	case "config":
+		action := "show"
+		args := os.Args[2:]
+		if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+			action = args[0]
+			args = args[1:]
+		}
 		fs, refs := cli.RegisterShowConfigFlags()
-		fs.Parse(os.Args[2:])
+		fs.Parse(args)
 		scf := cli.ParseShowConfigFlags(refs)
+		scf.Action = action
 		if err := cli.RunShowConfigCmd(scf); err != nil {
-			fmt.Fprintf(os.Stderr, "show-running-config error: %v\n", err)
+			fmt.Fprintf(os.Stderr, "config error: %v\n", err)
 			os.Exit(1)
 		}
 

--- a/src/main.go
+++ b/src/main.go
@@ -128,6 +128,8 @@ Usage:
   homer system [flags]          System operations (compaction, extensions, reload)
   homer agent [action] [flags]  Query heplify agent API (stats, health, watch)
   homer wizard [flags]          Interactive config generator wizard
+  homer show-running-config [flags]
+                                Print effective config (file + env + defaults)
   homer mcp [flags]             Start MCP stdio server
   homer migrate [action] [flags]
                                 Migrate data from Homer 7 (homer-app PostgreSQL).
@@ -214,6 +216,13 @@ agent -- Query heplify agent API:
 wizard -- Interactive config generator:
   --output <path>               Output file path (default: homer.json)
   --profile <name>              Non-interactive preset: all-in-one, writer, edge, coordinator, node
+
+show-running-config -- Print effective config after file + env + defaults
+  (alias: show-config). Not attached to a live process.
+  --config-path <path>          Path to config file or directory
+  --section <path>              Dotted JSON path, e.g. storage.ducklake.compaction
+  --include-secrets             Do not redact passwords, tokens, and keys
+  --compact                     Single-line JSON
 
 mcp -- Start MCP stdio server:
   --config-path <path>          Path to config file or directory
@@ -468,6 +477,15 @@ func main() {
 		wf := cli.ParseWizardFlags(refs)
 		if err := cli.RunWizardCmd(wf); err != nil {
 			fmt.Fprintf(os.Stderr, "Wizard error: %v\n", err)
+			os.Exit(1)
+		}
+
+	case "show-running-config", "show-config":
+		fs, refs := cli.RegisterShowConfigFlags()
+		fs.Parse(os.Args[2:])
+		scf := cli.ParseShowConfigFlags(refs)
+		if err := cli.RunShowConfigCmd(scf); err != nil {
+			fmt.Fprintf(os.Stderr, "show-running-config error: %v\n", err)
 			os.Exit(1)
 		}
 

--- a/src/writer/compaction.go
+++ b/src/writer/compaction.go
@@ -275,8 +275,11 @@ func (c *CompactionService) Start() error {
 	}
 
 	logger.Info("CompactionService starting",
+		"engine", c.resolvedEngine(),
 		"interval", fmt.Sprintf("%ds", c.config.CheckIntervalSec),
 		"min_age_sec", c.config.MinAgeSec,
+		"max_compacted_files", c.effectiveMaxCompactedFiles(),
+		"max_file_size_bytes", c.effectiveMaxFileSizeBytes(),
 		"retention_days", c.config.RetentionDays,
 		"retention_days_by_table", len(c.config.RetentionDaysByTable),
 		"tables", len(c.tables))
@@ -430,7 +433,8 @@ func (c *CompactionService) inlineFlushOnlyLoop() {
 // per-table for retention and merge, then per-call for expire/cleanup.
 func (c *CompactionService) runCompaction() {
 	start := time.Now()
-	logger.Info("CompactionService: Starting compaction cycle")
+	logger.Info("CompactionService: Starting compaction cycle",
+		"engine", c.resolvedEngine())
 
 	// Refresh table list (read-only, no lock needed)
 	if err := c.discoverTables(); err != nil {
@@ -1017,6 +1021,13 @@ func (c *CompactionService) GetStats() map[string]interface{} {
 		"total_compactions":       c.totalCompactions,
 		"total_rows_deleted":      c.totalRowsDeleted,
 	}
+}
+
+func (c *CompactionService) resolvedEngine() string {
+	if c.config.Engine == EngineNativeGo {
+		return EngineNativeGo
+	}
+	return EngineDuckDB
 }
 
 func (c *CompactionService) effectiveMaxCompactedFiles() int {

--- a/src/writer/compaction_merge_test.go
+++ b/src/writer/compaction_merge_test.go
@@ -5,6 +5,27 @@ import (
 	"testing"
 )
 
+func TestResolvedEngine(t *testing.T) {
+	tests := []struct {
+		name   string
+		engine string
+		want   string
+	}{
+		{"empty is duckdb", "", EngineDuckDB},
+		{"explicit duckdb", EngineDuckDB, EngineDuckDB},
+		{"native", EngineNativeGo, EngineNativeGo},
+		{"unknown treated as duckdb", "other", EngineDuckDB},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &CompactionService{config: CompactionConfig{Engine: tt.engine}}
+			if got := svc.resolvedEngine(); got != tt.want {
+				t.Fatalf("resolvedEngine()=%q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestEffectiveMaxCompactedFiles(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
## Summary
- Add `homer config show` to print the effective config after file + `HOMER_*` env + defaults. Secrets are redacted unless `--include-secrets`. `--section` prints a dotted JSON path (e.g. `storage.ducklake.compaction`). No aliases: `homer config` without `show` is an error.
- Log resolved compaction `engine` (and merge bounds) on CompactionService start and each cycle so operators can confirm the default is `duckdb` without a config dump.

This is not attached to a live PID; it is the same load path the process uses at startup.

## Test plan
- [ ] `go test ./cli/ ./writer/ -count=1` from `src/`
- [ ] `homer config show --config-path /path/to/homer.json --section storage.ducklake.compaction` shows `"engine": "duckdb"` when unset
- [ ] `homer config` without `show` exits with an error
- [ ] JWT/S3 secrets are `********` unless `--include-secrets`
- [ ] Writer log contains `CompactionService starting engine=duckdb`