### PR TITLE
fix(flightsql): Grafana handshake and listen config (11.0.331)

### DIFF
--- a/docs/FLIGHTSQL.md
+++ b/docs/FLIGHTSQL.md
@@ -9,14 +9,43 @@ Homer exposes **two different gRPC stacks** on the node:
 
 The coordinator REST API still talks to nodes over **HTTP** `POST /query` on `node.flight_server.port + 1`. Optional **`coordinator.flightsql_server`** (default **32010** when enabled with port `0`) is a **FlightSQL proxy** that fans out to each `coordinator.nodes[].flightsql_port` (must match the node’s FlightSQL listener).
 
+## Listen keys
+
+| What you want | Config | Default port |
+|---|---|---|
+| Node serves SQL to Grafana | `node.flightsql_server.enable: true` | `50055` |
+| Coordinator proxies Grafana to nodes | `coordinator.flightsql_server.enable: true` | `32010` |
+| Which node port the proxy dials | `coordinator.nodes[].flightsql_port` | `0` (unused) |
+
+`coordinator.flightsql_port` (a bare integer under `coordinator`) is **not** a listen key. Docker's published port can show `LISTEN` via `docker-proxy` even when Homer has no FlightSQL server. Homer treats that integer as `coordinator.flightsql_server.enable=true` plus `.port=<value>` and logs a warning. Prefer the nested object.
+
+Auth on FlightSQL is **required**. If `flightsql_server.auth_token` is empty, Homer copies `node.flight_server.auth_token` or generates one (see logs / `.homer_node_auth_token`). Grafana must use that token, not the coordinator JWT.
+
+The Flight `Handshake` RPC does not require Bearer metadata (Grafana / GizmoSQL / ADBC send it first). Subsequent RPCs accept `Authorization: Bearer <token>`, HTTP Basic with the token as password, or the raw token.
+
+## Docker Compose
+
+`HOMER_*` environment variables **override** `homer.json`. Setting `node.flightsql_server.enable: true` in JSON has no effect while `HOMER_NODE_FLIGHTSQL_SERVER_ENABLE=false` is set. Enable via env:
+
+```yaml
+HOMER_NODE_FLIGHTSQL_SERVER_ENABLE: "true"
+HOMER_NODE_FLIGHTSQL_SERVER_PORT: "50055"
+HOMER_NODE_FLIGHTSQL_SERVER_AUTH_TOKEN: your-secret-token-here
+HOMER_COORDINATOR_NODES_0_FLIGHTSQL_PORT: "50055"
+```
+
+Publish `50055:50055/tcp` only when the process actually listens. Publishing the port without a listener makes `ss` show `LISTEN` (docker-proxy) while every FlightSQL client drops during handshake.
+
+TLS in Grafana must be **off** unless you terminate TLS in front of Homer. The listener is plaintext gRPC. Airport (`grpc://host:50051`) will not complete a FlightSQL handshake.
+
 ## Grafana (InfluxDB datasource, FlightSQL)
 
 Step-by-step datasource setup, proxy configuration, and troubleshooting: **[GRAFANA_INTEGRATION.md](GRAFANA_INTEGRATION.md)**.
 
-1. Enable `node.flightsql_server.enable` and set `auth_token` if you want Bearer auth (same header pattern as Airport).
-2. Datasource type: **InfluxDB**, version **InfluxQL** or **SQL** / **FlightSQL** per your Grafana build (use the FlightSQL / InfluxDB 3 style URL).
-3. URL: `grpc://<node-host>:50055` (or `grpc://<coordinator-host>:32010` when using the coordinator proxy and `flightsql_port` on each node entry).
-4. If you set `auth_token`, add **Metadata** or **HTTP Headers** so requests include `Authorization: Bearer <token>` (Grafana field names vary by version).
+1. Enable `node.flightsql_server.enable` and set `auth_token` (required; Grafana uses this token, not the UI JWT).
+2. Datasource type: **InfluxDB**, version **InfluxQL** or **SQL** / **FlightSQL** per your Grafana build (use the FlightSQL / InfluxDB 3 style URL). GizmoSQL also works.
+3. URL: `grpc://<node-host>:50055` (or `grpc://<coordinator-host>:32010` when using the coordinator proxy and `flightsql_port` on each node entry). Leave TLS disabled.
+4. Add **Metadata** or **HTTP Headers** so requests include `Authorization: Bearer <token>` (Grafana field names vary by version). Username/password with the token as password is also accepted.
 
 FlightSQL is a protocol for high-performance SQL database access built on Apache Arrow Flight.
 

--- a/examples/docker/docker-compose.yaml
+++ b/examples/docker/docker-compose.yaml
@@ -178,7 +178,12 @@ services:
       HOMER_NODE_FLIGHT_SERVER_PORT: "50051"
       HOMER_NODE_FLIGHT_SERVER_AUTH_TOKEN: your-secret-token-here
       HOMER_NODE_FLIGHT_SERVER_MAX_MESSAGE_SIZE: "16777216"
-      HOMER_NODE_FLIGHTSQL_SERVER_ENABLE: "false"
+      # Arrow FlightSQL (Grafana). Off by default. Do not pin ENABLE=false here
+      # if you enable node.flightsql_server in a mounted homer.json — env wins.
+      # Also add "50055:50055/tcp" to ports when enabling.
+      # HOMER_NODE_FLIGHTSQL_SERVER_ENABLE: "true"
+      # HOMER_NODE_FLIGHTSQL_SERVER_PORT: "50055"
+      # HOMER_NODE_FLIGHTSQL_SERVER_AUTH_TOKEN: your-secret-token-here
 
       HOMER_NODE_DUCKLAKE_LAKE_NAME: homer_lake
 
