### PR TITLE
fix(storage): refresh credential_chain S3 secret before cold ops (11.0.333)

### DIFF
--- a/src/storage/ducklake/mover/move.go
+++ b/src/storage/ducklake/mover/move.go
@@ -33,6 +33,10 @@ type Options struct {
 	// for metadata reads and the source DELETE — never during the byte copy.
 	Lock   func()
 	Unlock func()
+	// BeforeRegister runs after parquet bytes are on the destination and
+	// before ducklake_add_data_files. Native S3 copies can outlive an IMDS
+	// token; this is how Homer recreates the DuckDB credential_chain secret.
+	BeforeRegister func() error
 }
 
 func (o Options) lock() {
@@ -154,6 +158,12 @@ func Move(ctx context.Context, opts Options) (Result, error) {
 		}
 		copied = append(copied, dst)
 		bytesCopied += f.fileSizeBytes
+	}
+
+	if opts.BeforeRegister != nil {
+		if err := opts.BeforeRegister(); err != nil {
+			return Result{}, fmt.Errorf("refresh destination credentials before register: %w", err)
+		}
 	}
 
 	// Destination catalog is a different SQLite file than the writer hot catalog.

--- a/src/storage/ducklake/mover/move_e2e_test.go
+++ b/src/storage/ducklake/mover/move_e2e_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 type twoLakeFixture struct {
-	db      *sql.DB
-	hotData string
+	db       *sql.DB
+	hotData  string
 	coldData string
 	hotLake  string
 	coldLake string
@@ -253,5 +253,38 @@ func TestNativeMoveDoesNotHoldLockDuringCopy(t *testing.T) {
 	}
 	if got := f.count(t, "cold", day); got != 15 {
 		t.Errorf("cold = %d", got)
+	}
+}
+
+func TestNativeMoveBeforeRegisterRunsAfterCopy(t *testing.T) {
+	f := newTwoLakeFixture(t)
+	if ok, reason := addDataFilesSupported(context.Background(), f.db); !ok {
+		t.Skip(reason)
+	}
+	day := "2026-07-18"
+	f.insert(t, day, 0, 12)
+
+	var copiedBeforeRegister atomic.Bool
+	var registerCalled atomic.Bool
+	opts := f.options(day)
+	opts.BeforeRegister = func() error {
+		registerCalled.Store(true)
+		if f.count(t, "cold", day) != 0 {
+			t.Error("destination catalog must still be empty before register")
+		}
+		copiedBeforeRegister.Store(true)
+		return nil
+	}
+	if _, err := Move(context.Background(), opts); err != nil {
+		t.Fatalf("Move: %v", err)
+	}
+	if !registerCalled.Load() {
+		t.Fatal("BeforeRegister was not called")
+	}
+	if !copiedBeforeRegister.Load() {
+		t.Fatal("BeforeRegister ran without a successful copy")
+	}
+	if got := f.count(t, "cold", day); got != 12 {
+		t.Errorf("cold after register = %d, want 12", got)
 	}
 }

--- a/src/storage/ducklake/retry_test.go
+++ b/src/storage/ducklake/retry_test.go
@@ -101,6 +101,26 @@ func TestUseNativeMove(t *testing.T) {
 	})
 }
 
