### PR TITLE
fix(import): send PCAP INSERT through node /exec (11.0.337)

### DIFF
--- a/src/coordinator/handlers/pcap_sip_import.go
+++ b/src/coordinator/handlers/pcap_sip_import.go
@@ -168,7 +168,7 @@ func importPcapSIP(
 		if err != nil {
 			return err
 		}
-		if _, err := flight.QueryFirstConnected(ctx, sql); err != nil {
+		if err := flight.ExecFirstConnected(ctx, sql); err != nil {
 			return err
 		}
 		inserted += len(rows)

--- a/src/coordinator/handlers/pcap_sip_import_test.go
+++ b/src/coordinator/handlers/pcap_sip_import_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/gopacket"
+	"github.com/sipcapture/homer-core/src/coordinator/sqlvalidator"
 	"github.com/sipcapture/homer-core/src/decoder"
 	"github.com/sipcapture/homer-core/src/pcapwriter"
 	"github.com/sipcapture/homer-core/src/storage/ducklake"
@@ -78,6 +79,9 @@ func TestPcapSyntheticInvitePipeline(t *testing.T) {
 	}
 	if !strings.Contains(sql, "314159") {
 		t.Fatalf("cseq not in sql: %s", sql)
+	}
+	if err := sqlvalidator.ValidateWriteSQL(sql); err != nil {
+		t.Fatalf("generated INSERT must pass write validator: %v\n%s", err, sql)
 	}
 }
 

--- a/src/coordinator/services/flight_service.go
+++ b/src/coordinator/services/flight_service.go
@@ -301,6 +301,27 @@ func (s *FlightService) QueryFirstConnected(ctx context.Context, sql string) ([]
 	return nil, fmt.Errorf("no connected storage nodes")
 }
 
+// ExecFirstConnected runs write SQL (INSERT) on the first connected node via POST /exec.
+// /query stays read-only; this is the path for PCAP import and other coordinator writes.
+func (s *FlightService) ExecFirstConnected(ctx context.Context, sql string) error {
+	s.mu.RLock()
+	nodes := make([]config.NodeEndpoint, len(s.nodes))
+	copy(nodes, s.nodes)
+	connected := make(map[string]bool)
+	for k, v := range s.connected {
+		connected[k] = v
+	}
+	s.mu.RUnlock()
+
+	for _, node := range nodes {
+		if !connected[node.Name] {
+			continue
+		}
+		return s.execNode(ctx, node, sql)
+	}
+	return fmt.Errorf("no connected storage nodes")
+}
+
 // nodesForRange filters connected nodes to those whose cached timestamp range
 // may overlap the query window [fromNs, toNs]. A node is skipped only when its
 // cached range (with flush/health slack on max) provably does not overlap the
@@ -441,8 +462,17 @@ func (s *FlightService) QueryNode(ctx context.Context, nodeName string, sql stri
 	return s.queryNode(ctx, node, sql)
 }
 
-// queryNode executes a query on a single node via HTTP
+// queryNode executes a query on a single node via HTTP POST /query
 func (s *FlightService) queryNode(ctx context.Context, node config.NodeEndpoint, sql string) ([]map[string]interface{}, error) {
+	return s.postNodeSQL(ctx, node, "/query", sql)
+}
+
+func (s *FlightService) execNode(ctx context.Context, node config.NodeEndpoint, sql string) error {
+	_, err := s.postNodeSQL(ctx, node, "/exec", sql)
+	return err
+}
+
+func (s *FlightService) postNodeSQL(ctx context.Context, node config.NodeEndpoint, path, sql string) ([]map[string]interface{}, error) {
 	// Per-query timeout; context.WithTimeout keeps the parent deadline when
 	// the caller's is sooner.
 	ctx, cancel := context.WithTimeout(ctx, s.queryTimeout)
@@ -450,7 +480,7 @@ func (s *FlightService) queryNode(ctx context.Context, node config.NodeEndpoint,
 
 	// Node HTTP API runs on FlightServer.Port + 1
 	httpPort := node.Port + 1
-	url := fmt.Sprintf("http://%s:%d/query", node.Host, httpPort)
+	url := fmt.Sprintf("http://%s:%d%s", node.Host, httpPort, path)
 
 	reqBody, err := json.Marshal(queryRequest{SQL: sql})
 	if err != nil {

--- a/src/coordinator/services/flight_service_test.go
+++ b/src/coordinator/services/flight_service_test.go
@@ -74,6 +74,45 @@ func TestFlightServiceQuerySendsBearerToken(t *testing.T) {
 	}
 }
 
+func TestFlightServiceExecFirstConnectedPostsExec(t *testing.T) {
+	var gotPath, gotAuth, gotSQL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		var req queryRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		gotSQL = req.SQL
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"data":[],"count":0}`))
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host := u.Hostname()
+	port, _ := strconv.Atoi(u.Port())
+	svc := NewFlightService([]config.NodeEndpoint{
+		{Name: "local", Host: host, Port: port - 1, Token: "node-secret"},
+	}, time.Second, false)
+	svc.connected["local"] = true
+
+	sql := "INSERT INTO homer_lake.main.hep_proto_1_call (id) VALUES (1)"
+	if err := svc.ExecFirstConnected(context.Background(), sql); err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != "/exec" {
+		t.Fatalf("path=%q want /exec", gotPath)
+	}
+	if gotAuth != "Bearer node-secret" {
+		t.Fatalf("Authorization=%q", gotAuth)
+	}
+	if gotSQL != sql {
+		t.Fatalf("sql=%q", gotSQL)
+	}
+}
+
 func TestFetchNodeRangeParsesStats(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/metadata/stats" {

--- a/src/coordinator/sqlvalidator/validator.go
+++ b/src/coordinator/sqlvalidator/validator.go
@@ -4,6 +4,7 @@ package sqlvalidator
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"unicode"
 )
@@ -210,8 +211,8 @@ var blockedDML = map[string]bool{
 	"ATTACH":   true,
 	"DETACH":   true,
 	"LOAD":     true,
-	"INSTALL": true,
-	"SET":     true,
+	"INSTALL":  true,
+	"SET":      true,
 }
 
 // blockedFunctions are DuckDB functions that access the filesystem or network.
@@ -260,32 +261,146 @@ var allowedStatementStarts = map[string]bool{
 // ValidateRawSQL validates a full SQL statement for safety.
 // Returns nil if the SQL is safe to execute, or an error describing the violation.
 func ValidateRawSQL(sql string) error {
-	trimmed := strings.TrimSpace(sql)
-	if trimmed == "" {
-		return fmt.Errorf("empty SQL query")
+	tokens, err := tokensForValidation(sql)
+	if err != nil {
+		return err
 	}
 
-	tokens := tokenize(trimmed)
-	if len(tokens) == 0 {
-		return fmt.Errorf("empty SQL query after parsing")
-	}
-
-	// 1. Must start with an allowed statement type
 	first := tokens[0]
 	if first.kind != tkIdent || !allowedStatementStarts[first.upper] {
 		return fmt.Errorf("query must start with SELECT, WITH, SHOW, DESCRIBE, EXPLAIN, or PRAGMA (got %q)", first.value)
 	}
 
-	// 2. No semicolons (prevents statement stacking)
+	return rejectSQLHazards(tokens, nil)
+}
+
+// hepProtoTableName is the only table name allowed on POST /exec (PCAP import).
+// Matches LakeTableFQN: <catalog>.main.hep_proto_<proto>_<suffix>.
+var hepProtoTableName = regexp.MustCompile(`(?i)^hep_proto_[0-9]+_[a-z][a-z0-9_]*$`)
+
+var blockedWriteCatalogs = map[string]bool{
+	"MEMORY":             true,
+	"TEMP":               true,
+	"SYSTEM":             true,
+	"INFORMATION_SCHEMA": true,
+	"PG_CATALOG":         true,
+}
+
+// ValidateWriteSQL validates coordinator-generated writes (PCAP import INSERT).
+// Only INSERT INTO <catalog>.main.hep_proto_* (...) VALUES ... is allowed.
+// SELECT/FROM, system catalogs, quoted identifiers, and DML/filesystem hazards stay blocked.
+func ValidateWriteSQL(sql string) error {
+	tokens, err := tokensForValidation(sql)
+	if err != nil {
+		return err
+	}
+
+	if err := requireInsertIntoHepProtoValues(tokens); err != nil {
+		return err
+	}
+
+	return rejectSQLHazards(tokens, map[string]bool{"INSERT": true})
+}
+
+func requireInsertIntoHepProtoValues(tokens []token) error {
+	for _, tok := range tokens {
+		if tok.kind == tkSemi {
+			return fmt.Errorf("semicolons are not allowed (prevents multi-statement injection)")
+		}
+		if tok.kind == tkIdent && strings.HasPrefix(tok.value, "\"") {
+			return fmt.Errorf("quoted identifiers are not allowed in write SQL")
+		}
+		if tok.kind == tkOp && (tok.value == "[" || tok.value == "`") {
+			return fmt.Errorf("quoted identifiers are not allowed in write SQL")
+		}
+	}
+
+	if len(tokens) < 8 {
+		return fmt.Errorf("write SQL must be INSERT INTO <catalog>.main.hep_proto_* VALUES ...")
+	}
+	if tokens[0].kind != tkIdent || tokens[0].upper != "INSERT" ||
+		tokens[1].kind != tkIdent || tokens[1].upper != "INTO" {
+		return fmt.Errorf("write SQL must start with INSERT INTO (got %q)", tokens[0].value)
+	}
+	if tokens[2].kind != tkIdent {
+		return fmt.Errorf("write target catalog must be an identifier")
+	}
+	if blockedWriteCatalogs[tokens[2].upper] {
+		return fmt.Errorf("system catalog %q is not allowed as write target", tokens[2].value)
+	}
+	if tokens[3].kind != tkDot ||
+		tokens[4].kind != tkIdent || tokens[4].upper != "MAIN" ||
+		tokens[5].kind != tkDot ||
+		tokens[6].kind != tkIdent {
+		return fmt.Errorf("write target must be <catalog>.main.hep_proto_<proto>_<name>")
+	}
+	if !hepProtoTableName.MatchString(tokens[6].value) {
+		return fmt.Errorf("write target table must match hep_proto_<proto>_<name> (got %q)", tokens[6].value)
+	}
+
+	i := 7
+	if i < len(tokens) && tokens[i].kind == tkLParen {
+		depth := 0
+		for i < len(tokens) {
+			switch tokens[i].kind {
+			case tkLParen:
+				depth++
+			case tkRParen:
+				depth--
+				i++
+				if depth == 0 {
+					goto afterCols
+				}
+				continue
+			}
+			i++
+		}
+		return fmt.Errorf("write SQL has an unclosed column list")
+	}
+afterCols:
+	if i >= len(tokens) || tokens[i].kind != tkIdent || tokens[i].upper != "VALUES" {
+		return fmt.Errorf("write SQL must use INSERT ... VALUES (SELECT/FROM is not allowed)")
+	}
+
+	for _, tok := range tokens {
+		if tok.kind != tkIdent {
+			continue
+		}
+		switch tok.upper {
+		case "SELECT", "FROM", "JOIN", "UNION", "EXCEPT", "INTERSECT",
+			"TABLE", "PIVOT", "UNPIVOT", "REPLACE", "OVERWRITE", "RETURNING":
+			return fmt.Errorf("blocked keyword %q in write SQL", tok.value)
+		}
+	}
+	return nil
+}
+
+func tokensForValidation(sql string) ([]token, error) {
+	trimmed := strings.TrimSpace(sql)
+	if trimmed == "" {
+		return nil, fmt.Errorf("empty SQL query")
+	}
+	tokens := tokenize(trimmed)
+	if len(tokens) == 0 {
+		return nil, fmt.Errorf("empty SQL query after parsing")
+	}
+	return tokens, nil
+}
+
+// rejectSQLHazards applies the GHSA-rm5w-rqr7-2h54 checks shared by read and write SQL.
+// skipDML lists keywords that may appear (the write path allows INSERT itself).
+func rejectSQLHazards(tokens []token, skipDML map[string]bool) error {
 	for _, tok := range tokens {
 		if tok.kind == tkSemi {
 			return fmt.Errorf("semicolons are not allowed (prevents multi-statement injection)")
 		}
 	}
 
-	// 3. Check for blocked DML/DDL keywords
 	for _, tok := range tokens {
 		if tok.kind != tkIdent {
+			continue
+		}
+		if skipDML[tok.upper] {
 			continue
 		}
 		if blockedDML[tok.upper] {
@@ -293,21 +408,17 @@ func ValidateRawSQL(sql string) error {
 		}
 	}
 
-	// 4. Check for blocked filesystem/network functions
 	for i, tok := range tokens {
 		if tok.kind != tkIdent {
 			continue
 		}
 		if blockedFunctions[tok.upper] {
-			// Only flag if it looks like a function call (followed by parenthesis)
 			if i+1 < len(tokens) && tokens[i+1].kind == tkLParen {
 				return fmt.Errorf("blocked function %q (filesystem/network access is not allowed)", tok.value)
 			}
-			// Also block as keyword for COPY, EXPORT, IMPORT (already in blockedDML)
 		}
 	}
 
-	// 5. Check for SELECT ... INTO (prevents writing to tables/files)
 	selectSeen := false
 	fromSeen := false
 	for _, tok := range tokens {
@@ -326,7 +437,6 @@ func ValidateRawSQL(sql string) error {
 		}
 	}
 
-	// 6. Check for CALL (except within string literals, already handled by tokenizer)
 	for _, tok := range tokens {
 		if tok.kind == tkIdent && tok.upper == "CALL" {
 			return fmt.Errorf("CALL statements are not allowed")
@@ -368,8 +478,8 @@ var blockedExprKeywords = map[string]bool{
 	"ATTACH":    true,
 	"DETACH":    true,
 	"LOAD":      true,
-	"INSTALL":  true,
-	"SET":      true,
+	"INSTALL":   true,
+	"SET":       true,
 	"INTO":      true,
 	"CALL":      true,
 	"UNION":     true,

--- a/src/coordinator/sqlvalidator/validator_test.go
+++ b/src/coordinator/sqlvalidator/validator_test.go
@@ -297,6 +297,95 @@ func TestValidateRawSQL(t *testing.T) {
 	}
 }
 
+func TestValidateWriteSQL(t *testing.T) {
+	tests := []struct {
+		name    string
+		sql     string
+		wantErr string
+	}{
+		{
+			name: "insert values",
+			sql:  "INSERT INTO homer_lake.main.hep_proto_1_call (id) VALUES (1)",
+		},
+		{
+			name: "insert values registration",
+			sql:  "INSERT INTO homer_lake.main.hep_proto_1_registration (uuid) VALUES ('abc')",
+		},
+		{
+			name:    "insert select from table",
+			sql:     "INSERT INTO homer_lake.main.hep_proto_1_call SELECT * FROM src_table",
+			wantErr: "VALUES",
+		},
+		{
+			name:    "insert values with subquery",
+			sql:     "INSERT INTO homer_lake.main.hep_proto_1_call (id) VALUES ((SELECT 1))",
+			wantErr: "blocked keyword",
+		},
+		{
+			name:    "wrong table",
+			sql:     "INSERT INTO homer_lake.main.users VALUES (1)",
+			wantErr: "hep_proto_",
+		},
+		{
+			name:    "memory catalog",
+			sql:     "INSERT INTO memory.main.hep_proto_1_call VALUES (1)",
+			wantErr: "system catalog",
+		},
+		{
+			name:    "quoted identifier",
+			sql:     `INSERT INTO "homer_lake".main.hep_proto_1_call VALUES (1)`,
+			wantErr: "quoted identifiers",
+		},
+		{
+			name:    "select rejected",
+			sql:     "SELECT * FROM t",
+			wantErr: "INSERT INTO",
+		},
+		{
+			name:    "drop rejected",
+			sql:     "DROP TABLE t",
+			wantErr: "INSERT INTO",
+		},
+		{
+			name:    "insert then drop stacked",
+			sql:     "INSERT INTO homer_lake.main.hep_proto_1_call VALUES (1); DROP TABLE t",
+			wantErr: "semicolons are not allowed",
+		},
+		{
+			name:    "insert select read_text",
+			sql:     "INSERT INTO homer_lake.main.hep_proto_1_call SELECT content FROM read_text('/etc/passwd')",
+			wantErr: "VALUES",
+		},
+		{
+			name:    "insert copy",
+			sql:     "INSERT INTO homer_lake.main.hep_proto_1_call COPY FROM '/tmp/x'",
+			wantErr: "VALUES",
+		},
+		{
+			name:    "empty",
+			sql:     "   ",
+			wantErr: "empty SQL query",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateWriteSQL(tt.sql)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.wantErr)
+				} else if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got: %v", tt.wantErr, err)
+				}
+			}
+		})
+	}
+}
+
 // ---- ValidateExpression tests ----------------------------------------------
 
 func TestValidateExpression(t *testing.T) {

--- a/src/node/http_auth.go
+++ b/src/node/http_auth.go
@@ -43,7 +43,7 @@ func ensureFlightAuthToken(cfg *config.NodeConfig) error {
 			"host", cfg.FlightServer.Host,
 			"hint", "set node.flight_server.auth_token or bind flight_server.host to 127.0.0.1")
 	} else if tok != "" {
-		logger.Info("node: HTTP /query and /vacuum require Authorization Bearer token")
+		logger.Info("node: HTTP /query, /exec and /vacuum require Authorization Bearer token")
 	}
 	return nil
 }