@@ -213,7 +218,9 @@ services:
       HOMER_COORDINATOR_NODES_0_PRIORITY: "1"
 
       HOMER_COORDINATOR_SETTINGS_DB_PATH: /data/homer/homer_settings.duckdb
-      HOMER_COORDINATOR_FLIGHTSQL_SERVER_ENABLE: "false"
+      # HOMER_COORDINATOR_FLIGHTSQL_SERVER_ENABLE: "true"
+      # HOMER_COORDINATOR_FLIGHTSQL_SERVER_PORT: "32010"
+      # HOMER_COORDINATOR_NODES_0_FLIGHTSQL_PORT: "50055"
 
       HOMER_COORDINATOR_JWT_SECRET: change-this-to-a-secure-random-string-in-production
       HOMER_COORDINATOR_JWT_EXPIRE_HOURS: "24"

--- a/examples/docker/docker-compose_s3direct.yaml
+++ b/examples/docker/docker-compose_s3direct.yaml
@@ -172,7 +172,10 @@ services:
       HOMER_NODE_FLIGHT_SERVER_PORT: "50051"
       HOMER_NODE_FLIGHT_SERVER_AUTH_TOKEN: your-secret-token-here
       HOMER_NODE_FLIGHT_SERVER_MAX_MESSAGE_SIZE: "16777216"
-      HOMER_NODE_FLIGHTSQL_SERVER_ENABLE: "false"
+      # Arrow FlightSQL (Grafana). Off by default. Env overrides homer.json.
+      # HOMER_NODE_FLIGHTSQL_SERVER_ENABLE: "true"
+      # HOMER_NODE_FLIGHTSQL_SERVER_PORT: "50055"
+      # HOMER_NODE_FLIGHTSQL_SERVER_AUTH_TOKEN: your-secret-token-here
 
       HOMER_NODE_DUCKLAKE_LAKE_NAME: homer_lake
 
@@ -201,7 +204,8 @@ services:
       HOMER_COORDINATOR_NODES_0_PRIORITY: "1"
 
       HOMER_COORDINATOR_SETTINGS_DB_PATH: /data/homer/homer_settings.duckdb
