### PR TITLE
fix(storage): serialize node credential_chain refresh (Azure + S3)

### DIFF
--- a/src/node/azure_secret_refresh_test.go
+++ b/src/node/azure_secret_refresh_test.go
@@ -17,14 +17,16 @@ import (
 	_ "github.com/duckdb/duckdb-go/v2"
 )
 
-func TestNodeUsesAzureCredentialChain(t *testing.T) {
+func TestNodeUsesCredentialChain(t *testing.T) {
 	cases := []struct {
 		name    string
 		volumes []config.VolumeConfig
 		want    bool
 	}{
 		{name: "no volumes", volumes: nil, want: false},
-		{name: "s3 volume only", volumes: []config.VolumeConfig{{Type: "s3"}}, want: false},
+		{name: "s3 with static key", volumes: []config.VolumeConfig{{Type: "s3", S3AccessKeyID: "AKIA..."}}, want: false},
+		{name: "s3 with custom endpoint", volumes: []config.VolumeConfig{{Type: "s3", S3Endpoint: "minio.local:9000"}}, want: false},
+		{name: "s3 empty keys native AWS", volumes: []config.VolumeConfig{{Type: "s3"}}, want: true},
 		{
 			name:    "azure with account key",
 			volumes: []config.VolumeConfig{{Type: "azure", AzureAccountKey: "k"}},
@@ -45,20 +47,20 @@ func TestNodeUsesAzureCredentialChain(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := &config.NodeConfig{DuckLake: config.DuckLakeConfig{Volumes: tc.volumes}}
-			if got := nodeUsesAzureCredentialChain(cfg); got != tc.want {
-				t.Errorf("nodeUsesAzureCredentialChain() = %v, want %v", got, tc.want)
+			if got := nodeUsesCredentialChain(cfg); got != tc.want {
+				t.Errorf("nodeUsesCredentialChain() = %v, want %v", got, tc.want)
 			}
 		})
 	}
 }
 
-// TestRefreshAzureSecrets_RecreatesCredentialChainSecret proves the refresh
+// TestRefreshCredentialChainSecrets_RecreatesAzure proves the refresh
 // actually reaches DuckDB: it drops and recreates the credential_chain
 // secret for an Azure volume, leaving a static-key volume's secret alone.
 // CREATE SECRET for credential_chain never resolves credentials itself (only
 // first use does, per DuckDB's azure extension), so this cannot hang like
 // the write-path tests that go on to ATTACH/glob.
-func TestRefreshAzureSecrets_RecreatesCredentialChainSecret(t *testing.T) {
+func TestRefreshCredentialChainSecrets_RecreatesAzure(t *testing.T) {
 	db, err := sql.Open("duckdb", "")
 	if err != nil {
 		t.Fatalf("open duckdb: %v", err)
@@ -81,25 +83,61 @@ func TestRefreshAzureSecrets_RecreatesCredentialChainSecret(t *testing.T) {
 		},
 	}
 
-	n.refreshAzureSecrets()
+	n.refreshCredentialChainSecrets()
 
 	assertNodeSecret(t, db, "azure_secret_cold", true)
 	assertNodeSecret(t, db, "azure_secret_static", false)
 }
 
-// TestRefreshAzureSecrets_NilDBIsNoOp is a defensive smoke: a node that
-// hasn't attached yet must not panic when the ticker fires early.
-func TestRefreshAzureSecrets_NilDBIsNoOp(t *testing.T) {
+// TestRefreshCredentialChainSecrets_RecreatesS3 is the S3 counterpart:
+// empty keys + no custom endpoint become PROVIDER credential_chain (the
+// node used to skip CREATE SECRET entirely, which is why #980's SQL
+// console survived while TSM died). Static-key volumes are left alone.
+func TestRefreshCredentialChainSecrets_RecreatesS3(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Fatalf("open duckdb: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec("LOAD httpfs;"); err != nil {
+		t.Skipf("httpfs extension unavailable: %v", err)
+	}
+	if _, err := db.Exec("LOAD aws;"); err != nil {
+		t.Skipf("aws extension unavailable: %v", err)
+	}
+
+	n := &Node{
+		db: db,
+		config: &config.NodeConfig{
+			DuckLake: config.DuckLakeConfig{
+				Volumes: []config.VolumeConfig{
+					{Name: "cold", Type: "s3", S3Region: "us-east-1"},
+					{Name: "static", Type: "s3", S3AccessKeyID: "AKIA...", S3SecretKey: "secret", S3Region: "us-east-1"},
+				},
+			},
+		},
+	}
+
+	n.refreshCredentialChainSecrets()
+
+	assertNodeSecret(t, db, "s3_secret_cold", true)
+	assertNodeSecret(t, db, "s3_secret_static", false)
+}
+
+// TestRefreshCredentialChainSecrets_NilDBIsNoOp is a defensive smoke: a node
+// that hasn't attached yet must not panic when the ticker fires early.
+func TestRefreshCredentialChainSecrets_NilDBIsNoOp(t *testing.T) {
 	n := &Node{config: &config.NodeConfig{DuckLake: config.DuckLakeConfig{
 		Volumes: []config.VolumeConfig{{Name: "cold", Type: "azure"}},
 	}}}
-	n.refreshAzureSecrets() // must not panic
+	n.refreshCredentialChainSecrets() // must not panic
 }
 
-// TestRefreshAzureSecrets_HoldsRefreshMu: FlightSQL catalog reconnect
+// TestRefreshCredentialChainSecrets_HoldsRefreshMu: FlightSQL catalog reconnect
 // closes n.db under refreshMu. DROP SECRET must take the same mutex so it
 // cannot run against a handle that refreshCatalog is about to Close.
-func TestRefreshAzureSecrets_HoldsRefreshMu(t *testing.T) {
+func TestRefreshCredentialChainSecrets_HoldsRefreshMu(t *testing.T) {
 	n := &Node{config: &config.NodeConfig{DuckLake: config.DuckLakeConfig{
 		Volumes: []config.VolumeConfig{{Name: "cold", Type: "azure"}},
 	}}}
@@ -108,43 +146,43 @@ func TestRefreshAzureSecrets_HoldsRefreshMu(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		close(started)
-		n.refreshAzureSecrets()
+		n.refreshCredentialChainSecrets()
 		close(done)
 	}()
 	<-started
 	select {
 	case <-done:
-		t.Fatal("refreshAzureSecrets returned while refreshMu is held")
+		t.Fatal("refreshCredentialChainSecrets returned while refreshMu is held")
 	case <-time.After(80 * time.Millisecond):
 	}
 	n.refreshMu.Unlock()
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("refreshAzureSecrets did not return after refreshMu was released")
+		t.Fatal("refreshCredentialChainSecrets did not return after refreshMu was released")
 	}
 }
 
-// TestStopAzureSecretRefresh_WaitsForInFlight: Stop must join the refresh
+// TestStopCredentialChainRefresh_WaitsForInFlight: Stop must join the refresh
 // goroutine before closing n.db, otherwise DROP SECRET can run on a closed handle.
-func TestStopAzureSecretRefresh_WaitsForInFlight(t *testing.T) {
+func TestStopCredentialChainRefresh_WaitsForInFlight(t *testing.T) {
 	n := &Node{}
-	n.stopAzureRefresh = make(chan struct{})
-	n.azureRefreshWg.Add(1)
+	n.stopSecretRefresh = make(chan struct{})
+	n.secretRefreshWg.Add(1)
 	started := make(chan struct{})
 	go func() {
-		defer n.azureRefreshWg.Done()
+		defer n.secretRefreshWg.Done()
 		close(started)
-		<-n.stopAzureRefresh
+		<-n.stopSecretRefresh
 		time.Sleep(80 * time.Millisecond)
 	}()
 	<-started
 	start := time.Now()
-	n.stopAzureSecretRefresh()
+	n.stopCredentialChainRefresh()
 	if time.Since(start) < 50*time.Millisecond {
-		t.Fatal("expected stopAzureSecretRefresh to wait for the in-flight goroutine")
+		t.Fatal("expected stopCredentialChainRefresh to wait for the in-flight goroutine")
 	}
-	n.stopAzureSecretRefresh() // second call must be a no-op
+	n.stopCredentialChainRefresh() // second call must be a no-op
 }
 
 func assertNodeSecret(t *testing.T, db *sql.DB, name string, wantExists bool) {

--- a/src/node/azure_secret_refresh_test.go
+++ b/src/node/azure_secret_refresh_test.go
@@ -10,6 +10,7 @@ package node
 import (
 	"database/sql"
 	"testing"
+	"time"
 
 	"github.com/sipcapture/homer-core/src/config"
 
@@ -93,6 +94,57 @@ func TestRefreshAzureSecrets_NilDBIsNoOp(t *testing.T) {
 		Volumes: []config.VolumeConfig{{Name: "cold", Type: "azure"}},
 	}}}
 	n.refreshAzureSecrets() // must not panic
+}
+
+// TestRefreshAzureSecrets_HoldsRefreshMu: FlightSQL catalog reconnect
+// closes n.db under refreshMu. DROP SECRET must take the same mutex so it
+// cannot run against a handle that refreshCatalog is about to Close.
+func TestRefreshAzureSecrets_HoldsRefreshMu(t *testing.T) {
+	n := &Node{config: &config.NodeConfig{DuckLake: config.DuckLakeConfig{
+		Volumes: []config.VolumeConfig{{Name: "cold", Type: "azure"}},
+	}}}
+	n.refreshMu.Lock()
+	started := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		close(started)
+		n.refreshAzureSecrets()
+		close(done)
+	}()
+	<-started
+	select {
+	case <-done:
+		t.Fatal("refreshAzureSecrets returned while refreshMu is held")
+	case <-time.After(80 * time.Millisecond):
+	}
+	n.refreshMu.Unlock()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("refreshAzureSecrets did not return after refreshMu was released")
+	}
+}
+
+// TestStopAzureSecretRefresh_WaitsForInFlight: Stop must join the refresh
+// goroutine before closing n.db, otherwise DROP SECRET can run on a closed handle.
+func TestStopAzureSecretRefresh_WaitsForInFlight(t *testing.T) {
+	n := &Node{}
+	n.stopAzureRefresh = make(chan struct{})
+	n.azureRefreshWg.Add(1)
+	started := make(chan struct{})
+	go func() {
+		defer n.azureRefreshWg.Done()
+		close(started)
+		<-n.stopAzureRefresh
+		time.Sleep(80 * time.Millisecond)
+	}()
+	<-started
+	start := time.Now()
+	n.stopAzureSecretRefresh()
+	if time.Since(start) < 50*time.Millisecond {
+		t.Fatal("expected stopAzureSecretRefresh to wait for the in-flight goroutine")
+	}
+	n.stopAzureSecretRefresh() // second call must be a no-op
 }
 
 func assertNodeSecret(t *testing.T, db *sql.DB, name string, wantExists bool) {

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -64,6 +64,7 @@ type Node struct {
 	// stopAzureRefresh, when non-nil, signals the periodic Azure
 	// credential_chain secret refresh goroutine (started in Start) to exit.
 	stopAzureRefresh chan struct{}
+	azureRefreshWg   sync.WaitGroup
 
 	// refreshMu serializes catalog reconnect on n.db so queries never observe
 	// a half-swapped handle while ObjectCache from DETACH+ATTACH is avoided.
@@ -234,7 +235,9 @@ func (n *Node) Start() error {
 	if n.sharedDB == nil && nodeUsesAzureCredentialChain(n.config) {
 		n.stopAzureRefresh = make(chan struct{})
 		stop := n.stopAzureRefresh
+		n.azureRefreshWg.Add(1)
 		go func() {
+			defer n.azureRefreshWg.Done()
 			ticker := time.NewTicker(azureSecretRefreshInterval)
 			defer ticker.Stop()
 			for {
@@ -273,6 +276,12 @@ func nodeUsesAzureCredentialChain(cfg *config.NodeConfig) bool {
 // reconnect is unnecessary overhead for what is otherwise just a DROP+CREATE
 // SECRET.
 func (n *Node) refreshAzureSecrets() {
+	// refreshCatalog closes n.db under refreshMu. Hold the same mutex for
+	// the duration of DROP+CREATE so we cannot Exec on a handle that is
+	// about to be (or already has been) closed.
+	n.refreshMu.Lock()
+	defer n.refreshMu.Unlock()
+
 	n.mu.RLock()
 	db := n.db
 	volumes := n.config.DuckLake.Volumes
@@ -341,6 +350,17 @@ func (n *Node) refreshCatalog() {
 // Stop stops the node module
 func (n *Node) Stop() error {
 	n.mu.Lock()
+	if !n.running {
+		n.mu.Unlock()
+		return nil
+	}
+	n.mu.Unlock()
+
+	// Join the Azure refresh goroutine before taking n.mu again: it needs
+	// n.mu.RLock (and refreshMu) to DROP SECRET, and Stop closes n.db below.
+	n.stopAzureSecretRefresh()
+
+	n.mu.Lock()
 	defer n.mu.Unlock()
 
 	if !n.running {
@@ -356,11 +376,6 @@ func (n *Node) Stop() error {
 
 	if n.fsql != nil {
 		n.fsql.Stop()
-	}
-
-	if n.stopAzureRefresh != nil {
-		close(n.stopAzureRefresh)
-		n.stopAzureRefresh = nil
 	}
 
 	// GracefulStop waits for all in-flight RPCs to finish. Guard with a timeout
@@ -385,6 +400,22 @@ func (n *Node) Stop() error {
 
 	logger.Info("Node: Airport server stopped")
 	return nil
+}
+
+// stopAzureSecretRefresh signals the periodic Azure secret refresher to
+// exit and waits for an in-flight DROP+CREATE to finish. Safe to call when
+// the goroutine was never started. Must not be held under n.mu: the
+// goroutine takes n.mu.RLock inside refreshAzureSecrets.
+func (n *Node) stopAzureSecretRefresh() {
+	n.mu.Lock()
+	ch := n.stopAzureRefresh
+	n.stopAzureRefresh = nil
+	n.mu.Unlock()
+	if ch == nil {
+		return
+	}
+	close(ch)
+	n.azureRefreshWg.Wait()
 }
 
 // QueryRequest represents a SQL query request

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -61,10 +61,11 @@ type Node struct {
 	// fsql is the optional Apache Arrow FlightSQL server (Grafana / InfluxDB FlightSQL).
 	fsql *fsqlServer
 
-	// stopAzureRefresh, when non-nil, signals the periodic Azure
-	// credential_chain secret refresh goroutine (started in Start) to exit.
-	stopAzureRefresh chan struct{}
-	azureRefreshWg   sync.WaitGroup
+	// stopSecretRefresh, when non-nil, signals the periodic credential_chain
+	// secret refresh goroutine (started in Start) to exit. Covers both
+	// Azure Managed Identity and S3 instance-profile / IRSA secrets.
+	stopSecretRefresh chan struct{}
+	secretRefreshWg   sync.WaitGroup
 
 	// refreshMu serializes catalog reconnect on n.db so queries never observe
 	// a half-swapped handle while ObjectCache from DETACH+ATTACH is avoided.
@@ -228,22 +229,23 @@ func (n *Node) Start() error {
 
 	// Standalone nodes attach volumes once in configureDuckLake and, unless
 	// FlightSQL's own catalog refresher happens to be running, never revisit
-	// them. A credential_chain Azure secret (e.g. Managed Identity via IMDS)
-	// is only valid for its token's lifetime, so it must be recreated
-	// periodically or queries start failing with an authentication error
-	// after the node has been running a while.
-	if n.sharedDB == nil && nodeUsesAzureCredentialChain(n.config) {
-		n.stopAzureRefresh = make(chan struct{})
-		stop := n.stopAzureRefresh
-		n.azureRefreshWg.Add(1)
+	// them. credential_chain secrets (Azure MI via IMDS, S3 instance profile
+	// / IRSA) cache the token resolved at CREATE SECRET. Azure has no
+	// REFRESH auto; S3's REFRESH auto may not fire on HTTP 400 ExpiredToken
+	// (sipcapture/homer#980). Recreate both on a timer or search dies after
+	// the node has been up for a token lifetime.
+	if n.sharedDB == nil && nodeUsesCredentialChain(n.config) {
+		n.stopSecretRefresh = make(chan struct{})
+		stop := n.stopSecretRefresh
+		n.secretRefreshWg.Add(1)
 		go func() {
-			defer n.azureRefreshWg.Done()
-			ticker := time.NewTicker(azureSecretRefreshInterval)
+			defer n.secretRefreshWg.Done()
+			ticker := time.NewTicker(credentialChainRefreshInterval)
 			defer ticker.Stop()
 			for {
 				select {
 				case <-ticker.C:
-					n.refreshAzureSecrets()
+					n.refreshCredentialChainSecrets()
 				case <-stop:
 					return
 				}
@@ -254,15 +256,23 @@ func (n *Node) Start() error {
 	return nil
 }
 
-// azureSecretRefreshInterval bounds how often a standalone node recreates its
-// Azure credential_chain secrets, mirroring the writer's flushLoop refresh
-// cadence for the same secret type.
-const azureSecretRefreshInterval = 20 * time.Minute
+// credentialChainRefreshInterval bounds how often a standalone node recreates
+// Azure and S3 credential_chain secrets, mirroring the writer's flushLoop
+// refresh cadence for Azure and TSM's per-cycle S3 replace.
+const credentialChainRefreshInterval = 20 * time.Minute
 
-// nodeUsesAzureCredentialChain reports whether any attached volume relies on
-// Azure's credential_chain provider (no static account key or connection
-// string), which is the only Azure auth mode whose secret can go stale.
+// nodeUsesCredentialChain reports whether any attached volume relies on a
+// credential_chain secret (Azure MI / ambient identity, or native AWS S3
+// with empty keys and no custom endpoint). Those are the secrets that go
+// stale; static keys and MinIO/R2 endpoints do not.
+func nodeUsesCredentialChain(cfg *config.NodeConfig) bool {
+	return nodeUsesAzureCredentialChain(cfg) || nodeUsesS3CredentialChain(cfg)
+}
+
 func nodeUsesAzureCredentialChain(cfg *config.NodeConfig) bool {
+	if cfg == nil {
+		return false
+	}
 	for _, vol := range cfg.DuckLake.Volumes {
 		if vol.Type == "azure" && ducklake.UsesAzureCredentialChain(vol.AzureAccountKey, vol.AzureConnectionString) {
 			return true
@@ -271,11 +281,23 @@ func nodeUsesAzureCredentialChain(cfg *config.NodeConfig) bool {
 	return false
 }
 
-// refreshAzureSecrets recreates the credential_chain Azure secret for every
-// attached Azure volume. Kept separate from refreshCatalog since a full
-// reconnect is unnecessary overhead for what is otherwise just a DROP+CREATE
-// SECRET.
-func (n *Node) refreshAzureSecrets() {
+func nodeUsesS3CredentialChain(cfg *config.NodeConfig) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, vol := range cfg.DuckLake.Volumes {
+		if vol.Type == "s3" && ducklake.UsesS3CredentialChain(vol.S3AccessKeyID, ducklake.S3EndpointHost(vol.S3Endpoint)) {
+			return true
+		}
+	}
+	return false
+}
+
+// refreshCredentialChainSecrets recreates credential_chain secrets for every
+// attached Azure and S3 volume that uses them. Kept separate from
+// refreshCatalog since a full reconnect is unnecessary overhead for what is
+// otherwise just a DROP+CREATE SECRET.
+func (n *Node) refreshCredentialChainSecrets() {
 	// refreshCatalog closes n.db under refreshMu. Hold the same mutex for
 	// the duration of DROP+CREATE so we cannot Exec on a handle that is
 	// about to be (or already has been) closed.
@@ -284,20 +306,37 @@ func (n *Node) refreshAzureSecrets() {
 
 	n.mu.RLock()
 	db := n.db
-	volumes := n.config.DuckLake.Volumes
+	var volumes []config.VolumeConfig
+	if n.config != nil {
+		volumes = n.config.DuckLake.Volumes
+	}
 	n.mu.RUnlock()
 	if db == nil {
 		return
 	}
 	for _, vol := range volumes {
-		if vol.Type != "azure" || !ducklake.UsesAzureCredentialChain(vol.AzureAccountKey, vol.AzureConnectionString) {
-			continue
-		}
-		secretName := fmt.Sprintf("azure_secret_%s", vol.Name)
-		db.Exec(fmt.Sprintf("DROP SECRET IF EXISTS %s;", secretName))
-		createSecret := ducklake.BuildAzureSecretSQL(secretName, vol.AzureAccountName, vol.AzureAccountKey, vol.AzureConnectionString, vol.AzureEndpoint)
-		if _, err := db.Exec(createSecret); err != nil {
-			logger.Warn(fmt.Sprintf("Node: failed to refresh Azure secret for volume %s: %v", vol.Name, err))
+		switch vol.Type {
+		case "azure":
+			if !ducklake.UsesAzureCredentialChain(vol.AzureAccountKey, vol.AzureConnectionString) {
+				continue
+			}
+			secretName := fmt.Sprintf("azure_secret_%s", vol.Name)
+			db.Exec(fmt.Sprintf("DROP SECRET IF EXISTS %s;", secretName))
+			createSecret := ducklake.BuildAzureSecretSQL(secretName, vol.AzureAccountName, vol.AzureAccountKey, vol.AzureConnectionString, vol.AzureEndpoint)
+			if _, err := db.Exec(createSecret); err != nil {
+				logger.Warn(fmt.Sprintf("Node: failed to refresh Azure secret for volume %s: %v", vol.Name, err))
+			}
+		case "s3":
+			endpoint := ducklake.S3EndpointHost(vol.S3Endpoint)
+			if !ducklake.UsesS3CredentialChain(vol.S3AccessKeyID, endpoint) {
+				continue
+			}
+			secretName := fmt.Sprintf("s3_secret_%s", vol.Name)
+			db.Exec(fmt.Sprintf("DROP SECRET IF EXISTS %s;", secretName))
+			createSecret := ducklake.BuildS3SecretSQL(secretName, vol.S3AccessKeyID, vol.S3SecretKey, vol.S3Region, endpoint, vol.S3UseSSL, vol.S3URLStyle)
+			if _, err := db.Exec(createSecret); err != nil {
+				logger.Warn(fmt.Sprintf("Node: failed to refresh S3 secret for volume %s: %v", vol.Name, err))
+			}
 		}
 	}
 }
@@ -356,9 +395,10 @@ func (n *Node) Stop() error {
 	}
 	n.mu.Unlock()
 
-	// Join the Azure refresh goroutine before taking n.mu again: it needs
-	// n.mu.RLock (and refreshMu) to DROP SECRET, and Stop closes n.db below.
-	n.stopAzureSecretRefresh()
+	// Join the credential-chain refresh goroutine before taking n.mu again:
+	// it needs n.mu.RLock (and refreshMu) to DROP SECRET, and Stop closes
+	// n.db below.
+	n.stopCredentialChainRefresh()
 
 	n.mu.Lock()
 	defer n.mu.Unlock()
@@ -402,20 +442,20 @@ func (n *Node) Stop() error {
 	return nil
 }
 
-// stopAzureSecretRefresh signals the periodic Azure secret refresher to
-// exit and waits for an in-flight DROP+CREATE to finish. Safe to call when
-// the goroutine was never started. Must not be held under n.mu: the
-// goroutine takes n.mu.RLock inside refreshAzureSecrets.
-func (n *Node) stopAzureSecretRefresh() {
+// stopCredentialChainRefresh signals the periodic secret refresher to exit
+// and waits for an in-flight DROP+CREATE to finish. Safe to call when the
+// goroutine was never started. Must not be held under n.mu: the goroutine
+// takes n.mu.RLock inside refreshCredentialChainSecrets.
+func (n *Node) stopCredentialChainRefresh() {
 	n.mu.Lock()
-	ch := n.stopAzureRefresh
-	n.stopAzureRefresh = nil
+	ch := n.stopSecretRefresh
+	n.stopSecretRefresh = nil
 	n.mu.Unlock()
 	if ch == nil {
 		return
 	}
 	close(ch)
-	n.azureRefreshWg.Wait()
+	n.secretRefreshWg.Wait()
 }
 
 // QueryRequest represents a SQL query request
@@ -1825,9 +1865,15 @@ func configureDuckLake(db *sql.DB, cfg *config.NodeConfig) ([]VolumeInfo, error)
 		return nil, fmt.Errorf("failed to configure S3: %w", err)
 	}
 
+	// Best-effort LOAD aws so S3 volumes can use PROVIDER credential_chain
+	// (instance profile / IRSA). Static-key and local-only setups do not
+	// need it; a load failure must not block startup.
+	if _, err := db.Exec("LOAD aws;"); err != nil {
+		logger.Warn(fmt.Sprintf("Node: failed to load aws extension (credential_chain S3 unavailable; run --install-extensions): %v", err))
+	}
+
 	// Best-effort load of the Azure extension so az:// volumes can attach.
-	// Same contract as the tiered-storage manager's LOAD aws: local/S3-only
-	// setups do not need it, so a load failure must not block startup.
+	// Same contract as LOAD aws above: local/S3-only setups do not need it.
 	ducklake.EnsureAzureCACertPath()
 	if _, err := db.Exec("LOAD azure;"); err != nil {
 		logger.Warn(fmt.Sprintf("Node: failed to load azure extension (Azure volumes unavailable; run --install-extensions): %v", err))
@@ -1882,52 +1928,28 @@ func attachVolume(db *sql.DB, baseLakeName string, vol config.VolumeConfig) (Vol
 		lakeName = baseLakeName + "_" + vol.Name
 	}
 
-	// Configure S3 secret for this volume if needed
-	if vol.Type == "s3" && vol.S3AccessKeyID != "" {
+	// Configure S3 secret for this volume. Shared with TSM
+	// (ducklake.BuildS3SecretSQL) so empty keys on native AWS become
+	// PROVIDER credential_chain + REFRESH auto instead of skipping the
+	// secret (the #980 node-vs-writer split). Custom endpoints / static
+	// keys keep KEY_ID/SECRET. credential_chain CREATE can fail when the
+	// aws extension did not load — fall back to the default SDK chain so
+	// attach still succeeds, matching the previous empty-key behaviour.
+	if vol.Type == "s3" {
 		secretName := fmt.Sprintf("s3_secret_%s", vol.Name)
-
-		// Drop existing secret if any
 		db.Exec(fmt.Sprintf("DROP SECRET IF EXISTS %s;", secretName))
-
-		// Build endpoint
-		endpoint := vol.S3Endpoint
-		if endpoint != "" {
-			endpoint = strings.TrimPrefix(endpoint, "http://")
-			endpoint = strings.TrimPrefix(endpoint, "https://")
-		}
+		endpoint := ducklake.S3EndpointHost(vol.S3Endpoint)
 		region := strings.TrimSpace(vol.S3Region)
 		if region == "" && endpoint != "" {
 			region = "us-east-1"
 		}
-		urlStyle := strings.ReplaceAll(ducklake.NormalizeS3URLStyle(vol.S3URLStyle), "'", "''")
-
-		// Create secret
-		var createSecret string
-		if endpoint != "" {
-			createSecret = fmt.Sprintf(`
-				CREATE SECRET %s (
-					TYPE S3,
-					KEY_ID '%s',
-					SECRET '%s',
-					REGION '%s',
-					ENDPOINT '%s',
-					URL_STYLE '%s',
-					USE_SSL %t
-				);
-			`, secretName, vol.S3AccessKeyID, vol.S3SecretKey, region, endpoint, urlStyle, vol.S3UseSSL)
-		} else {
-			createSecret = fmt.Sprintf(`
-				CREATE SECRET %s (
-					TYPE S3,
-					KEY_ID '%s',
-					SECRET '%s',
-					REGION '%s'
-				);
-			`, secretName, vol.S3AccessKeyID, vol.S3SecretKey, region)
-		}
-
+		createSecret := ducklake.BuildS3SecretSQL(secretName, vol.S3AccessKeyID, vol.S3SecretKey, region, endpoint, vol.S3UseSSL, vol.S3URLStyle)
 		if _, err := db.Exec(createSecret); err != nil {
-			return VolumeInfo{}, fmt.Errorf("failed to create S3 secret: %w", err)
+			if ducklake.UsesS3CredentialChain(vol.S3AccessKeyID, endpoint) {
+				logger.Warn(fmt.Sprintf("Node: failed to create credential_chain S3 secret for volume %s (falling back to default AWS chain): %v", vol.Name, err))
+			} else {
+				return VolumeInfo{}, fmt.Errorf("failed to create S3 secret: %w", err)
+			}
 		}
 	}
 

--- a/src/storage/ducklake/mover/azure.go
+++ b/src/storage/ducklake/mover/azure.go
@@ -87,16 +87,27 @@ func azureBlobClient(cfg AzureConfig) (*azblob.Client, error) {
 		if err != nil {
 			return nil, fmt.Errorf("azure: default credential chain: %w", err)
 		}
-		serviceURL := endpoint
-		if serviceURL == "" {
-			serviceURL = azureServiceURL(accountName)
-		}
-		return azblob.NewClient(serviceURL, cred, nil)
+		return azblob.NewClient(azureBlobServiceURL(accountName, endpoint), cred, nil)
 	}
 }
 
 func azureServiceURL(accountName string) string {
 	return fmt.Sprintf("https://%s.blob.core.windows.net/", accountName)
+}
+
+// azureBlobServiceURL is the account URL passed to azblob.NewClient.
+// NewClientFromConnectionString normalizes with a trailing slash; match
+// that here so a custom endpoint without a slash (Azurite / Gov) does not
+// disagree with the default public-cloud URL, which always has one.
+func azureBlobServiceURL(accountName, endpoint string) string {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return azureServiceURL(accountName)
+	}
+	if !strings.HasSuffix(endpoint, "/") {
+		return endpoint + "/"
+	}
+	return endpoint
 }
 
 // azureBlockSize and azureConcurrency mirror s3MultipartPartSize /

--- a/src/storage/ducklake/mover/azure_test.go
+++ b/src/storage/ducklake/mover/azure_test.go
@@ -70,6 +70,18 @@ func TestAzureBlobClient_AccountKey(t *testing.T) {
 	}
 }
 
+func TestAzureBlobServiceURL(t *testing.T) {
+	if got := azureBlobServiceURL("acct", ""); got != "https://acct.blob.core.windows.net/" {
+		t.Errorf("default: got %q", got)
+	}
+	if got := azureBlobServiceURL("acct", "http://azurite:10000/acct"); got != "http://azurite:10000/acct/" {
+		t.Errorf("azurite without slash: got %q", got)
+	}
+	if got := azureBlobServiceURL("acct", "http://azurite:10000/acct/"); got != "http://azurite:10000/acct/" {
+		t.Errorf("azurite with slash: got %q", got)
+	}
+}
+
 func TestAzureBlobClient_AccountKeyRequiresAccountName(t *testing.T) {
 	if _, err := azureBlobClient(AzureConfig{AccountKey: "ZmFrZQ=="}); err == nil {
 		t.Fatal("expected error when account_key is set without account_name")
@@ -161,8 +173,8 @@ func TestAzureBlobClient_CredentialChainWithEndpoint(t *testing.T) {
 	if client == nil {
 		t.Fatal("expected non-nil client")
 	}
-	if got := client.URL(); got != "http://fake-endpoint:10000/fakeaccount" {
-		t.Errorf("client.URL() = %q, want the configured endpoint", got)
+	if got := client.URL(); got != "http://fake-endpoint:10000/fakeaccount/" {
+		t.Errorf("client.URL() = %q, want the configured endpoint with trailing slash", got)
 	}
 }
 
@@ -179,8 +191,8 @@ func TestAzureBlobClient_CredentialChainWithGovCloudEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("azureBlobClient: %v", err)
 	}
-	if got := client.URL(); got != "https://myaccount.blob.core.usgovcloudapi.net" {
-		t.Errorf("client.URL() = %q, want the configured endpoint", got)
+	if got := client.URL(); got != "https://myaccount.blob.core.usgovcloudapi.net/" {
+		t.Errorf("client.URL() = %q, want the configured endpoint with trailing slash", got)
 	}
 }
 
@@ -213,8 +225,8 @@ func TestAzureBlobClient_CredentialChainWithStandardCloudEndpoint(t *testing.T) 
 	if err != nil {
 		t.Fatalf("azureBlobClient: %v", err)
 	}
-	if got := client.URL(); got != "https://myaccount.blob.core.windows.net" {
-		t.Errorf("client.URL() = %q, want the configured endpoint", got)
+	if got := client.URL(); got != "https://myaccount.blob.core.windows.net/" {
+		t.Errorf("client.URL() = %q, want the configured endpoint with trailing slash", got)
 	}
 }
 

--- a/src/storage/ducklake/tiered_storage.go
+++ b/src/storage/ducklake/tiered_storage.go
@@ -197,17 +197,27 @@ func s3SecretName(volumeName string) string {
 	return fmt.Sprintf("s3_secret_%s", volumeName)
 }
 
-func volumeS3EndpointHost(endpoint string) string {
+// S3EndpointHost strips http(s):// so DuckDB's ENDPOINT clause and
+// UsesS3CredentialChain see a host:port, not a URL.
+func S3EndpointHost(endpoint string) string {
 	endpoint = strings.TrimSpace(endpoint)
 	endpoint = strings.TrimPrefix(endpoint, "http://")
 	endpoint = strings.TrimPrefix(endpoint, "https://")
 	return endpoint
 }
 
-// usesS3CredentialChain is the native-AWS branch of buildS3SecretSQL: empty
+func volumeS3EndpointHost(endpoint string) string {
+	return S3EndpointHost(endpoint)
+}
+
+// UsesS3CredentialChain is the native-AWS branch of BuildS3SecretSQL: empty
 // static key and no custom endpoint, so DuckDB resolves IMDS / IRSA / env.
-func usesS3CredentialChain(accessKey, endpoint string) bool {
+func UsesS3CredentialChain(accessKey, endpoint string) bool {
 	return strings.TrimSpace(accessKey) == "" && strings.TrimSpace(endpoint) == ""
+}
+
+func usesS3CredentialChain(accessKey, endpoint string) bool {
+	return UsesS3CredentialChain(accessKey, endpoint)
 }
 
 func s3SecretSQLForVolume(vol *Volume, replace bool) string {
@@ -216,7 +226,7 @@ func s3SecretSQLForVolume(vol *Volume, replace bool) string {
 	if region == "" && endpoint != "" {
 		region = "us-east-1"
 	}
-	sql := buildS3SecretSQL(s3SecretName(vol.Name), vol.S3AccessKey, vol.S3SecretKey, region, endpoint, vol.S3UseSSL, vol.S3URLStyle)
+	sql := BuildS3SecretSQL(s3SecretName(vol.Name), vol.S3AccessKey, vol.S3SecretKey, region, endpoint, vol.S3UseSSL, vol.S3URLStyle)
 	if replace {
 		sql = strings.Replace(sql, "CREATE SECRET", "CREATE OR REPLACE SECRET", 1)
 	}
@@ -1009,7 +1019,7 @@ func sortResultsByTimestamp(results []map[string]interface{}) {
 	})
 }
 
-// buildS3SecretSQL returns the CREATE SECRET SQL for an S3 volume.
+// BuildS3SecretSQL returns the CREATE SECRET SQL for an S3 volume.
 // When accessKey is empty and endpoint is empty (native AWS S3), the secret
 // uses PROVIDER credential_chain so DuckDB resolves credentials through the
 // AWS SDK default chain (env, container/Pod Identity, instance profile).
@@ -1018,7 +1028,7 @@ func sortResultsByTimestamp(results []map[string]interface{}) {
 // without it the secret is resolved once at CREATE SECRET and every later
 // cold-volume operation fails with ExpiredToken until homer-core restarts.
 // Static keys and custom endpoints (MinIO / R2) use explicit KEY_ID/SECRET.
-func buildS3SecretSQL(secretName, accessKey, secretKey, region, endpoint string, useSSL bool, urlStyle string) string {
+func BuildS3SecretSQL(secretName, accessKey, secretKey, region, endpoint string, useSSL bool, urlStyle string) string {
 	switch {
 	case usesS3CredentialChain(accessKey, endpoint):
 		// Default region for native AWS S3 so the secret signs correctly even
@@ -1057,6 +1067,10 @@ func buildS3SecretSQL(secretName, accessKey, secretKey, region, endpoint string,
 			);
 		`, secretName, accessKey, secretKey, region)
 	}
+}
+
+func buildS3SecretSQL(secretName, accessKey, secretKey, region, endpoint string, useSSL bool, urlStyle string) string {
+	return BuildS3SecretSQL(secretName, accessKey, secretKey, region, endpoint, useSSL, urlStyle)
 }
 
 // BuildAzureConnectionString synthesizes an Azure Storage connection string

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.333"
+	VERSION_APPLICATION = "11.0.334"
 
 	// BuildDate is the build date
 	BuildDate = ""

--- a/src/writer/compaction.go
+++ b/src/writer/compaction.go
@@ -267,10 +267,8 @@ func (c *CompactionService) ensureS3ClientSettings() {
 // stale). Static account_key/connection_string secrets never expire, so
 // re-issuing them here would just be unnecessary DROP+CREATE churn — skip.
 //
-// NOTE: the node's own read path (node.attachVolume) has this same gap —
-// its azure secret is also created once at attach and never refreshed. Left
-// alone for now as a separate, pre-existing issue (S3 has the identical gap
-// there too, not introduced by Azure support) rather than widened here.
+// Standalone node recreates both Azure and S3 credential_chain secrets on
+// the same 20-minute ticker (see node.refreshCredentialChainSecrets).
 func (c *CompactionService) ensureAzureClientSettings() {
 	if c == nil || c.db == nil || c.azureClient == nil {
 		return


### PR DESCRIPTION
## Summary
- Hold `refreshMu` around node `DROP`/`CREATE SECRET` so credential_chain refresh cannot run against a DuckDB handle that FlightSQL catalog reconnect is closing.
- Join the refresh goroutine in `Stop()` before `n.db.Close()` (without holding `n.mu` across the wait, to avoid a deadlock with `RLock`).
- Normalize custom Blob endpoints with a trailing slash so the native copier matches `NewClientFromConnectionString` (Azurite / Gov / public cloud).
- Standalone node now creates S3 `PROVIDER credential_chain` secrets via shared `BuildS3SecretSQL` (empty keys, no custom endpoint) instead of skipping `CREATE SECRET`, and recreates them on the same 20-minute ticker. `REFRESH auto` alone can miss HTTP 400 `ExpiredToken` (#980). Static keys / MinIO / R2 unchanged.

Follow-up to leftover nits from #983.

## Test plan
- [x] `go test ./node/ ./storage/ducklake/ ./writer/ ./cli/`
- [x] `go vet ./node/ ./storage/ducklake/ ./writer/`
- [ ] Standalone node with Azure MI + FlightSQL catalog refresh: search still works across a reconnect
- [ ] Node shutdown with Azure MI / S3 instance profile does not log Exec-on-closed-DB
- [ ] Standalone node, S3 volume with empty keys: `duckdb_secrets()` shows `s3_secret_*` with `credential_chain`; search still works after > token lifetime without restart