### PR TITLE
chore: bump version to 11.0.325

### DIFF
--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.324"
+	VERSION_APPLICATION = "11.0.325"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Bump `VERSION_APPLICATION` to 11.0.325 for `homer config show` and compaction engine logging that landed in #958 after 11.0.324.

## Test plan
- [x] Merge to `homer11`
- [x] Release `11.0.325` from `homer11`