+func TestNativeMoveOptionsRefreshesChainSecretBeforeRegister(t *testing.T) {
+	hot := &Volume{Name: "hot", LakeName: "hot", Path: "/data/hot", Type: VolumeTypeLocal}
+	chain := &Volume{Name: "cold", LakeName: "cold", Path: "s3://bucket/cold", Type: VolumeTypeS3, S3Region: "us-east-1"}
+	tsm := &TieredStorageManager{config: TieredStorageConfig{MoveEngine: "native"}}
+
+	opts := tsm.nativeMoveOptions("hep_proto_1_call", "2026-08-25", hot, chain)
+	if opts.BeforeRegister == nil {
+		t.Fatal("S3 destination must set BeforeRegister to refresh the DuckDB secret after PUT")
+	}
+	if err := opts.BeforeRegister(); err != nil {
+		t.Fatalf("nil-db refresh must be a no-op: %v", err)
+	}
+
+	localDst := &Volume{Name: "warm", LakeName: "warm", Path: "/data/warm", Type: VolumeTypeLocal}
+	opts = tsm.nativeMoveOptions("hep_proto_1_call", "2026-08-25", hot, localDst)
+	if opts.BeforeRegister != nil {
+		t.Fatal("local destination does not need BeforeRegister")
+	}
+}
+
 func TestHotCatalogLockerOnlyForPrimaryVolume(t *testing.T) {
 	tsm := &TieredStorageManager{
 		primaryVolume: &Volume{LakeName: "homer_lake_hot"},

--- a/src/storage/ducklake/tiered_storage.go
+++ b/src/storage/ducklake/tiered_storage.go
@@ -179,40 +179,104 @@ func (tsm *TieredStorageManager) Start() error {
 	return nil
 }
 
-// attachVolume attaches a volume as a DuckLake database
-func (tsm *TieredStorageManager) attachVolume(vol *Volume) error {
-	// Configure S3 if needed
-	if vol.Type == VolumeTypeS3 {
-		// For S3-compatible storage (RustFS, MinIO, R2), create a secret
-		// This is required for DuckLake to use custom S3 endpoints
-		secretName := fmt.Sprintf("s3_secret_%s", vol.Name)
+func s3SecretName(volumeName string) string {
+	return fmt.Sprintf("s3_secret_%s", volumeName)
+}
 
-		// Drop existing secret if any
+func volumeS3EndpointHost(endpoint string) string {
+	endpoint = strings.TrimSpace(endpoint)
+	endpoint = strings.TrimPrefix(endpoint, "http://")
+	endpoint = strings.TrimPrefix(endpoint, "https://")
+	return endpoint
+}
+
+// usesS3CredentialChain is the native-AWS branch of buildS3SecretSQL: empty
+// static key and no custom endpoint, so DuckDB resolves IMDS / IRSA / env.
+func usesS3CredentialChain(accessKey, endpoint string) bool {
+	return strings.TrimSpace(accessKey) == "" && strings.TrimSpace(endpoint) == ""
+}
+
+func s3SecretSQLForVolume(vol *Volume, replace bool) string {
+	endpoint := volumeS3EndpointHost(vol.S3Endpoint)
+	region := strings.TrimSpace(vol.S3Region)
+	if region == "" && endpoint != "" {
+		region = "us-east-1"
+	}
+	sql := buildS3SecretSQL(s3SecretName(vol.Name), vol.S3AccessKey, vol.S3SecretKey, region, endpoint, vol.S3UseSSL, vol.S3URLStyle)
+	if replace {
+		sql = strings.Replace(sql, "CREATE SECRET", "CREATE OR REPLACE SECRET", 1)
+	}
+	return sql
+}
+
+func (tsm *TieredStorageManager) createVolumeS3Secret(vol *Volume, replace bool) error {
+	secretName := s3SecretName(vol.Name)
+	if !replace {
 		dropSecret := fmt.Sprintf("DROP SECRET IF EXISTS %s;", secretName)
 		if _, err := tsm.db.Exec(dropSecret); err != nil {
 			logger.Warn("TieredStorageManager: Failed to drop existing secret", "secret", secretName, "error", err)
 		}
+	}
 
-		// Build endpoint URL
-		endpoint := vol.S3Endpoint
-		if endpoint != "" {
-			endpoint = strings.TrimPrefix(endpoint, "http://")
-			endpoint = strings.TrimPrefix(endpoint, "https://")
-		}
-		region := strings.TrimSpace(vol.S3Region)
-		if region == "" && endpoint != "" {
-			region = "us-east-1"
-		}
-
-		createSecret := buildS3SecretSQL(secretName, vol.S3AccessKey, vol.S3SecretKey, region, endpoint, vol.S3UseSSL, vol.S3URLStyle)
-
+	endpoint := volumeS3EndpointHost(vol.S3Endpoint)
+	createSecret := s3SecretSQLForVolume(vol, replace)
+	if replace {
+		logger.Debug("TieredStorageManager: Refreshing credential_chain S3 secret",
+			"volume", vol.Name)
+	} else {
 		logger.Info("TieredStorageManager: Creating S3 secret",
 			"volume", vol.Name,
 			"endpoint", endpoint,
 			"use_ssl", vol.S3UseSSL)
+	}
 
-		if _, err := tsm.db.Exec(createSecret); err != nil {
-			return fmt.Errorf("failed to create S3 secret for volume %s: %w", vol.Name, err)
+	if _, err := tsm.db.Exec(createSecret); err != nil {
+		return fmt.Errorf("failed to create S3 secret for volume %s: %w", vol.Name, err)
+	}
+	return nil
+}
+
+// refreshCredentialChainSecret re-resolves a role-based S3 secret so DuckDB
+// does not keep the session token captured at CREATE SECRET / process start.
+// REFRESH auto is the DuckDB-side counterpart, but S3 ExpiredToken is HTTP 400
+// and may not trigger that retry; native register and volume maintenance
+// therefore recreate the secret explicitly. No-op for static keys / MinIO.
+func (tsm *TieredStorageManager) refreshCredentialChainSecret(vol *Volume) error {
+	if tsm == nil || tsm.db == nil || vol == nil || vol.Type != VolumeTypeS3 {
+		return nil
+	}
+	if !usesS3CredentialChain(vol.S3AccessKey, volumeS3EndpointHost(vol.S3Endpoint)) {
+		return nil
+	}
+	return tsm.createVolumeS3Secret(vol, true)
+}
+
+// RefreshCredentialChainSecrets re-creates DuckDB S3 secrets that use
+// PROVIDER credential_chain. Call at the start of a tiering cycle so COUNT,
+// expire, native register, and volume maintenance do not use a token resolved
+// at process start (sipcapture/homer#980).
+func (tsm *TieredStorageManager) RefreshCredentialChainSecrets() {
+	tsm.refreshCredentialChainSecrets()
+}
+
+func (tsm *TieredStorageManager) refreshCredentialChainSecrets() {
+	if tsm == nil {
+		return
+	}
+	for _, vol := range tsm.volumes {
+		if err := tsm.refreshCredentialChainSecret(vol); err != nil {
+			logger.Warn("TieredStorageManager: failed to refresh credential_chain S3 secret",
+				"volume", vol.Name, "error", err)
+		}
+	}
+}
+
+// attachVolume attaches a volume as a DuckLake database
+func (tsm *TieredStorageManager) attachVolume(vol *Volume) error {
+	// Configure S3 if needed
+	if vol.Type == VolumeTypeS3 {
+		if err := tsm.createVolumeS3Secret(vol, false); err != nil {
+			return err
 		}
 	}
 
@@ -363,6 +427,13 @@ func (tsm *TieredStorageManager) MovePartition(tableName string, date string, sr
 		"to", dstVol.Name,
 		"engine", tsm.moveEngine())
 
+	// DuckDB COUNT / INSERT / add_data_files on the cold lake use the session
+	// secret, not the AWS SDK copier. Re-resolve role credentials first.
+	if err := tsm.refreshCredentialChainSecret(dstVol); err != nil {
+		logger.Warn("TieredStorageManager: failed to refresh destination S3 secret",
+			"volume", dstVol.Name, "error", err)
+	}
+
 	hotLocker := tsm.hotCatalogLocker(srcVol)
 
 	srcCount, err := tsm.partitionRowCount(srcTable, date)
@@ -446,7 +517,7 @@ func (tsm *TieredStorageManager) useNativeMove(srcVol, dstVol *Volume) bool {
 	return true
 }
 
-func (tsm *TieredStorageManager) movePartitionNative(tableName, date string, srcVol, dstVol *Volume) error {
+func (tsm *TieredStorageManager) nativeMoveOptions(tableName, date string, srcVol, dstVol *Volume) mover.Options {
 	opts := mover.Options{
 		DB:          tsm.db,
 		SrcLake:     srcVol.LakeName,
@@ -469,7 +540,19 @@ func (tsm *TieredStorageManager) movePartitionNative(tableName, date string, src
 			URLStyle:  dstVol.S3URLStyle,
 			UseSSL:    dstVol.S3UseSSL,
 		}
+		// PUT uses the AWS SDK (auto-refresh). Register is DuckDB read_blob /
+		// add_data_files against the secret captured at start — recreate it
+		// after a long copy so ExpiredToken cannot land on register.
+		dst := dstVol
+		opts.BeforeRegister = func() error {
+			return tsm.refreshCredentialChainSecret(dst)
+		}
 	}
+	return opts
+}
+
+func (tsm *TieredStorageManager) movePartitionNative(tableName, date string, srcVol, dstVol *Volume) error {
+	opts := tsm.nativeMoveOptions(tableName, date, srcVol, dstVol)
 
 	res, err := mover.Move(context.Background(), opts)
 	if err != nil {
@@ -600,6 +683,11 @@ func volumeMaintenanceSQL(lakeName string, snapshotOlderThanSec int) []string {
 // (issue #882 follow-up: cold physical space was never reclaimed because
 // the writer CompactionService only maintains the writer lake).
 func (tsm *TieredStorageManager) RunVolumeMaintenance(vol *Volume, snapshotOlderThanSec int) error {
+	if err := tsm.refreshCredentialChainSecret(vol); err != nil {
+		logger.Warn("TieredStorageManager: failed to refresh S3 secret before maintenance",
+			"volume", vol.Name, "error", err)
+	}
+
 	locker := tsm.hotCatalogLocker(vol)
 
 	logger.Info("TieredStorageManager: Running volume maintenance",
@@ -836,10 +924,14 @@ func sortResultsByTimestamp(results []map[string]interface{}) {
 // When accessKey is empty and endpoint is empty (native AWS S3), the secret
 // uses PROVIDER credential_chain so DuckDB resolves credentials through the
 // AWS SDK default chain (env, container/Pod Identity, instance profile).
+// REFRESH auto re-runs that chain when the cached session token expires
+// (EC2 instance-profile tokens last ~6h; IRSA / Pod Identity are shorter);
+// without it the secret is resolved once at CREATE SECRET and every later
+// cold-volume operation fails with ExpiredToken until homer-core restarts.
 // Static keys and custom endpoints (MinIO / R2) use explicit KEY_ID/SECRET.
 func buildS3SecretSQL(secretName, accessKey, secretKey, region, endpoint string, useSSL bool, urlStyle string) string {
 	switch {
-	case strings.TrimSpace(accessKey) == "" && endpoint == "":
+	case usesS3CredentialChain(accessKey, endpoint):
 		// Default region for native AWS S3 so the secret signs correctly even
 		// when no s3_region is set (the SDK can also resolve it from the
 		// environment / instance metadata, but an explicit value is safer).
@@ -850,6 +942,7 @@ func buildS3SecretSQL(secretName, accessKey, secretKey, region, endpoint string,
 			CREATE SECRET %s (
 				TYPE S3,
 				PROVIDER credential_chain,
+				REFRESH auto,
 				REGION '%s'
 			);
 		`, secretName, region)

--- a/src/storage/ducklake/tiered_storage_test.go
+++ b/src/storage/ducklake/tiered_storage_test.go
@@ -150,6 +150,14 @@ func TestBuildS3SecretSQL_Branches(t *testing.T) {
 			if tc.denySubstr != "" && strings.Contains(sql, tc.denySubstr) {
 				t.Errorf("SQL should not contain %q:\n%s", tc.denySubstr, sql)
 			}
+			chain := strings.Contains(sql, "PROVIDER credential_chain")
+			refresh := strings.Contains(sql, "REFRESH auto")
+			if chain && !refresh {
+				t.Errorf("credential_chain SQL must include REFRESH auto:\n%s", sql)
+			}
+			if !chain && refresh {
+				t.Errorf("non-chain SQL must not include REFRESH auto:\n%s", sql)
+			}
 		})
 	}
 }
@@ -158,5 +166,54 @@ func TestBuildS3SecretSQL_CustomEndpointURLStyle(t *testing.T) {
 	sql := buildS3SecretSQL("test_secret", "AKIA...", "secret", "cn-hangzhou", "oss-cn-hangzhou.aliyuncs.com", true, "vhost")
 	if !strings.Contains(sql, "URL_STYLE 'vhost'") {
 		t.Fatalf("SQL should contain vhost URL_STYLE:\n%s", sql)
+	}
+}
+
+func TestUsesS3CredentialChain(t *testing.T) {
+	if !usesS3CredentialChain("", "") {
+		t.Fatal("empty key + empty endpoint is credential_chain")
+	}
+	if !usesS3CredentialChain("  ", "") {
+		t.Fatal("whitespace key is still credential_chain")
+	}
+	if usesS3CredentialChain("AKIA...", "") {
+		t.Fatal("static key is not credential_chain")
+	}
+	if usesS3CredentialChain("", "minio.local:9000") {
+		t.Fatal("custom endpoint is not credential_chain")
+	}
+}
+
+func TestS3SecretSQLForVolume_ReplaceKeepsRefreshAuto(t *testing.T) {
+	vol := &Volume{Name: "cold", Type: VolumeTypeS3, S3Region: "us-east-1"}
+	sql := s3SecretSQLForVolume(vol, true)
+	if !strings.Contains(sql, "CREATE OR REPLACE SECRET") {
+		t.Fatalf("refresh SQL must REPLACE, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "PROVIDER credential_chain") || !strings.Contains(sql, "REFRESH auto") {
+		t.Fatalf("refresh SQL must keep credential_chain + REFRESH auto:\n%s", sql)
+	}
+	static := s3SecretSQLForVolume(&Volume{
+		Name: "cold", Type: VolumeTypeS3, S3AccessKey: "AKIA...", S3Region: "us-east-1",
+	}, true)
+	if strings.Contains(static, "credential_chain") {
+		t.Fatalf("static-key refresh SQL must not use credential_chain:\n%s", static)
+	}
+}
+
+func TestRefreshCredentialChainSecret_NoOpWithoutDBOrStaticKeys(t *testing.T) {
+	tsm := &TieredStorageManager{}
+	if err := tsm.refreshCredentialChainSecret(&Volume{Type: VolumeTypeS3, Name: "cold"}); err != nil {
+		t.Fatalf("nil db: %v", err)
+	}
+	if err := tsm.refreshCredentialChainSecret(&Volume{
+		Type: VolumeTypeS3, Name: "cold", S3AccessKey: "AKIA...",
+	}); err != nil {
+		t.Fatalf("static keys: %v", err)
+	}
+	if err := tsm.refreshCredentialChainSecret(&Volume{
+		Type: VolumeTypeLocal, Name: "hot",
+	}); err != nil {
+		t.Fatalf("local volume: %v", err)
 	}
 }

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.332"
+	VERSION_APPLICATION = "11.0.333"
 
 	// BuildDate is the build date
 	BuildDate = ""

--- a/src/writer/tiering.go
+++ b/src/writer/tiering.go
@@ -131,6 +131,7 @@ func (ts *TieringService) runTieringCycle() {
 	logger.Info("TieringService: Starting tiering cycle")
 
 	volumes := ts.tieredStorage.GetVolumes()
+	ts.tieredStorage.RefreshCredentialChainSecrets()
 	var totalMoved int64
 	var totalExpired int64
 


### PR DESCRIPTION
## Summary
- Fixes #980: DuckDB `credential_chain` S3 secrets were resolved once at startup and never refreshed, so cold-volume ops failed with `ExpiredToken` ~6h later on EC2/IRSA.
- Add `REFRESH auto` on `CREATE SECRET`, and explicitly recreate the secret at the start of each tiering cycle, before `MovePartition` / volume maintenance, and after native PUT (`BeforeRegister`) so `ducklake_add_data_files` and `read_blob` do not keep the token from process start.
- Native AWS SDK PUT already refreshes; static keys and custom endpoints (MinIO/R2) are unchanged.

## Test plan
- [x] `go test ./storage/ducklake/ ./storage/ducklake/mover/` — secret SQL, refresh no-op, native `BeforeRegister` e2e
- [ ] On EC2 with instance profile and empty `s3_access_key_id`: leave `homer-core` running past one IMDS rotation (~6h) and confirm cold maintenance / native move still succeed without restart