### PR TITLE
fix(storage): omit DuckDB CREATE SECRET errors from logs (11.0.335)

### DIFF
--- a/src/node/node.go
+++ b/src/node/node.go
@@ -324,7 +324,7 @@ func (n *Node) refreshCredentialChainSecrets() {
 			db.Exec(fmt.Sprintf("DROP SECRET IF EXISTS %s;", secretName))
 			createSecret := ducklake.BuildAzureSecretSQL(secretName, vol.AzureAccountName, vol.AzureAccountKey, vol.AzureConnectionString, vol.AzureEndpoint)
 			if _, err := db.Exec(createSecret); err != nil {
-				logger.Warn(fmt.Sprintf("Node: failed to refresh Azure secret for volume %s: %v", vol.Name, err))
+				logger.Warn(fmt.Sprintf("Node: failed to refresh Azure secret for volume %s (DuckDB error omitted)", vol.Name))
 			}
 		case "s3":
 			endpoint := ducklake.S3EndpointHost(vol.S3Endpoint)
@@ -335,7 +335,7 @@ func (n *Node) refreshCredentialChainSecrets() {
 			db.Exec(fmt.Sprintf("DROP SECRET IF EXISTS %s;", secretName))
 			createSecret := ducklake.BuildS3SecretSQL(secretName, vol.S3AccessKeyID, vol.S3SecretKey, vol.S3Region, endpoint, vol.S3UseSSL, vol.S3URLStyle)
 			if _, err := db.Exec(createSecret); err != nil {
-				logger.Warn(fmt.Sprintf("Node: failed to refresh S3 secret for volume %s: %v", vol.Name, err))
+				logger.Warn(fmt.Sprintf("Node: failed to refresh S3 secret for volume %s (DuckDB error omitted)", vol.Name))
 			}
 		}
 	}
@@ -1946,9 +1946,9 @@ func attachVolume(db *sql.DB, baseLakeName string, vol config.VolumeConfig) (Vol
 		createSecret := ducklake.BuildS3SecretSQL(secretName, vol.S3AccessKeyID, vol.S3SecretKey, region, endpoint, vol.S3UseSSL, vol.S3URLStyle)
 		if _, err := db.Exec(createSecret); err != nil {
 			if ducklake.UsesS3CredentialChain(vol.S3AccessKeyID, endpoint) {
-				logger.Warn(fmt.Sprintf("Node: failed to create credential_chain S3 secret for volume %s (falling back to default AWS chain): %v", vol.Name, err))
+				logger.Warn(fmt.Sprintf("Node: failed to create credential_chain S3 secret for volume %s (falling back to default AWS chain; DuckDB error omitted)", vol.Name))
 			} else {
-				return VolumeInfo{}, fmt.Errorf("failed to create S3 secret: %w", err)
+				return VolumeInfo{}, fmt.Errorf("failed to create S3 secret (DuckDB error omitted to avoid leaking credentials)")
 			}
 		}
 	}
@@ -1961,7 +1961,9 @@ func attachVolume(db *sql.DB, baseLakeName string, vol config.VolumeConfig) (Vol
 		db.Exec(fmt.Sprintf("DROP SECRET IF EXISTS %s;", secretName))
 		createSecret := ducklake.BuildAzureSecretSQL(secretName, vol.AzureAccountName, vol.AzureAccountKey, vol.AzureConnectionString, vol.AzureEndpoint)
 		if _, err := db.Exec(createSecret); err != nil {
-			return VolumeInfo{}, fmt.Errorf("failed to create Azure secret: %w", err)
+			// Do not wrap the DuckDB error: CREATE SECRET SQL contains
+			// CONNECTION_STRING / AccountKey and the driver may echo it.
+			return VolumeInfo{}, fmt.Errorf("failed to create Azure secret (DuckDB error omitted to avoid leaking credentials)")
 		}
 	}
 

--- a/src/storage/ducklake/tiered_storage.go
+++ b/src/storage/ducklake/tiered_storage.go
@@ -255,7 +255,7 @@ func (tsm *TieredStorageManager) createVolumeS3Secret(vol *Volume, replace bool)
 	}
 
 	if _, err := tsm.db.Exec(createSecret); err != nil {
-		return fmt.Errorf("failed to create S3 secret for volume %s: %w", vol.Name, err)
+		return fmt.Errorf("failed to create S3 secret for volume %s (DuckDB error omitted to avoid leaking credentials)", vol.Name)
 	}
 	return nil
 }
@@ -300,7 +300,9 @@ func (tsm *TieredStorageManager) createVolumeAzureSecret(vol *Volume, replace bo
 	}
 
 	if _, err := tsm.db.Exec(createSecret); err != nil {
-		return fmt.Errorf("failed to create Azure secret for volume %s: %w", vol.Name, err)
+		// Do not wrap the DuckDB error: CREATE SECRET SQL contains
+		// CONNECTION_STRING / AccountKey and the driver may echo it.
+		return fmt.Errorf("failed to create Azure secret for volume %s (DuckDB error omitted to avoid leaking credentials)", vol.Name)
 	}
 	return nil
 }

--- a/src/storage/ducklake/tuning.go
+++ b/src/storage/ducklake/tuning.go
@@ -146,7 +146,9 @@ CREATE SECRET %s (
 );`, writerLakeS3Secret, sqlQuote(accessKeyID), sqlQuote(secretAccessKey), sqlQuote(reg))
 	}
 	if _, err := db.Exec(create); err != nil {
-		return fmt.Errorf("duckdb CREATE SECRET %s: %w", writerLakeS3Secret, err)
+		// Do not wrap the DuckDB error: CREATE SECRET SQL contains KEY_ID /
+		// SECRET and the driver may echo it.
+		return fmt.Errorf("duckdb CREATE SECRET %s failed (error omitted to avoid leaking credentials)", writerLakeS3Secret)
 	}
 	return nil
 }
@@ -243,7 +245,9 @@ func EnsureWriterAzureSecret(db *sql.DB, accountName, accountKey, connectionStri
 	}
 	create := BuildAzureSecretSQL(writerLakeAzureSecret, accountName, accountKey, connectionString, endpoint)
 	if _, err := db.Exec(create); err != nil {
-		return fmt.Errorf("duckdb CREATE SECRET %s: %w", writerLakeAzureSecret, err)
+		// Do not wrap the DuckDB error: CREATE SECRET SQL contains
+		// CONNECTION_STRING / AccountKey and the driver may echo it.
+		return fmt.Errorf("duckdb CREATE SECRET %s failed (error omitted to avoid leaking credentials)", writerLakeAzureSecret)
 	}
 	return nil
 }

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.334"
+	VERSION_APPLICATION = "11.0.335"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary

- Wrapping a failed DuckDB `CREATE SECRET` with `%w` / `%v` can put `CONNECTION_STRING` / `AccountKey` (and S3 `KEY_ID`/`SECRET`) into operator logs if the driver echoes the SQL.
- Do not wrap or log the original DuckDB error. Returned/logged text is only the volume/secret name plus `DuckDB error omitted to avoid leaking credentials`.

## Test plan

- [x] `go test ./storage/ducklake/ ./node/ ./writer/ -count=1`
- [ ] Confirm a forced bad Azure `CREATE SECRET` logs no account key