### PR TITLE
fix(auth): halt handlers when password change is required

### DIFF
--- a/docs/COORDINATOR.md
+++ b/docs/COORDINATOR.md
@@ -284,7 +284,7 @@ Authorization **code** flow (server exchanges `code`, loads userinfo, provisions
 | **Omitted** (`coordinator` without `auth`) | Same as **`{"type":"internal"}`** (default admin bootstrap with random password when hash omitted). |
 | **Object** without `type` (or empty `type`) | Same as **`{"type":"internal"}`**: internal bootstrap applies; unset `admin_user` defaults to `admin`; empty `admin_password_hash` triggers a one-time random password in logs. |
 
-**First login (`type` internal or string `"internal"`):** username `admin`. Password is either from **`admin_password_hash`** (SHA-256 hex for `--reset-admin-password`, or bcrypt from the setup wizard), or the **random bootstrap password** printed in coordinator logs on first startup when no hash is configured.
+**First login (`type` internal or string `"internal"`):** username `admin`. Password is either from **`admin_password_hash`** (SHA-256 hex for `--reset-admin-password`, or bcrypt from the setup wizard), or the **random bootstrap password** printed in coordinator logs on first startup when no hash is configured. In Docker, grep logs for `bootstrap_password` — [examples/docker/README.md](../examples/docker/README.md#first-login).
 
 **Reset admin password** — set `coordinator.auth.admin_password_hash` (and optional `admin_user`) in modular `homer.json` or via **`HOMER_COORDINATOR_AUTH_ADMIN_PASSWORD_HASH`**, then run:
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -54,6 +54,17 @@ Environment: `HOMER_COORDINATOR_JWT_SECRET`.
 | Empty hash | Random password generated; **logged once** at startup | Unchanged if row already has a password |
 | Docker examples | Hash omitted; random password in coordinator logs | Existing sipcapture hash in `users`: login then **forced password change** |
 
+**How to read the Docker password (fresh volume):**
+
+```bash
+docker compose -f examples/docker/docker-compose.yaml logs homer 2>&1 | grep bootstrap_password
+# or: docker logs <homer-container> 2>&1 | grep bootstrap_password
+```
+
+The warning looks like `generated one-time bootstrap admin password` with field
+`bootstrap_password`. It is printed only on first insert of the admin row, not
+on later restarts. See [examples/docker/README.md](../examples/docker/README.md#first-login).
+
 Legacy SHA-256 rows from **migrated homer-app users** still authenticate. The well-known **`sipcapture`** digest still logs in, but the session is limited to `GET/PATCH /api/v4/me` and logout until the password is changed. `--reset-admin-password` still refuses that digest as a *new* hash.
 
 **Wizard:** empty admin password field → random password (bcrypt in JSON) shown once after save.

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -64,10 +64,39 @@ high ingest. Details: [OOM.md](../../docs/OOM.md), [DUCKDB_TUNING.md](../../docs
 
 ## First login
 
-Omit `HOMER_COORDINATOR_AUTH_ADMIN_PASSWORD_HASH`. On first start the coordinator
-creates `admin` with a random bcrypt password and logs it once. Existing installs
-that still have the historical `sipcapture` hash can sign in, then must set a
-new password in the UI before using the rest of the API.
+New installs do **not** use `admin` / `sipcapture`. Omit
+`HOMER_COORDINATOR_AUTH_ADMIN_PASSWORD_HASH`. On first start the coordinator
+creates user `admin` with a **random** bcrypt password and prints it **once**
+in the Homer logs.
+
+```bash
+# Compose (from this directory)
+docker compose -f docker-compose.yaml logs homer 2>&1 | grep bootstrap_password
+
+# Named container (docker run)
+docker logs homer 2>&1 | grep bootstrap_password
+```
+
+Look for:
+
+```text
+WRN coordinator: generated one-time bootstrap admin password — change after first login
+    admin_user=admin bootstrap_password=<value>
+```
+
+Username is `admin` (or `HOMER_COORDINATOR_AUTH_ADMIN_USER` if you set it). Open
+http://localhost:8080 and sign in with that password, then change it in the UI.
+
+The line appears only when the `users` row is created (empty volume / first
+boot). Restarts do not print it again. If you missed it, set a new
+`HOMER_COORDINATOR_AUTH_ADMIN_PASSWORD_HASH` (SHA-256 hex of your password)
+and run `homer --reset-admin-password` inside the container, or recreate the
+`homer_data` volume (destroys settings).
+
+Existing installs that still store the historical `sipcapture` hash can sign
+in, then must set a new password in the UI before the rest of the API works.
+See [SECURITY.md](../../docs/SECURITY.md#bootstrap-admin-password-coordinatorauth).
+
 
 ## Endpoints
 

--- a/src/coordinator/handlers/auth.go
+++ b/src/coordinator/handlers/auth.go
@@ -340,8 +340,10 @@ func (h *AuthHandler) JWTMiddleware() echo.MiddlewareFunc {
 			}
 
 			c.Set("user", token)
-			if err := h.rejectIfPasswordChangeRequired(c, claims, false); err != nil {
-				return err
+			if passwordChangeRequiredBlocks(c, claims) {
+				return c.JSON(http.StatusForbidden, map[string]interface{}{
+					"error": "Password change required",
+				})
 			}
 			return next(c)
 		}

--- a/src/coordinator/handlers/auth_v4_helpers.go
+++ b/src/coordinator/handlers/auth_v4_helpers.go
@@ -199,8 +199,8 @@ func (h *AuthHandler) JWTMiddlewareV4() echo.MiddlewareFunc {
 			}
 			c.Set("user", token)
 			c.Set("auth_source", src)
-			if err := h.rejectIfPasswordChangeRequired(c, claims, true); err != nil {
-				return err
+			if passwordChangeRequiredBlocks(c, claims) {
+				return writeError(c, http.StatusForbidden, "Forbidden", "Password change required")
 			}
 			return next(c)
 		}
@@ -221,13 +221,6 @@ func allowedWhilePasswordChangeRequired(c echo.Context) bool {
 	}
 }
 
-func (h *AuthHandler) rejectIfPasswordChangeRequired(c echo.Context, claims *JWTClaims, v4 bool) error {
-	if claims == nil || !claims.MustChangePassword || allowedWhilePasswordChangeRequired(c) {
-		return nil
-	}
-	const msg = "Password change required"
-	if v4 {
-		return writeError(c, http.StatusForbidden, "Forbidden", msg)
-	}
-	return c.JSON(http.StatusForbidden, map[string]interface{}{"error": msg})
+func passwordChangeRequiredBlocks(c echo.Context, claims *JWTClaims) bool {
+	return claims != nil && claims.MustChangePassword && !allowedWhilePasswordChangeRequired(c)
 }

--- a/src/coordinator/handlers/auth_v4_test.go
+++ b/src/coordinator/handlers/auth_v4_test.go
@@ -314,8 +314,12 @@ func TestJWTMiddlewareV4_BlocksUntilPasswordChanged(t *testing.T) {
 	e := echo.New()
 	g := e.Group("/api/v4")
 	g.Use(h.JWTMiddlewareV4())
+	handlerRan := false
 	g.GET("/me", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
-	g.GET("/dashboards", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
+	g.GET("/dashboards", func(c echo.Context) error {
+		handlerRan = true
+		return c.JSON(http.StatusOK, map[string]any{"items": []int{1}})
+	})
 
 	token, _, err := h.generateToken("admin", true, true)
 	if err != nil {
@@ -328,6 +332,12 @@ func TestJWTMiddlewareV4_BlocksUntilPasswordChanged(t *testing.T) {
 	e.ServeHTTP(rec, req)
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("dashboards: got %d want 403 body=%s", rec.Code, rec.Body.String())
+	}
+	if handlerRan {
+		t.Fatal("dashboards handler must not run while password change is required")
+	}
+	if strings.Contains(rec.Body.String(), "items") {
+		t.Fatalf("dashboards body leaked handler response: %s", rec.Body.String())
 	}
 
 	req = httptest.NewRequest(http.MethodGet, "/api/v4/me", nil)

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.326"
+	VERSION_APPLICATION = "11.0.327"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- 11.0.326 set `must_change_password` and wrote 403, but `writeError` returns nil, so JWT middleware still invoked the next handler.
- A sipcapture session could receive both the 403 envelope and the real `/dashboards` payload.
- Middleware now returns immediately on the 403 path. Tests fail if the protected handler runs. Version bump to 11.0.327.

## Test plan
- [x] Login with historical sipcapture hash.
- [x] `GET /api/v4/dashboards` is 403 only (no dashboard JSON).
- [x] `GET /api/v4/me` still 200 with `must_change_password`.
- [x] After `PATCH /me` with a new password, dashboards return 200.