### PR TITLE
fix(scripting): sandbox Lua VMs (GHSA-m726-p857-j3cc)

### DIFF
--- a/src/scripting/correlation/engine_test.go
+++ b/src/scripting/correlation/engine_test.go
@@ -109,6 +109,19 @@ end
 	}
 }
 
+func TestCorrelateOsExecuteBlocked(t *testing.T) {
+	script := `
+function correlate(data, nodes)
+  os.execute("true")
+  return {"leaked"}
+end
+`
+	e := newTestEngine(t, script, nil)
+	if res := e.Correlate(context.Background(), CorrelationInput{HepID: 1, Profile: "call"}); res != nil {
+		t.Fatalf("expected nil when os.execute is used, got %#v", res)
+	}
+}
+
 func TestCorrelateMissingCorrelateFunction(t *testing.T) {
 	// DoString succeeds but `correlate` is absent — must not crash.
 	e := newTestEngine(t, `local x = 1`, nil)

--- a/src/scripting/correlation/vm.go
+++ b/src/scripting/correlation/vm.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	"github.com/sipcapture/golua/lua"
+	"github.com/sipcapture/homer-core/src/scripting"
 	"github.com/sipcapture/homer-core/src/scripting/luar"
 )
 
@@ -42,7 +43,7 @@ func runScript(ctx context.Context, e *CorrelationEngine, scr *compiledScript, i
 		return nil, fmt.Errorf("correlation: failed to create Lua state")
 	}
 	defer L.Close()
-	L.OpenLibs()
+	scripting.OpenSandbox(L)
 
 	bridge := newSQLBridge(ctx, e, in)
 	result := &CorrelationResult{}

--- a/src/scripting/luaengine.go
+++ b/src/scripting/luaengine.go
@@ -37,7 +37,7 @@ func NewLuaEngine(cfg *ScriptConfig) (*LuaEngine, error) {
 		lokiAllow: remotelog.LokiCustomLabelAllowlist(cfg.LokiCustomLabels),
 	}
 	d.LuaState = lua.NewState()
-	d.LuaState.OpenLibs()
+	OpenSandbox(d.LuaState)
 
 	// Register functions available in Lua scripts
 	luar.Register(d.LuaState, "", luar.Map{

--- a/src/scripting/sandbox.go
+++ b/src/scripting/sandbox.go
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package scripting
+
+import "github.com/sipcapture/golua/lua"
+
+// dangerousLuaGlobals are stripped after opening the safe subset of stdlib.
+// os/io/package/debug are RCE primitives (GHSA-m726-p857-j3cc). loadfile/dofile
+// read the host FS. load/loadstring accept bytecode. getfenv/setfenv can restore
+// a previous full _G. ffi/jit are LuaJIT escape hatches.
+var dangerousLuaGlobals = []string{
+	"os", "io", "package", "debug",
+	"dofile", "loadfile", "load", "loadstring",
+	"require", "module",
+	"getfenv", "setfenv",
+	"ffi", "jit",
+}
+
+// OpenSandbox loads base, table, string, and math only — not OpenLibs().
+// Helper APIs (HEP getters, executeSQL, …) are registered by the caller.
+func OpenSandbox(L *lua.State) {
+	if L == nil {
+		return
+	}
+	L.OpenBase()
+	L.OpenTable()
+	L.OpenString()
+	L.OpenMath()
+	for _, name := range dangerousLuaGlobals {
+		L.PushNil()
+		L.SetGlobal(name)
+	}
+}

--- a/src/scripting/sandbox_test.go
+++ b/src/scripting/sandbox_test.go
@@ -1,0 +1,69 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package scripting
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sipcapture/golua/lua"
+)
+
+func newSandboxedState(t *testing.T) *lua.State {
+	t.Helper()
+	L := lua.NewState()
+	if L == nil {
+		t.Fatal("lua.NewState returned nil")
+	}
+	t.Cleanup(L.Close)
+	OpenSandbox(L)
+	return L
+}
+
+func TestOpenSandboxBlocksOSExecute(t *testing.T) {
+	L := newSandboxedState(t)
+	err := L.DoString(`os.execute("true")`)
+	if err == nil {
+		t.Fatal("expected os.execute to fail in the sandbox")
+	}
+	if !strings.Contains(err.Error(), "os") && !strings.Contains(err.Error(), "nil") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestOpenSandboxBlocksIOPopen(t *testing.T) {
+	L := newSandboxedState(t)
+	err := L.DoString(`io.popen("true")`)
+	if err == nil {
+		t.Fatal("expected io.popen to fail in the sandbox")
+	}
+}
+
+func TestOpenSandboxKeepsStringGsub(t *testing.T) {
+	L := newSandboxedState(t)
+	if err := L.DoString(`_G.__sandbox_out = ("id_b2b-1"):gsub("_b2b%-%d+$", "")`); err != nil {
+		t.Fatalf("string.gsub should work: %v", err)
+	}
+	L.GetGlobal("__sandbox_out")
+	defer L.Pop(1)
+	if got := L.ToString(-1); got != "id" {
+		t.Fatalf("gsub result = %q, want %q", got, "id")
+	}
+}
+
+func TestOpenSandboxDangerousGlobalsAreNil(t *testing.T) {
+	L := newSandboxedState(t)
+	for _, name := range []string{"os", "io", "package", "debug", "loadfile", "dofile", "require", "ffi", "jit"} {
+		L.GetGlobal(name)
+		nilish := L.IsNil(-1)
+		L.Pop(1)
+		if !nilish {
+			t.Errorf("%s should be nil", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Stop calling `OpenLibs()` in HEP packet scripting and correlation Lua VMs.
- Load only `base` / `table` / `string` / `math`, then nil `os`, `io`, `package`, `debug`, `loadfile`/`dofile`/`load`/`loadstring`, `getfenv`/`setfenv`, `ffi`/`jit`.
- Go helpers (`executeSQL`, HEP getters, `HashString`, …) stay registered by the engines.

Closes draft advisory https://github.com/sipcapture/homer/security/advisories/GHSA-m726-p857-j3cc

## Test plan
- [x] `go test ./scripting/ ./scripting/correlation/`
- [x] `os.execute` / `io.popen` fail; `string.gsub` still works
- [x] Correlation `os.execute` script returns nil extras