### PR TITLE
fix(auth): force password change after sipcapture login (GHSA-263f-5xrw-c34r)

### DIFF
--- a/docs/AUTH_LDAP_AND_OAUTH.md
+++ b/docs/AUTH_LDAP_AND_OAUTH.md
@@ -70,7 +70,7 @@ Meaning (string or `{"type":"internal"}` without custom hash):
 - If a row for that username **already** exists with a non-empty `password_hash`, bootstrap does not change the password (upgrade-safe). Empty `password_hash` on an existing row may be repaired from config hash or a new random password when hash is omitted.
 - After first login, operators should **change the password** (Settings → Users, or `PATCH /me`). Updates store a **bcrypt** hash. Further logins use the stored hash only.
 
-**Docker / explicit bootstrap:** `examples/docker/docker-compose.yaml` sets `HOMER_COORDINATOR_AUTH_ADMIN_PASSWORD_HASH` to the SHA-256 hex of **`sipcapture`** — that path is unchanged and still yields first login **`admin` / `sipcapture`** on fresh installs using those examples.
+**Docker / explicit bootstrap:** `examples/docker/docker-compose.yaml` omits `HOMER_COORDINATOR_AUTH_ADMIN_PASSWORD_HASH`. Fresh installs get a random admin password in coordinator logs. Existing `users` rows with the historical **`sipcapture`** SHA-256 hash can still log in, then must change the password in the UI.
 
 ### Legacy object: only `admin_user` / `admin_password_hash` (no `type`)
 
@@ -83,7 +83,7 @@ You may still use an object **without** `type` (for environment overrides, confi
 }
 ```
 
-- If **`admin_user`** is unset or **`admin`** and **`admin_password_hash`** is empty, the loader treats this as **`internal`** with random bootstrap password when no `users` row exists. If **`admin_password_hash`** is set (including the legacy sipcapture SHA-256 hex from docker examples), bootstrap uses that hash.
+- If **`admin_user`** is unset or **`admin`** and **`admin_password_hash`** is empty, the loader treats this as **`internal`** with random bootstrap password when no `users` row exists. If **`admin_password_hash`** is set, bootstrap uses that hash (except the well-known sipcapture digest, which is treated as empty and replaced with a random bcrypt password).
 - For **`--reset-admin-password`**, the config field **`admin_password_hash`** remains **SHA-256 hex** (see [Reset admin password](#reset-admin-password)). User records created or updated through the API use **bcrypt** instead.
 
 ### Reset admin password

--- a/docs/COORDINATOR.md
+++ b/docs/COORDINATOR.md
@@ -294,7 +294,7 @@ homer --config-path /path/to/homer.json --reset-admin-password
 
 The process opens **`coordinator.settings_db_path`**, ensures schema, updates or inserts the **`users`** row for `admin_user`, and **exits** (no HTTP server). Details, JSON examples, and env overrides: [AUTH_LDAP_AND_OAUTH.md](./AUTH_LDAP_AND_OAUTH.md#reset-admin-password).
 
-**Password hashes:** Users created or updated via the API store **bcrypt** in `users.password_hash`. Login also accepts legacy **SHA-256 hex** (migrated homer-app users), except the well-known digest of **`sipcapture`**, which is refused. **`--reset-admin-password`** still expects **SHA-256 hex** or bcrypt in `admin_password_hash` (see [AUTH_LDAP_AND_OAUTH.md](./AUTH_LDAP_AND_OAUTH.md#reset-admin-password)).
+**Password hashes:** Users created or updated via the API store **bcrypt** in `users.password_hash`. Login also accepts legacy **SHA-256 hex** (migrated homer-app users). The well-known digest of **`sipcapture`** still verifies so existing installs can sign in, then the session requires a password change (`must_change_password`). **`--reset-admin-password`** still expects **SHA-256 hex** or bcrypt in `admin_password_hash` (see [AUTH_LDAP_AND_OAUTH.md](./AUTH_LDAP_AND_OAUTH.md#reset-admin-password)).
 
 **Generating a SHA-256 hex hash (for `admin_password_hash` / reset only):**
 
@@ -303,7 +303,7 @@ The process opens **`coordinator.settings_db_path`**, ensures schema, updates or
 echo -n "your-password" | sha256sum | cut -d' ' -f1
 ```
 
-Do not use the historical password `sipcapture`; that hash is blocked.
+Do not use the historical password `sipcapture`; bootstrap and password updates refuse that value. Existing sipcapture hashes require a UI password change after login.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -7,7 +7,7 @@ Homer 11.0.282–11.0.284 closes three coordinator security issues. **11.0.313**
 | Issue | Risk (before) | Fix | Typical upgrade impact |
 |-------|----------------|-----|-------------------------|
 | Empty `coordinator.jwt.secret` | Protected API routes were **unauthenticated** | JWT middleware always enforced; empty secret → auto-generated persisted secret | Installs with explicit JWT env/config: **no change**. Installs with empty secret: API now requires login or `Auth-Token` |
