### PR TITLE
fix(packaging): pin SHA-256 of bundled DuckDB extensions (GHSA-vqh9-j3rh-cj62)

### DIFF
--- a/scripts/download_duckdb_extensions.sh
+++ b/scripts/download_duckdb_extensions.sh
@@ -6,6 +6,9 @@
 # DUCKDB_VERSION must stay in sync with embedded DuckDB from
 # github.com/duckdb/duckdb-go-bindings in src/go.mod (e.g. v0.10505.x -> v1.5.5).
 #
+# Gzip blobs are SHA-256 pinned in scripts/duckdb_extension_checksums.txt
+# (GHSA-vqh9-j3rh-cj62). Update that file when bumping DUCKDB_VERSION.
+#
 # Usage:
 #   ./scripts/download_duckdb_extensions.sh [EXT_PLATFORM]
 #   If EXT_PLATFORM is omitted, it is derived from uname (linux_amd64, …).
@@ -13,6 +16,8 @@
 set -euo pipefail
 
 DUCKDB_VERSION="${DUCKDB_VERSION:-v1.5.5}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHECKSUMS="${SCRIPT_DIR}/duckdb_extension_checksums.txt"
 
 if [ -n "${1:-}" ]; then
   EXT_PLATFORM="$1"
@@ -22,6 +27,16 @@ else
   EXT_PLATFORM="${os}_${arch}"
 fi
 
+if [ ! -f "${CHECKSUMS}" ]; then
+  echo "error: missing checksum file ${CHECKSUMS}" >&2
+  exit 1
+fi
+
+expected_sha256() {
+  local key="$1"
+  awk -v k="${key}" '$1 !~ /^#/ && NF>=2 && $2==k {print $1; found=1; exit} END{exit !found}' "${CHECKSUMS}"
+}
+
 ext_dir="bundled_extensions/${DUCKDB_VERSION}/${EXT_PLATFORM}"
 mkdir -p "${ext_dir}"
 
@@ -29,15 +44,29 @@ echo "Downloading DuckDB ${DUCKDB_VERSION} extensions for ${EXT_PLATFORM}..."
 
 # httpfs + aws are required for S3 secrets using PROVIDER credential_chain
 # (IAM-role / instance-profile credentials); aws depends on httpfs.
-for ext in ducklake httpfs aws; do
-  url="https://extensions.duckdb.org/${DUCKDB_VERSION}/${EXT_PLATFORM}/${ext}.duckdb_extension.gz"
+for ext in ducklake httpfs aws sqlite_scanner; do
+  rel="${DUCKDB_VERSION}/${EXT_PLATFORM}/${ext}.duckdb_extension.gz"
+  url="https://extensions.duckdb.org/${rel}"
   dest="${ext_dir}/${ext}.duckdb_extension"
+  expected="$(expected_sha256 "${rel}" || true)"
+  if [ -z "${expected}" ]; then
+    echo "error: no SHA-256 pin for ${rel} in ${CHECKSUMS}" >&2
+    exit 1
+  fi
   echo "  ${url} -> ${dest}"
-  curl -fsSL "${url}" | gunzip > "${dest}"
+  gz_tmp="$(mktemp)"
+  trap 'rm -f "${gz_tmp}"' EXIT
+  curl -fsSL -o "${gz_tmp}" "${url}"
+  actual="$(sha256sum "${gz_tmp}" | awk '{print $1}')"
+  if [ "${actual}" != "${expected}" ]; then
+    echo "error: SHA-256 mismatch for ${rel}" >&2
+    echo "  expected ${expected}" >&2
+    echo "  got      ${actual}" >&2
+    exit 1
+  fi
+  gunzip -c "${gz_tmp}" > "${dest}"
+  rm -f "${gz_tmp}"
+  trap - EXIT
 done
-
-echo "  sqlite_scanner (as sqlite_scanner.duckdb_extension)..."
-curl -fsSL "https://extensions.duckdb.org/${DUCKDB_VERSION}/${EXT_PLATFORM}/sqlite_scanner.duckdb_extension.gz" \
-  | gunzip > "${ext_dir}/sqlite_scanner.duckdb_extension"
 
 echo "Extensions downloaded to ${ext_dir}/"

--- a/scripts/duckdb_extension_checksums.txt
+++ b/scripts/duckdb_extension_checksums.txt
@@ -1,0 +1,18 @@
+# SHA-256 of DuckDB core extension .gz blobs from https://extensions.duckdb.org
+# (GHSA-vqh9-j3rh-cj62). Fail the download script on mismatch.
+#
+# Format: <sha256>  <DUCKDB_VERSION>/<EXT_PLATFORM>/<name>.duckdb_extension.gz
+#
+# Refresh when DUCKDB_VERSION changes:
+#   curl -fsSL "https://extensions.duckdb.org/${VER}/${PLAT}/${NAME}.duckdb_extension.gz" | sha256sum
+#
+# Recorded 2026-08-20 from extensions.duckdb.org for v1.5.5.
+
+733ccf19fedcfd5e0bfaf85993219145181099cc411076cabf14933ea16ab452  v1.5.5/linux_amd64/ducklake.duckdb_extension.gz
+7cdd52a3135388718884a9b71e3987ba723002121e8e9de399c4ed619d824a05  v1.5.5/linux_amd64/httpfs.duckdb_extension.gz
+7454a7830b21e678f1700c6cc428540be3a688e959c81515fd1bfc0a538db3b3  v1.5.5/linux_amd64/aws.duckdb_extension.gz
+01292812092200c2d0b76324df9568d336ddaa5a198e7cc8fed124e84088e14e  v1.5.5/linux_amd64/sqlite_scanner.duckdb_extension.gz
+1813f74b24060d6ae97187b87d221c7ecbae67e5321929bc543bc5fdb1dc95b4  v1.5.5/linux_arm64/ducklake.duckdb_extension.gz
+0820e0b5b74efaa23608c239df8e744a68943318d530b483a529eace19cb5475  v1.5.5/linux_arm64/httpfs.duckdb_extension.gz
+c0c2ff813d07a1f69a3c06fb69663b93299f1145dbaab9aaeee1be4003da7170  v1.5.5/linux_arm64/aws.duckdb_extension.gz
+59e3d3197d8767e51c3df10157d4423f4df58f97d85ffe0eb0bf752325f76641  v1.5.5/linux_arm64/sqlite_scanner.duckdb_extension.gz


### PR DESCRIPTION
## Summary
- Pin gzip SHA-256 for `ducklake`, `httpfs`, `aws`, and `sqlite_scanner` on `linux_amd64` / `linux_arm64` (DuckDB v1.5.5).
- `scripts/download_duckdb_extensions.sh` downloads to a temp file, verifies the pin, then gunzips. Unknown platform or mismatch fails the build.

Closes draft advisory https://github.com/sipcapture/homer/security/advisories/GHSA-vqh9-j3rh-cj62

## Test plan
- [x] `bash -n scripts/download_duckdb_extensions.sh`
- [x] Re-fetch `linux_amd64/aws.duckdb_extension.gz` and confirm `sha256sum -c` against the committed pin
- [x] Package CI (`download_duckdb_extensions.sh linux_amd64` / `linux_arm64`) succeeds
- [x] Tampering with a pin or a downloaded blob fails the script