### PR TITLE
fix(vqrtcp): parse RFC 6035 CallID and LocalAddr/RemoteAddr (11.0.330)

### DIFF
--- a/docs/VQRTCP.md
+++ b/docs/VQRTCP.md
@@ -35,12 +35,14 @@ Transaction modal → **QoS** tab → **VQRTCP** sub-tab (when data exists). API
 
 ## Example body
 
+RFC 6035 `LocalAddr` / `RemoteAddr` use `IP=` / `PORT=` / `SSRC=` (legacy `IP PORT` and `IP:PORT` are still accepted):
+
 ```
-Call-ID: abc@host
+CallID: abc@host
 VQIntervalReport:
 QualityEst:MOSLQ=4.20 MOSCQ=4.10
-LocalAddr: 10.0.0.1 5060
-RemoteAddr: 10.0.0.2 5070
+LocalAddr: IP=10.10.1.100 PORT=5000 SSRC=1a3b5c7d
+RemoteAddr:IP=11.1.1.150 PORT=5002 SSRC=0x2468abcd
 JitterBuffer:JBA=0 JBR=0 JBN=10 JBM=0 JBX=0
 PacketLoss:NLR=0.5 JDR=0.1
 ```

--- a/examples/mappings/fields_sip_call.json
+++ b/examples/mappings/fields_sip_call.json
@@ -45,7 +45,7 @@
   },
   {
     "id": "to_user",
-    "name": "To user (callee)",
+    "name": "RURI/To user (callee)",
     "type": "string",
     "index": "none",
     "form_type": "input",

--- a/src/coordinator/services/seeds/fields_sip_call.json
+++ b/src/coordinator/services/seeds/fields_sip_call.json
@@ -45,7 +45,7 @@
   },
   {
     "id": "to_user",
-    "name": "To user (callee)",
+    "name": "RURI/To user (callee)",
     "type": "string",
     "index": "none",
     "form_type": "input",

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.329"
+	VERSION_APPLICATION = "11.0.330"
 
 	// BuildDate is the build date
 	BuildDate = ""

--- a/src/vqrtcpreceiver/parser.go
+++ b/src/vqrtcpreceiver/parser.go
@@ -58,8 +58,10 @@ func ParseBody(body []byte) Report {
 		}
 		s := string(line)
 		switch {
-		case strings.HasPrefix(s, "Call-ID:"):
-			r.CallID = strings.TrimSpace(s[len("Call-ID:"):])
+		// RFC 6035 SessionInfo uses "CallID:" (the measured dialog).
+		// "Call-ID:" is the SIP header of the PUBLISH/MESSAGE itself — do not use it.
+		case strings.HasPrefix(s, "CallID:"):
+			r.CallID = strings.TrimSpace(s[len("CallID:"):])
 		case strings.HasPrefix(s, "VQSessionReport:"):
 			r.HasSessionReport = true
 		case strings.HasPrefix(s, "VQIntervalReport:"):
@@ -118,11 +120,15 @@ func parsePort(s string) (uint16, bool) {
 	return uint16(p), true
 }
 
-// SplitHostPort parses "IP PORT" or "IP:PORT" style LocalAddr/RemoteAddr.
+// SplitHostPort parses LocalAddr/RemoteAddr values.
+// RFC 6035 uses "IP=<addr> PORT=<port> SSRC=<ssrc>"; legacy "IP PORT" and "IP:PORT" are also accepted.
 func SplitHostPort(addr string) (host string, port uint16) {
 	addr = strings.TrimSpace(addr)
 	if addr == "" {
 		return "", 0
+	}
+	if h, p, ok := splitRFC6035HostPort(addr); ok {
+		return h, p
 	}
 	if i := strings.LastIndex(addr, ":"); i > 0 && strings.Count(addr, ":") == 1 {
 		host = addr[:i]
@@ -137,4 +143,28 @@ func SplitHostPort(addr string) (host string, port uint16) {
 		}
 	}
 	return addr, 0
+}
+
+// splitRFC6035HostPort parses "IP=<addr> PORT=<port> [SSRC=<ssrc>]" (RFC 6035 §4.6).
+func splitRFC6035HostPort(addr string) (host string, port uint16, ok bool) {
+	var portRaw string
+	for _, part := range strings.Fields(addr) {
+		k, v, found := strings.Cut(part, "=")
+		if !found {
+			continue
+		}
+		switch strings.ToUpper(k) {
+		case "IP":
+			host = strings.Trim(v, "[]")
+		case "PORT":
+			portRaw = v
+		}
+	}
+	if host == "" {
+		return "", 0, false
+	}
+	if p, valid := parsePort(portRaw); valid {
+		return host, p, true
+	}
+	return host, 0, true
 }

--- a/src/vqrtcpreceiver/parser_test.go
+++ b/src/vqrtcpreceiver/parser_test.go
@@ -7,7 +7,7 @@ package vqrtcpreceiver
 import "testing"
 
 func TestParseBody(t *testing.T) {
-	body := `Call-ID: abc-123@host
+	body := `CallID: abc-123@host
 VQIntervalReport: 
 QualityEst:MOSLQ=4.20 MOSCQ=4.10
 LocalAddr: 10.0.0.1 5060
@@ -34,6 +34,41 @@ PacketLoss:NLR=0.5 JDR=0.1
 	}
 }
 
+func TestParseBodyRFC6035(t *testing.T) {
+	body := `CallID: 20910623@10.10.1.100
+VQSessionReport:
+QualityEst:RCQ=90 MOSLQ=4.2 MOSCQ=4.3
+LocalAddr: IP=10.10.1.100 PORT=5000 SSRC=1a3b5c7d
+RemoteAddr:IP=11.1.1.150 PORT=5002 SSRC=0x2468abcd
+`
+	r := ParseBody([]byte(body))
+	if r.CallID != "20910623@10.10.1.100" {
+		t.Fatalf("callid: got %q", r.CallID)
+	}
+	if !r.HasSessionReport {
+		t.Fatal("expected session report")
+	}
+	host, port := SplitHostPort(r.LocalAddr)
+	if host != "10.10.1.100" || port != 5000 {
+		t.Fatalf("local: %s %d", host, port)
+	}
+	host, port = SplitHostPort(r.RemoteAddr)
+	if host != "11.1.1.150" || port != 5002 {
+		t.Fatalf("remote: %s %d", host, port)
+	}
+}
+
+func TestParseBodyIgnoresSIPCallIDHeader(t *testing.T) {
+	body := `Call-ID: publish-message-id@sbc
+CallID: dialog-call-id@host
+VQIntervalReport:
+`
+	r := ParseBody([]byte(body))
+	if r.CallID != "dialog-call-id@host" {
+		t.Fatalf("callid: got %q, want dialog CallID from RFC 6035 body", r.CallID)
+	}
+}
+
 func TestSplitHostPort(t *testing.T) {
 	tests := []struct {
 		addr     string
@@ -45,6 +80,12 @@ func TestSplitHostPort(t *testing.T) {
 		{"10.0.0.1 70000", "10.0.0.1 70000", 0},
 		{"10.0.0.1:-1", "10.0.0.1:-1", 0},
 		{"", "", 0},
+		{"IP=10.10.1.100 PORT=5000 SSRC=1a3b5c7d", "10.10.1.100", 5000},
+		{"IP=11.1.1.150 PORT=5002 SSRC=0x2468abcd", "11.1.1.150", 5002},
+		{"IP=2001:db8::1 PORT=5000 SSRC=0x2468abcd", "2001:db8::1", 5000},
+		{"IP=[2001:db8::1] PORT=5000 SSRC=0x2468abcd", "2001:db8::1", 5000},
+		{"IP=10.10.1.100", "10.10.1.100", 0},
+		{"ip=10.10.1.100 port=5000 ssrc=1a3b5c7d", "10.10.1.100", 5000},
 	}
 	for _, tt := range tests {
 		host, port := SplitHostPort(tt.addr)


### PR DESCRIPTION
## Summary
- Parse VQ-RTCPXR `CallID:` from the report body (RFC 6035) instead of `Call-ID:`, which is the SIP header of the PUBLISH/MESSAGE itself ([#974](https://github.com/sipcapture/homer/issues/974)).
- Parse `LocalAddr` / `RemoteAddr` as `IP=<addr> PORT=<port> SSRC=<ssrc>` (IPv4/IPv6); keep the legacy `IP PORT` and `IP:PORT` forms ([#975](https://github.com/sipcapture/homer/issues/975)).
- Bump `VERSION_APPLICATION` to **11.0.330**.

## Test plan
- [x] `go test ./vqrtcpreceiver/` (RFC examples, mixed `Call-ID`/`CallID` body, IPv6)
- [x] PUBLISH/MESSAGE with a real `application/vq-rtcpxr` body: stored `callid` matches the measured dialog, not the report SIP Call-ID
- [x] QoS tab correlates VQ-RTCPXR rows to the SIP transaction by Call-ID
- [x] `source_ip`/`source_port` and `destination_ip`/`destination_port` match `IP=` / `PORT=` from the body

Fixes #974
Fixes #975