-| Default admin `sipcapture` | Predictable first-login password | No compose hash; random bcrypt at first boot; login refuses the well-known SHA-256 digest | Existing `users` row with sipcapture hash: **login fails** until `--reset-admin-password` |
+| Default admin `sipcapture` | Predictable first-login password | No compose hash; random bcrypt at first boot; JWT `must_change_password` until a new password is set | Existing `users` row with sipcapture hash: **login works**, then the UI/API require a password change |
 | `POST /api/v4/statistics/query` `rawquery` | Unvalidated SQL passthrough | Same `ValidateRawSQL` rules as `/api/v4/query` | Legitimate `SELECT` / `WITH` / `SHOW` queries: **no change** |
 | Node `POST /query` (port+1) | Unauthenticated arbitrary DuckDB SQL / file read | `ValidateRawSQL` always; Bearer auth when `flight_server.auth_token` set; auto-token on non-loopback bind | All-in-one with default `0.0.0.0`: token auto-persisted; coordinator local node gets `token` automatically |
 | `sqlite_scan` / external scanners | Authenticated bypass of SQL denylist | Blocked in `ValidateRawSQL` | Legitimate lake `SELECT`s: **no change** |
@@ -52,9 +52,9 @@ Environment: `HOMER_COORDINATOR_JWT_SECRET`.
 |--------|--------------------------------|----------------------|
 | Explicit `admin_password_hash` or env | Uses configured hash | Unchanged if row already has a password |
 | Empty hash | Random password generated; **logged once** at startup | Unchanged if row already has a password |
-| Docker examples | Hash omitted; random password in coordinator logs | Existing sipcapture hash in `users` **no longer logs in** |
+| Docker examples | Hash omitted; random password in coordinator logs | Existing sipcapture hash in `users`: login then **forced password change** |
 
-Legacy SHA-256 rows from **migrated homer-app users** still authenticate, except the well-known **`sipcapture`** digest, which is refused. Reset with `homer --reset-admin-password`.
+Legacy SHA-256 rows from **migrated homer-app users** still authenticate. The well-known **`sipcapture`** digest still logs in, but the session is limited to `GET/PATCH /api/v4/me` and logout until the password is changed. `--reset-admin-password` still refuses that digest as a *new* hash.
 
 **Wizard:** empty admin password field → random password (bcrypt in JSON) shown once after save.
 

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -65,8 +65,9 @@ high ingest. Details: [OOM.md](../../docs/OOM.md), [DUCKDB_TUNING.md](../../docs
 ## First login
 
 Omit `HOMER_COORDINATOR_AUTH_ADMIN_PASSWORD_HASH`. On first start the coordinator
-creates `admin` with a random bcrypt password and logs it once. Do not use the
-historical password `sipcapture` — that hash is refused at login.
+creates `admin` with a random bcrypt password and logs it once. Existing installs
+that still have the historical `sipcapture` hash can sign in, then must set a
+new password in the UI before using the rest of the API.
 
 ## Endpoints
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -897,8 +897,9 @@ type JWTConfig struct {
 
 const (
 	// LegacySHA256SipcaptureHash is the SHA-256 hex digest of the historical
-	// default password "sipcapture". Tests and docs may reference it; login
-	// and bootstrap refuse this value (see passwordhash.IsDisallowedDefaultHash).
+	// default password "sipcapture". Tests and docs may reference it; bootstrap
+	// and --reset-admin-password refuse this value. Login still verifies it so
+	// existing installs can be forced to change the password in the UI.
 	LegacySHA256SipcaptureHash = passwordhash.LegacySHA256SipcaptureHash
 )
 

--- a/src/coordinator/handlers/auth.go
+++ b/src/coordinator/handlers/auth.go
@@ -21,6 +21,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/sipcapture/homer-core/src/config"
 	"github.com/sipcapture/homer-core/src/coordinator/services"
+	"github.com/sipcapture/homer-core/src/passwordhash"
 	"golang.org/x/oauth2"
 )
 
@@ -182,15 +183,17 @@ type LoginResponse struct {
 	Token string `json:"token"`
 	Scope string `json:"scope"`
 	User  struct {
-		Admin    bool   `json:"admin"`
-		Username string `json:"username"`
+		Admin              bool   `json:"admin"`
+		Username           string `json:"username"`
+		MustChangePassword bool   `json:"must_change_password,omitempty"`
 	} `json:"user"`
 }
 
 // JWTClaims represents the JWT claims
 type JWTClaims struct {
-	Username string `json:"username"`
-	Admin    bool   `json:"admin"`
+	Username           string `json:"username"`
+	Admin              bool   `json:"admin"`
+	MustChangePassword bool   `json:"must_change_password,omitempty"`
 	jwt.RegisteredClaims
 }
 
@@ -228,7 +231,7 @@ func (h *AuthHandler) Login(c echo.Context) error {
 	}
 
 	// Generate JWT token
-	token, _, err := h.generateToken(user.Username, user.IsAdmin)
+	token, _, err := h.generateToken(user.Username, user.IsAdmin, passwordhash.IsDisallowedDefaultHash(user.PasswordHash))
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]interface{}{
 			"error": "Failed to generate token",
@@ -247,11 +250,13 @@ func (h *AuthHandler) Login(c echo.Context) error {
 			Token: token,
 			Scope: scope,
 			User: struct {
-				Admin    bool   `json:"admin"`
-				Username string `json:"username"`
+				Admin              bool   `json:"admin"`
+				Username           string `json:"username"`
+				MustChangePassword bool   `json:"must_change_password,omitempty"`
 			}{
-				Admin:    user.IsAdmin,
-				Username: user.Username,
+				Admin:              user.IsAdmin,
+				Username:           user.Username,
+				MustChangePassword: passwordhash.IsDisallowedDefaultHash(user.PasswordHash),
 			},
 		},
 	})