-      HOMER_COORDINATOR_FLIGHTSQL_SERVER_ENABLE: "false"
+      # HOMER_COORDINATOR_FLIGHTSQL_SERVER_ENABLE: "true"
+      # HOMER_COORDINATOR_NODES_0_FLIGHTSQL_PORT: "50055"
 
       HOMER_COORDINATOR_JWT_SECRET: change-this-to-a-secure-random-string-in-production
       HOMER_COORDINATOR_JWT_EXPIRE_HOURS: "24"

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -443,6 +443,11 @@ type CoordinatorConfig struct {
 	// to node flightsql_port endpoints (Grafana single entrypoint).
 	FlightSQLServer FlightSQLServerConfig `json:"flightsql_server" mapstructure:"flightsql_server"`
 
+	// DeprecatedListenPort is the mistaken coordinator.flightsql_port integer
+	// (not coordinator.nodes[].flightsql_port). It does not start a listener by
+	// itself; applyDefaults copies it onto flightsql_server and enables the proxy.
+	DeprecatedListenPort int `json:"flightsql_port,omitempty" mapstructure:"flightsql_port"`
+
 	// LineProtoTablePrefix mirrors ingest.line_protocol.table_prefix for
 	// GET /api/v4/line_protocol/tables default ?prefix=; set at load from Ingest
 	// (not read from JSON).
@@ -1689,6 +1694,12 @@ func applyDefaults(cfg *Config) {
 	if cfg.Coordinator.LakeName == "" {
 		cfg.Coordinator.LakeName = "homer_lake"
 	}
+	if cfg.Coordinator.DeprecatedListenPort > 0 {
+		slog.Warn("config: coordinator.flightsql_port is not a listen key; use coordinator.flightsql_server.enable and coordinator.flightsql_server.port. Enabling the FlightSQL proxy on that port.",
+			"port", cfg.Coordinator.DeprecatedListenPort)
+		cfg.Coordinator.FlightSQLServer.Enable = true
+		cfg.Coordinator.FlightSQLServer.Port = cfg.Coordinator.DeprecatedListenPort
+	}
 	if cfg.Coordinator.FlightSQLServer.CatalogRefreshIntervalSec <= 0 {
 		cfg.Coordinator.FlightSQLServer.CatalogRefreshIntervalSec = 30
 	}
@@ -1900,14 +1911,19 @@ func applyDefaults(cfg *Config) {
 
 	// If no nodes configured but node is enabled locally, add local node
 	if cfg.Coordinator.Enable && len(cfg.Coordinator.Nodes) == 0 && cfg.Node.Enable {
-		cfg.Coordinator.Nodes = []NodeEndpoint{
-			{
-				Name:  "local",
-				Host:  "127.0.0.1",
-				Port:  cfg.Node.FlightServer.Port,
-				Token: cfg.Node.FlightServer.AuthToken,
-			},
+		local := NodeEndpoint{
+			Name:  "local",
+			Host:  "127.0.0.1",
+			Port:  cfg.Node.FlightServer.Port,
+			Token: cfg.Node.FlightServer.AuthToken,
 		}
+		if cfg.Node.FlightSQLServer.Enable {
+			local.FlightSQLPort = cfg.Node.FlightSQLServer.Port
+			if local.Token == "" {
+				local.Token = cfg.Node.FlightSQLServer.AuthToken
+			}
+		}
+		cfg.Coordinator.Nodes = []NodeEndpoint{local}
 	}
 
 	// Same-process local nodes: copy flight_server.auth_token into empty node tokens
@@ -1920,6 +1936,27 @@ func applyDefaults(cfg *Config) {
 			}
 			if IsLoopbackBindHost(n.Host) && n.Port == cfg.Node.FlightServer.Port {
 				n.Token = cfg.Node.FlightServer.AuthToken
+			}
+		}
+	}
+
+	// Same-process: point coordinator FlightSQL proxy at the local node listener.
+	if cfg.Node.Enable && cfg.Node.FlightSQLServer.Enable {
+		port := cfg.Node.FlightSQLServer.Port
+		if port == 0 {
+			port = 50055
+		}
+		tok := strings.TrimSpace(cfg.Node.FlightSQLServer.AuthToken)
+		for i := range cfg.Coordinator.Nodes {
+			n := &cfg.Coordinator.Nodes[i]
+			if !IsLoopbackBindHost(n.Host) || n.Port != cfg.Node.FlightServer.Port {
+				continue
+			}
+			if n.FlightSQLPort == 0 {
+				n.FlightSQLPort = port
+			}
+			if n.Token == "" && tok != "" {
+				n.Token = tok
 			}
 		}
 	}

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -975,3 +975,33 @@ func TestEnsureNodeDuckLakeVolumes_S3CopiesCredentials(t *testing.T) {
 		t.Fatalf("s3 volume credentials: %+v", v)
 	}
 }
+
+func TestLoad_CoordinatorBareFlightSQLPortEnablesProxy(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTmpConfig(t, `{
+  "node": {
+    "enable": true,
+    "flight_server": { "host": "127.0.0.1", "port": 50051 },
+    "flightsql_server": { "enable": true, "host": "127.0.0.1", "port": 50055, "auth_token": "fsql-token" },
+    "ducklake": { "catalog_path": "`+dir+`/cat.sqlite" }
+  },
+  "coordinator": {
+    "enable": true,
+    "flightsql_port": 50055,
+    "settings_db_path": "`+dir+`/settings.duckdb"
+  }
+}`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.Coordinator.FlightSQLServer.Enable {
+		t.Fatal("coordinator.flightsql_port should enable flightsql_server")
+	}
+	if cfg.Coordinator.FlightSQLServer.Port != 50055 {
+		t.Fatalf("port=%d", cfg.Coordinator.FlightSQLServer.Port)
+	}
+	if len(cfg.Coordinator.Nodes) == 0 || cfg.Coordinator.Nodes[0].FlightSQLPort != 50055 {
+		t.Fatalf("local node flightsql_port not wired: %+v", cfg.Coordinator.Nodes)
+	}
+}

--- a/src/coordinator/coordinator.go
+++ b/src/coordinator/coordinator.go
@@ -86,7 +86,7 @@ func New(cfg *config.CoordinatorConfig) (*Coordinator, error) {
 		flightService: flightService,
 	}
 	if cfg.FlightSQLServer.Enable {
-		c.fsqlProxy = newFlightSQLProxy(cfg.FlightSQLServer, cfg.Nodes)
+		c.fsqlProxy = newFlightSQLProxy(cfg.FlightSQLServer, cfg.Nodes, cfg.LakeName)
 	}
 
 	// Open settings DuckDB

--- a/src/coordinator/flightsql_proxy.go
+++ b/src/coordinator/flightsql_proxy.go
@@ -9,15 +9,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/flight"
 	"github.com/apache/arrow-go/v18/arrow/flight/flightsql"
+	"github.com/apache/arrow-go/v18/arrow/flight/flightsql/schema_ref"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/sipcapture/homer-core/src/config"
 	"github.com/sipcapture/homer-core/src/coordinator/sqlvalidator"
+	"github.com/sipcapture/homer-core/src/fsqlauth"
 	logger "github.com/sipcapture/homer-core/src/utils/logging"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -33,6 +36,7 @@ type flightSQLProxy struct {
 
 	cfg        config.FlightSQLServerConfig
 	nodes      []config.NodeEndpoint
+	lakeName   string
 	grpcServer *grpc.Server
 	listener   net.Listener
 	mu         sync.RWMutex
@@ -43,13 +47,72 @@ type flightSQLProxyTicket struct {
 	Query string `json:"q"`
 }
 
-func newFlightSQLProxy(cfg config.FlightSQLServerConfig, nodes []config.NodeEndpoint) *flightSQLProxy {
-	p := &flightSQLProxy{cfg: cfg, nodes: nodes}
+func newFlightSQLProxy(cfg config.FlightSQLServerConfig, nodes []config.NodeEndpoint, lakeName string) *flightSQLProxy {
+	if lakeName == "" {
+		lakeName = "homer_lake"
+	}
+	p := &flightSQLProxy{cfg: cfg, nodes: nodes, lakeName: lakeName}
 	p.RegisterSqlInfo(flightsql.SqlInfoFlightSqlServerName, "homer-core-coordinator")
 	p.RegisterSqlInfo(flightsql.SqlInfoFlightSqlServerVersion, "1.0")
 	p.RegisterSqlInfo(flightsql.SqlInfoFlightSqlServerArrowVersion, "1.3")
 	p.RegisterSqlInfo(flightsql.SqlInfoFlightSqlServerReadOnly, true)
 	return p
+}
+
+func (p *flightSQLProxy) GetFlightInfoCatalogs(_ context.Context, desc *flight.FlightDescriptor) (*flight.FlightInfo, error) {
+	return &flight.FlightInfo{
+		Endpoint:         []*flight.FlightEndpoint{{Ticket: &flight.Ticket{Ticket: desc.Cmd}}},
+		FlightDescriptor: desc,
+		TotalRecords:     -1,
+		TotalBytes:       -1,
+		Schema:           flight.SerializeSchema(schema_ref.Catalogs, memory.DefaultAllocator),
+	}, nil
+}
+
+func (p *flightSQLProxy) DoGetCatalogs(context.Context) (*arrow.Schema, <-chan flight.StreamChunk, error) {
+	schema := schema_ref.Catalogs
+	bldr := array.NewStringBuilder(memory.DefaultAllocator)
+	defer bldr.Release()
+	bldr.Append(p.lakeName)
+	arr := bldr.NewArray()
+	defer arr.Release()
+	batch := array.NewRecord(schema, []arrow.Array{arr}, 1)
+	ch := make(chan flight.StreamChunk, 1)
+	ch <- flight.StreamChunk{Data: batch}
+	close(ch)
+	return schema, ch, nil
+}
+
+func (p *flightSQLProxy) GetFlightInfoSchemas(_ context.Context, _ flightsql.GetDBSchemas, desc *flight.FlightDescriptor) (*flight.FlightInfo, error) {
+	return &flight.FlightInfo{
+		Endpoint:         []*flight.FlightEndpoint{{Ticket: &flight.Ticket{Ticket: desc.Cmd}}},
+		FlightDescriptor: desc,
+		TotalRecords:     -1,
+		TotalBytes:       -1,
+		Schema:           flight.SerializeSchema(schema_ref.DBSchemas, memory.DefaultAllocator),
+	}, nil
+}
+
+func (p *flightSQLProxy) DoGetDBSchemas(_ context.Context, cmd flightsql.GetDBSchemas) (*arrow.Schema, <-chan flight.StreamChunk, error) {
+	schema := schema_ref.DBSchemas
+	ch := make(chan flight.StreamChunk, 1)
+	if pat := cmd.GetDBSchemaFilterPattern(); pat != nil && *pat != "" && *pat != "%" && *pat != "main" {
+		close(ch)
+		return schema, ch, nil
+	}
+	cb := array.NewStringBuilder(memory.DefaultAllocator)
+	sb := array.NewStringBuilder(memory.DefaultAllocator)
+	cb.Append(p.lakeName)
+	sb.Append("main")
+	ca, sa := cb.NewArray(), sb.NewArray()
+	cb.Release()
+	sb.Release()
+	batch := array.NewRecord(schema, []arrow.Array{ca, sa}, 1)
+	ca.Release()
+	sa.Release()
+	ch <- flight.StreamChunk{Data: batch}
+	close(ch)
+	return schema, ch, nil
 }
 
 func (p *flightSQLProxy) GetFlightInfoStatement(
@@ -302,14 +365,7 @@ func (p *flightSQLProxy) Start() error {
 		return fmt.Errorf("FlightSQL proxy already running")
 	}
 	addr := fmt.Sprintf("%s:%d", p.cfg.Host, p.cfg.Port)
-	var opts []grpc.ServerOption
-	if p.cfg.AuthToken != "" {
-		opts = append(opts,
-			grpc.ChainUnaryInterceptor(p.requireAuthUnary),
-			grpc.ChainStreamInterceptor(p.requireAuthStream),
-		)
-	}
-	p.grpcServer = grpc.NewServer(opts...)
+	p.grpcServer = grpc.NewServer(fsqlauth.ServerOptions(p.cfg.AuthToken)...)
 	flight.RegisterFlightServiceServer(p.grpcServer, flightsql.NewFlightServer(p))
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
@@ -350,35 +406,4 @@ func (p *flightSQLProxy) Stop() {
 	}
 	p.running = false
 	logger.Info("Coordinator: FlightSQL proxy stopped")
-}
-
-func (p *flightSQLProxy) requireAuthUnary(
-	ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
-) (interface{}, error) {
-	if err := p.checkToken(ctx); err != nil {
-		return nil, err
-	}
-	return handler(ctx, req)
-}
-
-func (p *flightSQLProxy) requireAuthStream(
-	srv interface{}, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler,
-) error {
-	if err := p.checkToken(ss.Context()); err != nil {
-		return err
-	}
-	return handler(srv, ss)
-}
-
-func (p *flightSQLProxy) checkToken(ctx context.Context) error {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return status.Error(codes.Unauthenticated, "missing metadata")
-	}
-	for _, v := range md.Get("authorization") {
-		if strings.HasPrefix(v, "Bearer ") && strings.TrimPrefix(v, "Bearer ") == p.cfg.AuthToken {
-			return nil
-		}
-	}
-	return status.Error(codes.Unauthenticated, "invalid or missing Bearer token")
 }

--- a/src/fsqlauth/auth.go
+++ b/src/fsqlauth/auth.go
@@ -1,0 +1,133 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package fsqlauth implements Arrow FlightSQL gRPC auth for Grafana / ADBC /
+// GizmoSQL clients. Flight Handshake is allowed through without Bearer
+// metadata (clients authenticate on subsequent RPCs, or send Basic/Bearer
+// on Handshake itself).
+package fsqlauth
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/base64"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	authorizationHeader = "authorization"
+	authTokenBinHeader  = "auth-token-bin"
+	bearerPrefix        = "bearer "
+	basicPrefix         = "basic "
+)
+
+// ServerOptions returns gRPC interceptors that require expectedToken on every
+// RPC except Flight Handshake. An empty token disables auth.
+func ServerOptions(expectedToken string) []grpc.ServerOption {
+	expectedToken = strings.TrimSpace(expectedToken)
+	if expectedToken == "" {
+		return nil
+	}
+	return []grpc.ServerOption{
+		grpc.ChainUnaryInterceptor(unaryInterceptor(expectedToken)),
+		grpc.ChainStreamInterceptor(streamInterceptor(expectedToken)),
+	}
+}
+
+func unaryInterceptor(expected string) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		if err := CheckIncoming(ctx, expected); err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+}
+
+func streamInterceptor(expected string) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		// Grafana FlightSQL, GizmoSQL, and ADBC call Handshake before they
+		// attach Authorization metadata. Rejecting it drops the connection
+		// mid-handshake. Auth is enforced on GetFlightInfo / DoGet / etc.
+		if strings.HasSuffix(info.FullMethod, "/Handshake") {
+			return handler(srv, ss)
+		}
+		if err := CheckIncoming(ss.Context(), expected); err != nil {
+			return err
+		}
+		return handler(srv, ss)
+	}
+}
+
+// CheckIncoming validates Flight/gRPC auth metadata against expectedToken.
+func CheckIncoming(ctx context.Context, expectedToken string) error {
+	expectedToken = strings.TrimSpace(expectedToken)
+	if expectedToken == "" {
+		return nil
+	}
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return status.Error(codes.Unauthenticated, "missing metadata")
+	}
+	for _, v := range md.Get(authorizationHeader) {
+		if headerMatches(v, expectedToken) {
+			return nil
+		}
+	}
+	for _, v := range md.Get(authTokenBinHeader) {
+		if tokenEq(expectedToken, v) {
+			return nil
+		}
+	}
+	return status.Error(codes.Unauthenticated, "invalid or missing Bearer token")
+}
+
+func headerMatches(header, expected string) bool {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return false
+	}
+	lower := strings.ToLower(header)
+	switch {
+	case strings.HasPrefix(lower, bearerPrefix):
+		return tokenEq(expected, strings.TrimSpace(header[len(bearerPrefix):]))
+	case strings.HasPrefix(lower, basicPrefix):
+		return basicMatches(strings.TrimSpace(header[len(basicPrefix):]), expected)
+	default:
+		// Grafana/ADBC sometimes send the raw token with no scheme.
+		return tokenEq(expected, header)
+	}
+}
+
+func basicMatches(b64, expected string) bool {
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		raw, err = base64.RawStdEncoding.DecodeString(b64)
+		if err != nil {
+			return false
+		}
+	}
+	user, pass, ok := strings.Cut(string(raw), ":")
+	if !ok {
+		return tokenEq(expected, string(raw))
+	}
+	// Token as password (user ignored), as username, or either side.
+	return tokenEq(expected, pass) || tokenEq(expected, user)
+}
+
+func tokenEq(expected, got string) bool {
+	expected = strings.TrimSpace(expected)
+	got = strings.TrimSpace(got)
+	if expected == "" || got == "" {
+		return false
+	}
+	if len(expected) != len(got) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(expected), []byte(got)) == 1
+}