--- a/src/node/http_auth_test.go
+++ b/src/node/http_auth_test.go
@@ -93,6 +93,51 @@ func TestHandleQueryRejectsDML(t *testing.T) {
 	}
 }
 
+func TestHandleQueryRejectsInsert(t *testing.T) {
+	node := &Node{}
+	body, _ := json.Marshal(QueryRequest{SQL: `INSERT INTO t VALUES (1)`})
+	req := httptest.NewRequest(http.MethodPost, "/query", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	node.handleQuery(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for INSERT on /query, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleExecValidatesWriteSQL(t *testing.T) {
+	node := &Node{}
+
+	t.Run("drop", func(t *testing.T) {
+		body, _ := json.Marshal(QueryRequest{SQL: `DROP TABLE t`})
+		req := httptest.NewRequest(http.MethodPost, "/exec", bytes.NewReader(body))
+		rr := httptest.NewRecorder()
+		node.handleExec(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d body=%s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("insert with read_text", func(t *testing.T) {
+		body, _ := json.Marshal(QueryRequest{SQL: `INSERT INTO t SELECT content FROM read_text('/etc/passwd')`})
+		req := httptest.NewRequest(http.MethodPost, "/exec", bytes.NewReader(body))
+		rr := httptest.NewRecorder()
+		node.handleExec(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d body=%s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("valid insert without db is 503", func(t *testing.T) {
+		body, _ := json.Marshal(QueryRequest{SQL: `INSERT INTO homer_lake.main.hep_proto_1_call (id) VALUES (1)`})
+		req := httptest.NewRequest(http.MethodPost, "/exec", bytes.NewReader(body))
+		rr := httptest.NewRecorder()
+		node.handleExec(rr, req)
+		if rr.Code != http.StatusServiceUnavailable {
+			t.Fatalf("expected 503 after validation, got %d body=%s", rr.Code, rr.Body.String())
+		}
+	})
+}
+
 func TestBearerTokenFromRequest(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer  abc ")

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -197,6 +197,7 @@ func (n *Node) Start() error {
 	mux := http.NewServeMux()
 	authTok := n.config.FlightServer.AuthToken
 	mux.HandleFunc("/query", withBearerAuth(authTok, n.handleQuery))
+	mux.HandleFunc("/exec", withBearerAuth(authTok, n.handleExec))
 	mux.HandleFunc("/health", n.handleHealth)
 	mux.HandleFunc("/vacuum", withBearerAuth(authTok, n.handleVacuum))
 	mux.HandleFunc("/metadata/stats", withBearerAuth(authTok, n.handleMetadataStats))
@@ -1212,6 +1213,7 @@ func (n *Node) handleQuery(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Deny DML/DDL and filesystem/network table functions (GHSA-rm5w-rqr7-2h54).
+	// Coordinator writes (PCAP import INSERT) go to POST /exec, not /query.
 	if err := sqlvalidator.ValidateRawSQL(req.SQL); err != nil {
 		writeJSON(w, http.StatusBadRequest, QueryResponse{
 			Success: false,
@@ -1322,6 +1324,67 @@ func (n *Node) handleQuery(w http.ResponseWriter, r *http.Request) {
 		Success: true,
 		Data:    results,
 		Count:   len(results),
+	})
+}
+
+// handleExec handles POST /exec for coordinator-generated writes (PCAP import).
+// /query stays read-only (GHSA-rm5w-rqr7-2h54); this path allows INSERT only.
+func (n *Node) handleExec(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req QueryRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, QueryResponse{
+			Success: false,
+			Error:   "Invalid request body",
+		})
+		return
+	}
+
+	if req.SQL == "" {
+		writeJSON(w, http.StatusBadRequest, QueryResponse{
+			Success: false,
+			Error:   "SQL query is required",
+		})
+		return
+	}
+
+	if err := sqlvalidator.ValidateWriteSQL(req.SQL); err != nil {
+		writeJSON(w, http.StatusBadRequest, QueryResponse{
+			Success: false,
+			Error:   "SQL validation failed: " + err.Error(),
+		})
+		return
+	}
+
+	db := n.queryDB()
+	if db == nil {
+		writeJSON(w, http.StatusServiceUnavailable, QueryResponse{
+			Success: false,
+			Error:   "storage not ready",
+		})
+		return
+	}
+
+	logger.Info("Node: handleExec", "sql_chars", len(req.SQL))
+	res, err := db.ExecContext(r.Context(), req.SQL)
+	if err != nil {
+		logger.Error("Node: Exec failed", "sql", req.SQL, "error", err)
+		writeJSON(w, http.StatusOK, QueryResponse{
+			Success: false,
+			Error:   err.Error(),
+		})
+		return
+	}
+	nAff, _ := res.RowsAffected()
+	logger.Info("Node: handleExec OK", "rows_affected", nAff)
+	writeJSON(w, http.StatusOK, QueryResponse{
+		Success: true,
+		Data:    []map[string]interface{}{},
+		Count:   0,
 	})
 }
 

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.336"
+	VERSION_APPLICATION = "11.0.337"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Keep node `POST /query` read-only (GHSA-rm5w-rqr7-2h54). PCAP import now writes via authenticated `POST /exec`.
- `ValidateWriteSQL` allows only `INSERT INTO <catalog>.main.hep_proto_* (...) VALUES ...` — no `SELECT`/`FROM`, system catalogs, quoted identifiers, or statement stacking.
- Bump `VERSION_APPLICATION` to **11.0.337**.

Fixes #993

## Test plan
- [x] `go test ./coordinator/sqlvalidator/ ./node/ ./coordinator/services/ ./coordinator/handlers/`
- [ ] UI/API: `POST /api/v4/imports/pcap` on an all-in-one DuckLake node imports SIP instead of 400 `got "INSERT"`
- [ ] Confirm `POST /query` still rejects `INSERT`/`DROP`/`read_text()`