@@ -335,17 +340,21 @@ func (h *AuthHandler) JWTMiddleware() echo.MiddlewareFunc {
 			}
 
 			c.Set("user", token)
+			if err := h.rejectIfPasswordChangeRequired(c, claims, false); err != nil {
+				return err
+			}
 			return next(c)
 		}
 	}
 }
 
 // generateToken generates a JWT token and returns token + sessionId
-func (h *AuthHandler) generateToken(username string, admin bool) (string, string, error) {
+func (h *AuthHandler) generateToken(username string, admin bool, mustChangePassword bool) (string, string, error) {
 	sessionID := newSessionID()
 	claims := &JWTClaims{
-		Username: username,
-		Admin:    admin,
+		Username:           username,
+		Admin:              admin,
+		MustChangePassword: mustChangePassword,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ID:        sessionID,
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Duration(h.expireHours) * time.Hour)),

--- a/src/coordinator/handlers/auth_session_cookie_test.go
+++ b/src/coordinator/handlers/auth_session_cookie_test.go
@@ -105,7 +105,7 @@ func TestV4CreateSession_RememberSetsPersistentCookie(t *testing.T) {
 
 func TestJWTMiddlewareV4_AcceptsSessionCookie(t *testing.T) {
 	h := newCookieAuthHandler(t)
-	token, _, err := h.generateToken("admin", true)
+	token, _, err := h.generateToken("admin", true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,7 +130,7 @@ func TestJWTMiddlewareV4_AcceptsSessionCookie(t *testing.T) {
 
 func TestV4LogoutCurrentSession_ClearsCookie(t *testing.T) {
 	h := newCookieAuthHandler(t)
-	token, _, err := h.generateToken("admin", true)
+	token, _, err := h.generateToken("admin", true, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/coordinator/handlers/auth_v4.go
+++ b/src/coordinator/handlers/auth_v4.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/labstack/echo/v4"
+	"github.com/sipcapture/homer-core/src/passwordhash"
 )
 
 type LoginResponseV4 struct {
@@ -23,7 +24,8 @@ type LoginResponseV4 struct {
 		Token string `json:"token"`
 		Scope string `json:"scope"`
 		User  struct {
-			Admin bool `json:"admin"`
+			Admin              bool `json:"admin"`
+			MustChangePassword bool `json:"must_change_password,omitempty"`
 		} `json:"user"`
 	} `json:"data"`
 	Meta Meta `json:"meta"`
@@ -62,15 +64,16 @@ type OAuth2TokenExchangeRequest struct {
 }
 
 type UserProfileV4 struct {
-	GUID            string `json:"guid,omitempty"`
-	Username        string `json:"username,omitempty"`
-	DisplayName     string `json:"display_name,omitempty"`
-	Email           string `json:"email,omitempty"`
-	Avatar          string `json:"avatar,omitempty"`
-	Group           string `json:"group,omitempty"`
-	Admin           bool   `json:"admin,omitempty"`
-	ExternalAuth    bool   `json:"external_auth,omitempty"`
-	ExternalProfile string `json:"external_profile,omitempty"`
+	MustChangePassword bool   `json:"must_change_password,omitempty"`
+	GUID               string `json:"guid,omitempty"`
+	Username           string `json:"username,omitempty"`
+	DisplayName        string `json:"display_name,omitempty"`
+	Email              string `json:"email,omitempty"`
+	Avatar             string `json:"avatar,omitempty"`
+	Group              string `json:"group,omitempty"`
+	Admin              bool   `json:"admin,omitempty"`
+	ExternalAuth       bool   `json:"external_auth,omitempty"`
+	ExternalProfile    string `json:"external_profile,omitempty"`
 }
 
 // MePatchRequest is the body for PATCH /api/v4/me (Profile panel).
@@ -113,7 +116,8 @@ func (h *AuthHandler) V4CreateSession(c echo.Context) error {
 		return writeError(c, http.StatusUnauthorized, "Unauthorized", "Invalid credentials")
 	}
 
-	token, _, err := h.generateToken(user.Username, user.IsAdmin)
+	mustChange := passwordhash.IsDisallowedDefaultHash(user.PasswordHash)
+	token, _, err := h.generateToken(user.Username, user.IsAdmin, mustChange)
 	if err != nil {
 		return writeError(c, http.StatusInternalServerError, "Server Error", "Failed to generate token")
 	}
@@ -127,6 +131,7 @@ func (h *AuthHandler) V4CreateSession(c echo.Context) error {
 	resp.Data.Token = token
 	resp.Data.Scope = scope
 	resp.Data.User.Admin = user.IsAdmin
+	resp.Data.User.MustChangePassword = mustChange
 	resp.Meta = buildMeta(c, "")
 
 	h.setSessionCookie(c, token, req.Remember)
@@ -249,7 +254,7 @@ func (h *AuthHandler) V4OAuth2TokenExchange(c echo.Context) error {
 		return writeError(c, http.StatusUnauthorized, "Unauthorized", "Invalid or expired token")
 	}
 
-	jwtToken, _, err := h.generateToken(username, isAdmin)
+	jwtToken, _, err := h.generateToken(username, isAdmin, false)
 	if err != nil {
 		return writeError(c, http.StatusInternalServerError, "Server Error", "Failed to generate token")
 	}
@@ -312,6 +317,12 @@ func (h *AuthHandler) V4PatchMe(c echo.Context) error {
 	if email == nil && password == nil && name == nil {
 		return writeError(c, http.StatusBadRequest, "Bad Request", "No fields to update")
 	}
+	if claims.MustChangePassword && password == nil {
+		return writeError(c, http.StatusBadRequest, "Bad Request", "Password change is required")
+	}
+	if password != nil && passwordhash.IsDefaultSipcapturePassword(*password) {
+		return writeError(c, http.StatusBadRequest, "Bad Request", "Choose a password other than the historical default")
+	}
 
 	dbUser, err := h.userService.GetUserByUsername(c.Request().Context(), claims.Username)
 	if err != nil {
@@ -326,10 +337,29 @@ func (h *AuthHandler) V4PatchMe(c echo.Context) error {
 		if err.Error() == "no fields to update" {
 			return writeError(c, http.StatusBadRequest, "Bad Request", "No fields to update")
 		}
+		if err == passwordhash.ErrDefaultSipcapturePassword {
+			return writeError(c, http.StatusBadRequest, "Bad Request", "Choose a password other than the historical default")
+		}
 		return writeError(c, http.StatusInternalServerError, "Server Error", "Failed to update profile")
 	}
 	if !updated {
 		return writeError(c, http.StatusNotFound, "Not Found", "User not found")
+	}
+
+	if password != nil {
+		if claims.ID != "" && h.sessionStore != nil {
+			exp := time.Now().Add(time.Duration(h.expireHours) * time.Hour)
+			if claims.ExpiresAt != nil {
+				exp = claims.ExpiresAt.Time
+			}
+			h.sessionStore.Revoke(claims.ID, exp)
+		}
+		newToken, _, err := h.generateToken(claims.Username, claims.Admin, false)
+		if err != nil {
+			return writeError(c, http.StatusInternalServerError, "Server Error", "Failed to generate token")
+		}
+		h.setSessionCookie(c, newToken, true)
+		claims.MustChangePassword = false
 	}
 
 	profile := h.buildUserProfileV4(c, claims)
@@ -378,10 +408,11 @@ func v4ContextError(c echo.Context, err error) error {
 
 func (h *AuthHandler) buildUserProfileV4(c echo.Context, claims *JWTClaims) UserProfileV4 {
 	profile := UserProfileV4{
-		Username:    claims.Username,
-		DisplayName: claims.Username,
-		Admin:       claims.Admin,
-		Group:       "user",
+		Username:           claims.Username,
+		DisplayName:        claims.Username,
+		Admin:              claims.Admin,
+		MustChangePassword: claims.MustChangePassword,
+		Group:              "user",
 	}
 	if claims.Admin {
 		profile.Group = "admin"

--- a/src/coordinator/handlers/auth_v4_helpers.go
+++ b/src/coordinator/handlers/auth_v4_helpers.go
@@ -199,7 +199,35 @@ func (h *AuthHandler) JWTMiddlewareV4() echo.MiddlewareFunc {
 			}
 			c.Set("user", token)
 			c.Set("auth_source", src)
+			if err := h.rejectIfPasswordChangeRequired(c, claims, true); err != nil {
+				return err
+			}
 			return next(c)
 		}
 	}
+}
+
+func allowedWhilePasswordChangeRequired(c echo.Context) bool {
+	path := strings.TrimSuffix(c.Request().URL.Path, "/")
+	switch c.Request().Method {
+	case http.MethodGet:
+		return path == "/api/v4/me" || path == "/api/v3/auth/me"
+	case http.MethodPatch:
+		return path == "/api/v4/me"
+	case http.MethodDelete:
+		return path == "/api/v4/auth/sessions/current" || strings.HasPrefix(path, "/api/v4/auth/sessions/")
+	default:
+		return false
+	}
+}
+
+func (h *AuthHandler) rejectIfPasswordChangeRequired(c echo.Context, claims *JWTClaims, v4 bool) error {
+	if claims == nil || !claims.MustChangePassword || allowedWhilePasswordChangeRequired(c) {
+		return nil
+	}
+	const msg = "Password change required"
+	if v4 {
+		return writeError(c, http.StatusForbidden, "Forbidden", msg)
+	}
+	return c.JSON(http.StatusForbidden, map[string]interface{}{"error": msg})
 }

--- a/src/coordinator/handlers/auth_v4_test.go
+++ b/src/coordinator/handlers/auth_v4_test.go
@@ -127,8 +127,12 @@ func newTestAuthHandlerWithUsers(t *testing.T) (*AuthHandler, *services.UserServ
 }
 
 func setJWTOnContext(t *testing.T, c echo.Context, h *AuthHandler, username string, admin bool) {
+	setJWTOnContextWithMustChange(t, c, h, username, admin, false)
+}
+
+func setJWTOnContextWithMustChange(t *testing.T, c echo.Context, h *AuthHandler, username string, admin, mustChange bool) {
 	t.Helper()
-	tokenStr, _, err := h.generateToken(username, admin)
+	tokenStr, _, err := h.generateToken(username, admin, mustChange)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -242,5 +246,129 @@ func TestJWTTokenFromAuthTokenItem_NonAdminUserGroup(t *testing.T) {
 	}
 	if claims.Admin {
 		t.Fatal("admin: got true want false")
+	}
+}
+
+func newTestAuthHandlerWithSipcaptureHash(t *testing.T) *AuthHandler {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.duckdb")
+	db, err := services.OpenSettingsDB(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := services.EnsureSettingsSchema(db); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO users (username, password_hash, email, full_name, is_admin, is_active, created_at, updated_at)
+		VALUES ('admin', '`+passwordhash.LegacySHA256SipcaptureHash+`', '', '', true, true, current_timestamp, current_timestamp)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &AuthHandler{
+		jwtSecret:   "test-secret-minimum-32-characters-long",
+		expireHours: 24,
+		userService: services.NewUserService(db),
+	}
+}
+
+func TestV4CreateSession_SipcaptureSetsMustChangePassword(t *testing.T) {
+	h := newTestAuthHandlerWithSipcaptureHash(t)
+	e := echo.New()
+	body := `{"username":"admin","password":"sipcapture","type":"internal"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v4/auth/sessions", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := h.V4CreateSession(c); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status: got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp LoginResponseV4
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Data.User.MustChangePassword {
+		t.Fatal("must_change_password: want true")
+	}
+	tok, err := jwt.ParseWithClaims(resp.Data.Token, &JWTClaims{}, func(token *jwt.Token) (interface{}, error) {
+		return []byte(h.jwtSecret), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claims := tok.Claims.(*JWTClaims)
+	if !claims.MustChangePassword {
+		t.Fatal("JWT must_change_password: want true")
+	}
+}
+
+func TestJWTMiddlewareV4_BlocksUntilPasswordChanged(t *testing.T) {
+	h := newTestAuthHandler(false)
+	e := echo.New()
+	g := e.Group("/api/v4")
+	g.Use(h.JWTMiddlewareV4())
+	g.GET("/me", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
+	g.GET("/dashboards", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
+
+	token, _, err := h.generateToken("admin", true, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v4/dashboards", nil)
+	req.Header.Set(echo.HeaderAuthorization, "Bearer "+token)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("dashboards: got %d want 403 body=%s", rec.Code, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v4/me", nil)
+	req.Header.Set(echo.HeaderAuthorization, "Bearer "+token)
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("me: got %d want 200 body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestV4PatchMe_MustChangeRequiresPassword(t *testing.T) {
+	h, _ := newTestAuthHandlerWithUsers(t)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPatch, "/api/v4/me", strings.NewReader(`{"email":"x@example.com"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	setJWTOnContextWithMustChange(t, c, h, "admin", true, true)
+
+	if err := h.V4PatchMe(c); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestV4PatchMe_RejectsSipcapturePassword(t *testing.T) {
+	h, _ := newTestAuthHandlerWithUsers(t)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPatch, "/api/v4/me", strings.NewReader(`{"password":"sipcapture"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	setJWTOnContext(t, c, h, "admin", true)
+
+	if err := h.V4PatchMe(c); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d body=%s", rec.Code, rec.Body.String())
 	}
 }

--- a/src/coordinator/handlers/users_v4.go
+++ b/src/coordinator/handlers/users_v4.go
@@ -15,6 +15,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/labstack/echo/v4"
 	"github.com/sipcapture/homer-core/src/coordinator/services"
+	"github.com/sipcapture/homer-core/src/passwordhash"
 )
 
 type UsersHandler struct {
@@ -137,6 +138,9 @@ func (h *UsersHandler) V4UsersCreate(c echo.Context) error {
 
 	id, err := h.userService.CreateUser(c.Request().Context(), req.Username, req.Password, req.Email, strings.TrimSpace(req.Name), isAdmin, enabled)
 	if err != nil {
+		if err == passwordhash.ErrDefaultSipcapturePassword {
+			return writeError(c, http.StatusBadRequest, "Bad Request", "Choose a password other than the historical default")
+		}
 		return writeError(c, http.StatusInternalServerError, "Server Error", "Failed to create user")
 	}
 
@@ -207,6 +211,9 @@ func (h *UsersHandler) V4UsersUpdate(c echo.Context) error {
 	if err != nil {
 		if err.Error() == "no fields to update" {
 			return writeError(c, http.StatusBadRequest, "Bad Request", "No fields to update")
+		}
+		if err == passwordhash.ErrDefaultSipcapturePassword {
+			return writeError(c, http.StatusBadRequest, "Bad Request", "Choose a password other than the historical default")
 		}
 		return writeError(c, http.StatusInternalServerError, "Server Error", "Failed to update user")
 	}

--- a/src/coordinator/services/user_service.go
+++ b/src/coordinator/services/user_service.go
@@ -193,6 +193,9 @@ func (s *UserService) CreateUser(ctx context.Context, username, password, email,
 	if s.db == nil {
 		return 0, fmt.Errorf("settings db not available")
 	}
+	if passwordhash.IsDefaultSipcapturePassword(password) {
+		return 0, passwordhash.ErrDefaultSipcapturePassword
+	}
 
 	passwordHash, err := passwordhash.Hash(password)
 	if err != nil {
@@ -229,6 +232,9 @@ func (s *UserService) UpdateUser(ctx context.Context, id int64, email, password,
 		set = append(set, fmt.Sprintf("email = '%s'", sqlvalidator.SafeString(*email)))
 	}
 	if password != nil {
+		if passwordhash.IsDefaultSipcapturePassword(*password) {
+			return false, passwordhash.ErrDefaultSipcapturePassword
+		}
 		passwordHash, err := passwordhash.Hash(*password)
 		if err != nil {
 			return false, err
@@ -383,7 +389,7 @@ func escapeSQL(s string) string {
 // single-quoted SQL string. Unlike escapeSQL/SafeString it does NOT truncate,
 // because fields_mapping and Lua scripts can exceed the SafeString length limit.
 //
-// DuckDB does not treat backslash as an escape inside '...' literals (only ''
+// DuckDB does not treat backslash as an escape inside '...' literals (only ”
 // doubles a quote). GHSA-vxc3-v6h9-8856 recommended also doubling backslashes
 // to match SafeString; that would store extra backslashes and corrupt JSON \n,
 // \t, \uXXXX and Windows paths. Do not apply that change unless the parser

--- a/src/coordinator/services/user_service_test.go
+++ b/src/coordinator/services/user_service_test.go
@@ -162,7 +162,7 @@ func TestGetUserByUsername_CaseInsensitive(t *testing.T) {
 	}
 }
 
-func TestAuthenticate_RejectsSipcaptureDefaultHash(t *testing.T) {
+func TestAuthenticate_AcceptsSipcaptureDefaultHash(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "settings.duckdb")
 	db, err := OpenSettingsDB(path)
@@ -182,7 +182,8 @@ func TestAuthenticate_RejectsSipcaptureDefaultHash(t *testing.T) {
 		t.Fatal(err)
 	}
 	svc := NewUserService(db)
-	if _, err := svc.Authenticate(ctx, "admin", "sipcapture"); err == nil {
-		t.Fatal("sipcapture default hash must not authenticate")
+	u, err := svc.Authenticate(ctx, "admin", "sipcapture")
+	if err != nil || u == nil {
+		t.Fatalf("sipcapture default hash should authenticate so the UI can force a change: err=%v", err)
 	}
 }

--- a/src/passwordhash/password.go
+++ b/src/passwordhash/password.go
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 // Package passwordhash provides password hashing and verification for Homer.
-// New passwords use bcrypt; legacy SHA-256 hex hashes (homer-app) remain
-// verifiable except the well-known sipcapture digest.
+// New passwords use bcrypt; legacy SHA-256 hex hashes (homer-app) remain verifiable.
 package passwordhash
 
 import (
+	"errors"
 	"strings"
 
 	"golang.org/x/crypto/bcrypt"
@@ -16,12 +16,21 @@ import (
 const bcryptCost = bcrypt.DefaultCost
 
 // LegacySHA256SipcaptureHash is SHA-256("sipcapture"), the historical default
-// admin password. Login and bootstrap refuse this digest (GHSA-263f-5xrw-c34r).
+// admin password (GHSA-263f-5xrw-c34r).
 const LegacySHA256SipcaptureHash = "883ffc1f37fd0fe542b0fb9740035c4383e7d976c411161d24e62edace280f90"
+
+// ErrDefaultSipcapturePassword is returned when creating or updating a user
+// with the historical default password.
+var ErrDefaultSipcapturePassword = errors.New("password cannot be the historical default sipcapture")
 
 // IsDisallowedDefaultHash reports the well-known sipcapture SHA-256 hex.
 func IsDisallowedDefaultHash(stored string) bool {
 	return strings.EqualFold(strings.TrimSpace(stored), LegacySHA256SipcaptureHash)
+}
+
+// IsDefaultSipcapturePassword reports the historical cleartext default.
+func IsDefaultSipcapturePassword(password string) bool {
+	return strings.TrimSpace(password) == "sipcapture"
 }
 
 // Hash returns a bcrypt hash for a new password.
@@ -50,9 +59,6 @@ func Verify(password, stored string) bool {
 	}
 	if isBcryptHash(stored) {
 		return bcrypt.CompareHashAndPassword([]byte(stored), []byte(password)) == nil
-	}
-	if IsDisallowedDefaultHash(stored) {
-		return false
 	}
 	return legacySHA256HexEqual(password, stored)
 }

--- a/src/passwordhash/password_test.go
+++ b/src/passwordhash/password_test.go
@@ -35,11 +35,20 @@ func TestVerifyLegacySHA256(t *testing.T) {
 	}
 }
 
-func TestVerifyRejectsSipcaptureDefault(t *testing.T) {
-	if Verify("sipcapture", LegacySHA256SipcaptureHash) {
-		t.Fatal("well-known sipcapture hash must not authenticate")
+func TestVerifyAcceptsSipcaptureDefaultHash(t *testing.T) {
+	if !Verify("sipcapture", LegacySHA256SipcaptureHash) {
+		t.Fatal("sipcapture SHA-256 should still verify so upgrades can force a password change")
 	}
-	if Verify("sipcapture", strings.ToUpper(LegacySHA256SipcaptureHash)) {
-		t.Fatal("uppercase sipcapture hash must not authenticate")
+	if !Verify("sipcapture", strings.ToUpper(LegacySHA256SipcaptureHash)) {
+		t.Fatal("uppercase sipcapture SHA-256 should still verify")
+	}
+}
+
+func TestIsDisallowedDefaultHash(t *testing.T) {
+	if !IsDisallowedDefaultHash(LegacySHA256SipcaptureHash) {
+		t.Fatal("expected sipcapture digest")
+	}
+	if IsDisallowedDefaultHash("13d249f2cb4127b40cfa757866850278793f814ded3c587fe5889e889a7a9f6c") {
+		t.Fatal("other SHA-256 hashes must not be treated as the default")
 	}
 }

--- a/src/ui/src/App.test.tsx
+++ b/src/ui/src/App.test.tsx
@@ -70,6 +70,49 @@ describe('App smoke/integration', () => {
     })
   })
 
+  it('forces a password change when the session requires it', async () => {
+    let sessionActive = false
+    vi.stubGlobal('fetch', vi.fn(async (url, opts: { method?: string } = {}) => {
+      const asString = String(url)
+      if (asString.endsWith('/auth/providers')) {
+        return { ok: true, status: 200, json: async () => ({ data: { internal: { enable: true } } }) }
+      }
+      if (asString.endsWith('/auth/sessions') && opts.method === 'POST') {
+        sessionActive = true
+        return { ok: true, status: 201, json: async () => ({ data: { token: 'test-token' } }) }
+      }
+      if (asString.endsWith('/me') && opts.method !== 'PATCH') {
+        if (!sessionActive) {
+          return { ok: false, status: 401, json: async () => ({}) }
+        }
+        return { ok: true, status: 200, json: async () => ({ data: { username: 'admin', admin: true, must_change_password: true } }) }
+      }
+      return { ok: true, status: 200, json: async () => ({ data: {} }) }
+    }))
+
+    renderApp()
+    await waitFor(() => {
+      expect(screen.getByLabelText('Login')).toBeInTheDocument()
+    })
+    fireEvent.change(screen.getByLabelText('Login'), { target: { value: 'admin' } })
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'sipcapture' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Change default password')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('No dashboards available. Create one above or reset to defaults.')).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText('New password'), { target: { value: 'newsecret' } })
+    fireEvent.change(screen.getByPlaceholderText('Confirm password'), { target: { value: 'newsecret' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save and sign in again' }))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Login')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Change default password')).not.toBeInTheDocument()
+  })
+
   it('defaults to system theme and follows prefers-color-scheme when storage is empty', async () => {
     vi.stubGlobal(
       'matchMedia',

--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -32,6 +32,7 @@ import { LocaleProvider } from "@/components/locale/locale-provider"
 import { WindowDock } from "@/components/ui/window-dock"
 import { useConfirm } from "@/components/ui/confirm-dialog"
 import { LoginPage } from './LoginPage'
+import { ForcePasswordChange } from './ForcePasswordChange'
 import { parseLoginProvidersPayload, type PasswordAuthMethodRow } from './loginProviders'
 import { toast } from 'sonner'
 import {
@@ -84,6 +85,7 @@ function App() {
   const [autoOAuthProvider, setAutoOAuthProvider] = useState<string | null>(null)
   const role = useMemo(() => detectRole(me), [me])
   const usersPerms = useMemo(() => getSectionPerms(role, 'users'), [role])
+  const mustChangePassword = !!me?.must_change_password
 
   const persistToken = (next: string, _remember = false) => {
     setAuthToken(next, false)
@@ -195,7 +197,7 @@ function App() {
     }
   }
 
-  const logout = async () => {
+  const endSession = async (message: string) => {
     try {
       await apiDelete('/auth/sessions/current')
     } catch {
@@ -209,7 +211,11 @@ function App() {
     setUsers([])
     setSettingsOpen(false)
     setActiveSection('about')
-    toast.success('Logged out')
+    toast.success(message)
+  }
+
+  const logout = async () => {
+    await endSession('Logged out')
   }
 
   const openSettings = () => {
@@ -602,6 +608,15 @@ function App() {
               autoOAuthProvider={autoOAuthProvider}
               onLogin={persistToken}
               onOAuth2={loginOAuth2}
+            />
+          ) : loadingMe && me === null ? (
+            <div className="flex min-h-screen items-center justify-center text-sm text-muted-foreground">
+              Loading…
+            </div>
+          ) : mustChangePassword ? (
+            <ForcePasswordChange
+              onChanged={() => endSession('Password updated. Sign in with the new password.')}
+              onLogout={logout}
             />
           ) : (
             <>

--- a/src/ui/src/ForcePasswordChange.tsx
+++ b/src/ui/src/ForcePasswordChange.tsx
@@ -1,0 +1,92 @@
+import { useState, type FormEvent } from 'react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { apiPatch } from './api'
+
+interface ForcePasswordChangeProps {
+  onChanged: () => void
+  onLogout: () => void
+}
+
+export function ForcePasswordChange({ onChanged, onLogout }: ForcePasswordChangeProps) {
+  const [password, setPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [error, setError] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setError('')
+    const next = password.trim()
+    if (!next) {
+      setError('New password is required')
+      return
+    }
+    if (next === 'sipcapture') {
+      setError('Choose a password other than the historical default')
+      return
+    }
+    if (next !== confirm) {
+      setError('Passwords do not match')
+      return
+    }
+    setSaving(true)
+    try {
+      await apiPatch('/me', { password: next })
+      onChanged()
+    } catch (err) {
+      setError((err as Error).message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4">
+      <Card className="relative z-10 w-full max-w-md border-border/70 shadow-lg">
+        <CardHeader>
+          <CardTitle>Change default password</CardTitle>
+          <CardDescription>
+            You signed in with the historical default password. Choose a new password, then sign in again.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            {error && (
+              <Alert variant="destructive">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+            <Input
+              type="password"
+              autoComplete="new-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="New password"
+              disabled={saving}
+              autoFocus
+            />
+            <Input
+              type="password"
+              autoComplete="new-password"
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              placeholder="Confirm password"
+              disabled={saving}
+            />
+            <div className="flex items-center justify-between gap-2">
+              <Button type="button" variant="ghost" onClick={onLogout} disabled={saving}>
+                Sign out
+              </Button>
+              <Button type="submit" disabled={saving}>
+                {saving ? 'Saving…' : 'Save and sign in again'}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.325"
+	VERSION_APPLICATION = "11.0.326"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Follow-up to #968: the well-known `sipcapture` SHA-256 hash still authenticates so existing installs are not locked out.
- Login sets `must_change_password` on the JWT; protected APIs return 403 except `GET/PATCH /me` and logout until a new password is saved.
- UI shows a change-password screen, then signs the user out so they re-login with the new password. Creating or updating a user with `sipcapture` is rejected.
- Bump `VERSION_APPLICATION` to 11.0.326.

## Test plan
- [x] Fresh install without `HOMER_COORDINATOR_AUTH_ADMIN_PASSWORD_HASH`: random admin password in logs; no force-change screen.
- [x] Existing `users` row with sipcapture hash: login succeeds, UI requires a new password, dashboard is blocked.
- [x] After save, session ends and login with the new password reaches the dashboard.
- [x] Reusing `sipcapture` as the new password is rejected.
- [x] `go test ./passwordhash ./coordinator/handlers ./coordinator/services` and UI `App.test.tsx`.