--- a/src/fsqlauth/auth_test.go
+++ b/src/fsqlauth/auth_test.go
@@ -1,0 +1,89 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package fsqlauth
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func TestCheckIncomingBearer(t *testing.T) {
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "Bearer secret"))
+	if err := CheckIncoming(ctx, "secret"); err != nil {
+		t.Fatal(err)
+	}
+	if err := CheckIncoming(ctx, "other"); err == nil {
+		t.Fatal("expected mismatch")
+	}
+}
+
+func TestCheckIncomingBearerCaseInsensitive(t *testing.T) {
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "bearer secret"))
+	if err := CheckIncoming(ctx, "secret"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckIncomingRawToken(t *testing.T) {
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "secret"))
+	if err := CheckIncoming(ctx, "secret"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckIncomingBasicPassword(t *testing.T) {
+	b64 := base64.StdEncoding.EncodeToString([]byte("grafana:secret"))
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("authorization", "Basic "+b64))
+	if err := CheckIncoming(ctx, "secret"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckIncomingMissingMetadata(t *testing.T) {
+	err := CheckIncoming(context.Background(), "secret")
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestStreamInterceptorSkipsHandshake(t *testing.T) {
+	called := false
+	interceptor := streamInterceptor("secret")
+	err := interceptor(nil, &stubStream{ctx: context.Background()}, &grpc.StreamServerInfo{
+		FullMethod: "/arrow.flight.protocol.FlightService/Handshake",
+	}, func(interface{}, grpc.ServerStream) error {
+		called = true
+		return nil
+	})
+	if err != nil || !called {
+		t.Fatalf("handshake should pass without metadata: err=%v called=%v", err, called)
+	}
+}
+
+func TestStreamInterceptorRequiresTokenOnDoGet(t *testing.T) {
+	interceptor := streamInterceptor("secret")
+	err := interceptor(nil, &stubStream{ctx: context.Background()}, &grpc.StreamServerInfo{
+		FullMethod: "/arrow.flight.protocol.FlightService/DoGet",
+	}, func(interface{}, grpc.ServerStream) error {
+		t.Fatal("handler should not run")
+		return nil
+	})
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("got %v", err)
+	}
+}
+
+type stubStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *stubStream) Context() context.Context { return s.ctx }

--- a/src/node/fsql_handshake_test.go
+++ b/src/node/fsql_handshake_test.go
@@ -1,0 +1,122 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package node
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/flight/flightsql"
+	"github.com/sipcapture/homer-core/src/config"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+)
+
+func startAuthFsql(t *testing.T, token string) (*fsqlServer, *flightsql.Client) {
+	t.Helper()
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	db.SetMaxOpenConns(1)
+
+	n := &Node{
+		db:     db,
+		config: &config.NodeConfig{DuckLake: config.DuckLakeConfig{LakeName: "homer_lake"}},
+	}
+	fsql := newFsqlServer(n, config.FlightSQLServerConfig{
+		Enable:    true,
+		Host:      "127.0.0.1",
+		Port:      0,
+		AuthToken: token,
+	}, "homer_lake")
+	if err := fsql.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(fsql.Stop)
+
+	client, err := flightsql.NewClient(fsql.listener.Addr().String(), nil, nil,
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("flightsql client: %v", err)
+	}
+	t.Cleanup(func() { client.Close() })
+	return fsql, client
+}
+
+// TestFlightSQLHandshakeWithoutMetadata reproduces Grafana/GizmoSQL/ADBC:
+// Handshake is the first RPC and often has no Authorization header.
+func TestFlightSQLHandshakeWithoutMetadata(t *testing.T) {
+	_, client := startAuthFsql(t, "secret-token")
+	stream, err := client.Client.Handshake(context.Background())
+	if err != nil {
+		t.Fatalf("Handshake RPC: %v", err)
+	}
+	if err := stream.CloseSend(); err != nil {
+		t.Fatalf("CloseSend: %v", err)
+	}
+	_, err = stream.Recv()
+	if err != nil && err != io.EOF {
+		t.Fatalf("Handshake Recv: %v", err)
+	}
+}
+
+func TestFlightSQLGetSqlInfoWithBearer(t *testing.T) {
+	_, client := startAuthFsql(t, "secret-token")
+	ctx := metadata.AppendToOutgoingContext(context.Background(), "authorization", "Bearer secret-token")
+	info, err := client.GetSqlInfo(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetSqlInfo: %v", err)
+	}
+	if len(info.Endpoint) == 0 {
+		t.Fatal("no endpoints")
+	}
+	rdr, err := client.DoGet(ctx, info.Endpoint[0].Ticket)
+	if err != nil {
+		t.Fatalf("DoGet SqlInfo: %v", err)
+	}
+	defer rdr.Release()
+	if !rdr.Next() {
+		t.Fatal("expected SqlInfo batch")
+	}
+}
+
+func TestFlightSQLGetCatalogsWithBearer(t *testing.T) {
+	_, client := startAuthFsql(t, "secret-token")
+	ctx := metadata.AppendToOutgoingContext(context.Background(), "authorization", "Bearer secret-token")
+	info, err := client.GetCatalogs(ctx)
+	if err != nil {
+		t.Fatalf("GetCatalogs: %v", err)
+	}
+	if len(info.Endpoint) == 0 {
+		t.Fatal("no endpoints")
+	}
+	rdr, err := client.DoGet(ctx, info.Endpoint[0].Ticket)
+	if err != nil {
+		t.Fatalf("DoGet catalogs: %v", err)
+	}
+	defer rdr.Release()
+	if !rdr.Next() {
+		t.Fatal("expected catalogs batch")
+	}
+	rec := rdr.Record()
+	if rec.NumRows() != 1 {
+		t.Fatalf("catalog rows=%d", rec.NumRows())
+	}
+}
+
+func TestFlightSQLExecuteRejectedWithoutToken(t *testing.T) {
+	_, client := startAuthFsql(t, "secret-token")
+	_, err := client.Execute(context.Background(), "SELECT 1 AS x")
+	if err == nil {
+		t.Fatal("expected unauthenticated execute")
+	}
+}

--- a/src/node/fsql_metadata.go
+++ b/src/node/fsql_metadata.go
@@ -1,0 +1,162 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package node
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/flight"
+	"github.com/apache/arrow-go/v18/arrow/flight/flightsql"
+	"github.com/apache/arrow-go/v18/arrow/flight/flightsql/schema_ref"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func flightInfoForCommand(desc *flight.FlightDescriptor, schema *arrow.Schema) *flight.FlightInfo {
+	return &flight.FlightInfo{
+		Endpoint:         []*flight.FlightEndpoint{{Ticket: &flight.Ticket{Ticket: desc.Cmd}}},
+		FlightDescriptor: desc,
+		TotalRecords:     -1,
+		TotalBytes:       -1,
+		Schema:           flight.SerializeSchema(schema, memory.DefaultAllocator),
+	}
+}
+
+func (s *fsqlServer) GetFlightInfoCatalogs(_ context.Context, desc *flight.FlightDescriptor) (*flight.FlightInfo, error) {
+	return flightInfoForCommand(desc, schema_ref.Catalogs), nil
+}
+
+func (s *fsqlServer) DoGetCatalogs(context.Context) (*arrow.Schema, <-chan flight.StreamChunk, error) {
+	name := s.lakeName
+	if name == "" {
+		name = "homer_lake"
+	}
+	return stringColumnStream(schema_ref.Catalogs, []string{name})
+}
+
+func (s *fsqlServer) GetFlightInfoSchemas(_ context.Context, _ flightsql.GetDBSchemas, desc *flight.FlightDescriptor) (*flight.FlightInfo, error) {
+	return flightInfoForCommand(desc, schema_ref.DBSchemas), nil
+}
+
+func (s *fsqlServer) DoGetDBSchemas(_ context.Context, cmd flightsql.GetDBSchemas) (*arrow.Schema, <-chan flight.StreamChunk, error) {
+	if pat := cmd.GetDBSchemaFilterPattern(); pat != nil && *pat != "" && *pat != "%" && *pat != "main" {
+		return emptyRecordStream(schema_ref.DBSchemas)
+	}
+	catalog := s.lakeName
+	if catalog == "" {
+		catalog = "homer_lake"
+	}
+	return twoStringColumnStream(schema_ref.DBSchemas, []string{catalog}, []string{"main"})
+}
+
+func (s *fsqlServer) GetFlightInfoTables(_ context.Context, _ flightsql.GetTables, desc *flight.FlightDescriptor) (*flight.FlightInfo, error) {
+	return flightInfoForCommand(desc, schema_ref.Tables), nil
+}
+
+func (s *fsqlServer) DoGetTables(ctx context.Context, cmd flightsql.GetTables) (*arrow.Schema, <-chan flight.StreamChunk, error) {
+	schema := schema_ref.Tables
+	db := s.node.queryDB()
+	if db == nil {
+		return emptyRecordStream(schema)
+	}
+	q := `SELECT table_catalog, table_schema, table_name, table_type
+FROM information_schema.tables
+WHERE table_catalog NOT IN ('system', 'temp', 'memory')`
+	if cat := cmd.GetCatalog(); cat != nil && *cat != "" {
+		q += fmt.Sprintf(" AND table_catalog = '%s'", escapeSQLLiteral(*cat))
+	}
+	if pat := cmd.GetDBSchemaFilterPattern(); pat != nil && *pat != "" && *pat != "%" {
+		q += fmt.Sprintf(" AND table_schema LIKE '%s'", escapeSQLLiteral(*pat))
+	}
+	if pat := cmd.GetTableNameFilterPattern(); pat != nil && *pat != "" && *pat != "%" {
+		q += fmt.Sprintf(" AND table_name LIKE '%s'", escapeSQLLiteral(*pat))
+	}
+	rows, err := db.QueryContext(ctx, q)
+	if err != nil {
+		return emptyRecordStream(schema)
+	}
+	defer rows.Close()
+
+	var catalogs, schemas, names, types []string
+	for rows.Next() {
+		var catalog, sch, name, typ string
+		if err := rows.Scan(&catalog, &sch, &name, &typ); err != nil {
+			return nil, nil, status.Errorf(codes.Internal, "tables scan: %v", err)
+		}
+		catalogs = append(catalogs, catalog)
+		schemas = append(schemas, sch)
+		names = append(names, name)
+		types = append(types, typ)
+	}
+	if len(names) == 0 {
+		return emptyRecordStream(schema)
+	}
+	return fourStringColumnStream(schema, catalogs, schemas, names, types)
+}
+
+func escapeSQLLiteral(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
+
+func stringColumnStream(schema *arrow.Schema, values []string) (*arrow.Schema, <-chan flight.StreamChunk, error) {
+	bldr := array.NewStringBuilder(memory.DefaultAllocator)
+	defer bldr.Release()
+	bldr.AppendValues(values, nil)
+	arr := bldr.NewArray()
+	defer arr.Release()
+	batch := array.NewRecord(schema, []arrow.Array{arr}, int64(len(values)))
+	return recordStream(schema, batch)
+}
+
+func twoStringColumnStream(schema *arrow.Schema, a, b []string) (*arrow.Schema, <-chan flight.StreamChunk, error) {
+	ba := array.NewStringBuilder(memory.DefaultAllocator)
+	defer ba.Release()
+	bb := array.NewStringBuilder(memory.DefaultAllocator)
+	defer bb.Release()
+	ba.AppendValues(a, nil)
+	bb.AppendValues(b, nil)
+	aa, ab := ba.NewArray(), bb.NewArray()
+	defer aa.Release()
+	defer ab.Release()
+	batch := array.NewRecord(schema, []arrow.Array{aa, ab}, int64(len(a)))
+	return recordStream(schema, batch)
+}
+
+func fourStringColumnStream(schema *arrow.Schema, a, b, c, d []string) (*arrow.Schema, <-chan flight.StreamChunk, error) {
+	builders := make([]*array.StringBuilder, 4)
+	arrs := make([]arrow.Array, 4)
+	cols := [][]string{a, b, c, d}
+	for i := range builders {
+		builders[i] = array.NewStringBuilder(memory.DefaultAllocator)
+		builders[i].AppendValues(cols[i], nil)
+		arrs[i] = builders[i].NewArray()
+		builders[i].Release()
+	}
+	defer func() {
+		for _, arr := range arrs {
+			arr.Release()
+		}
+	}()
+	batch := array.NewRecord(schema, arrs, int64(len(a)))
+	return recordStream(schema, batch)
+}
+
+func emptyRecordStream(schema *arrow.Schema) (*arrow.Schema, <-chan flight.StreamChunk, error) {
+	ch := make(chan flight.StreamChunk)
+	close(ch)
+	return schema, ch, nil
+}
+
+func recordStream(schema *arrow.Schema, batch arrow.Record) (*arrow.Schema, <-chan flight.StreamChunk, error) {
+	ch := make(chan flight.StreamChunk, 1)
+	ch <- flight.StreamChunk{Data: batch}
+	close(ch)
+	return schema, ch, nil
+}

--- a/src/node/fsql_server.go
+++ b/src/node/fsql_server.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"strings"
 	"sync"
 	"time"
 
@@ -22,11 +21,11 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/sipcapture/homer-core/src/config"
 	"github.com/sipcapture/homer-core/src/coordinator/sqlvalidator"
+	"github.com/sipcapture/homer-core/src/fsqlauth"
 	"github.com/sipcapture/homer-core/src/sqlrewrite"
 	logger "github.com/sipcapture/homer-core/src/utils/logging"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -185,14 +184,7 @@ func (s *fsqlServer) Start() error {
 		return fmt.Errorf("FlightSQL server already running")
 	}
 	addr := fmt.Sprintf("%s:%d", s.cfg.Host, s.cfg.Port)
-	var opts []grpc.ServerOption
-	if s.cfg.AuthToken != "" {
-		opts = append(opts,
-			grpc.ChainUnaryInterceptor(s.requireAuthUnary),
-			grpc.ChainStreamInterceptor(s.requireAuthStream),
-		)
-	}
-	s.grpcServer = grpc.NewServer(opts...)
+	s.grpcServer = grpc.NewServer(fsqlauth.ServerOptions(s.cfg.AuthToken)...)
 	flight.RegisterFlightServiceServer(s.grpcServer, flightsql.NewFlightServer(s))
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
@@ -260,35 +252,4 @@ func (s *fsqlServer) Stop() {
 	}
 	s.running = false
 	logger.Info("Node: Arrow FlightSQL server stopped")
-}
-
-func (s *fsqlServer) requireAuthUnary(
-	ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
-) (interface{}, error) {
-	if err := s.checkToken(ctx); err != nil {
-		return nil, err
-	}
-	return handler(ctx, req)
-}
-
-func (s *fsqlServer) requireAuthStream(
-	srv interface{}, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler,
-) error {
-	if err := s.checkToken(ss.Context()); err != nil {
-		return err
-	}
-	return handler(srv, ss)
-}
-
-func (s *fsqlServer) checkToken(ctx context.Context) error {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return status.Error(codes.Unauthenticated, "missing metadata")
-	}
-	for _, v := range md.Get("authorization") {
-		if strings.HasPrefix(v, "Bearer ") && strings.TrimPrefix(v, "Bearer ") == s.cfg.AuthToken {
-			return nil
-		}
-	}
-	return status.Error(codes.Unauthenticated, "invalid or missing Bearer token")
 }

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -178,9 +178,9 @@ func (n *Node) Start() error {
 	n.running = true
 
 	go func() {
-		logger.Info("Node: FlightSQL server started", "addr", grpcAddr)
+		logger.Info("Node: Airport (DuckDB Flight) server started", "addr", grpcAddr)
 		if err := n.grpcServer.Serve(listener); err != nil {
-			logger.Error(fmt.Sprintf("Node: FlightSQL server error: %v", err))
+			logger.Error(fmt.Sprintf("Node: Airport server error: %v", err))
 		}
 	}()
 
@@ -309,7 +309,7 @@ func (n *Node) Stop() error {
 		n.db.Close()
 	}
 
-	logger.Info("Node: FlightSQL server stopped")
+	logger.Info("Node: Airport server stopped")
 	return nil
 }
 

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.330"
+	VERSION_APPLICATION = "11.0.331"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Fix FlightSQL handshake for Grafana / GizmoSQL / ADBC: skip Bearer on `Handshake`, accept Bearer/Basic/raw tokens on later RPCs, and implement `GetCatalogs` / `GetDBSchemas`.
- Honor `node.flightsql_server` vs Docker env overrides; treat `coordinator.flightsql_port` as an alias that enables the coordinator proxy and auto-wire local `nodes[].flightsql_port`.
- Document the Airport vs FlightSQL split, TLS/plaintext, and token (`flightsql_server.auth_token`, not the UI JWT). Bump version to **11.0.331**.

Fixes https://github.com/sipcapture/homer/issues/977

## Test plan
- [x] `go test ./fsqlauth/ ./node/ ./config/ -run 'TestFlightSQL|TestCheckIncoming|TestStreamInterceptor|TestLoad_CoordinatorBareFlightSQLPort'`
- [x] Enable `node.flightsql_server` (or `HOMER_NODE_FLIGHTSQL_SERVER_ENABLE=true`) and confirm a listener on `:50055` inside the container, not only docker-proxy on the host
- [x] Grafana FlightSQL / GizmoSQL: TLS off, Bearer token from `flightsql_server.auth_token`, Handshake + `SELECT 1` succeed
- [ ] Confirm `coordinator.flightsql_port: 50055` logs a deprecation warning and starts the proxy