### PR TITLE
UI fixes to ease HOMER7 → HOMER11 migration

### DIFF
--- a/src/ui/src/components/ui/floating-window.tsx
+++ b/src/ui/src/components/ui/floating-window.tsx
@@ -16,6 +16,7 @@ interface FloatingWindowProps {
   onClose: () => void
   title?: ReactNode
   headerActions?: ReactNode
+  headerColor?: string
   children?: ReactNode
   className?: string
   id?: string
@@ -30,6 +31,7 @@ export function FloatingWindow({
   onClose,
   title,
   headerActions,
+  headerColor,
   children,
   className,
   id,
@@ -252,8 +254,10 @@ export function FloatingWindow({
       <div
         className={cn(
           'flex shrink-0 items-center gap-2 border-b border-border bg-card/80 px-3 py-2',
+          headerColor && 'text-white',
           headerStyle,
         )}
+        style={headerColor ? { backgroundColor: headerColor } : undefined}
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}

--- a/src/ui/src/dashboard/TransactionModal.tsx
+++ b/src/ui/src/dashboard/TransactionModal.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { apiPost } from '../api'
 import ExportModal from '../settings/ExportModal'
 import CallFlow from './CallFlow'
+import { getColorByString } from './flow-utils'
 import ExportTab from './ExportTab'
 import MessageModal from './MessageModal'
 import QosPanel from './QosPanel'
@@ -646,6 +647,7 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
   if (!modal) return null
   const { id, loading, items, error, timeRange, modalKey, sessionIds, primarySessionId } = modal
   const primaryId = primarySessionId ?? (sessionIds && sessionIds[0]) ?? id
+  const headerColor = primaryId ? getColorByString(primaryId, 75, 42, 1) : undefined
   const isMultiSession = Array.isArray(sessionIds) && sessionIds.length > 1
   const sessionIdsForApi = (Array.isArray(sessionIds) && sessionIds.length)
     ? sessionIds.map((s) => String(s).trim()).filter(Boolean)
@@ -823,18 +825,19 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
       <FloatingWindow
         open
         onClose={onClose}
+        headerColor={headerColor}
         id={`tx:${modalKey || id}`}
         title={
           isMultiSession ? (
             <span className="truncate text-sm">
               Transactions:{' '}
-              <span className="font-mono text-muted-foreground">
+              <span className={cn('font-mono', headerColor ? 'text-white/75' : 'text-muted-foreground')}>
                 {sessionIds.length} {sessionIds.length === 1 ? 'session' : 'sessions'}
               </span>
             </span>
           ) : (
             <span className="truncate font-mono text-sm">
-              Transaction: <span className="text-muted-foreground">{id}</span>
+              Transaction: <span className={headerColor ? 'text-white/75' : 'text-muted-foreground'}>{id}</span>
             </span>
           )
         }

--- a/src/ui/src/dashboard/components/SearchWidgetSettings.tsx
+++ b/src/ui/src/dashboard/components/SearchWidgetSettings.tsx
@@ -52,6 +52,7 @@ const DEFAULT_FIELDS: FieldItem[] = [
     form_type: 'select',
     form_default: 'default',
   },
+  { id: 'sort_order', name: 'Sort Order', type: 'string', form_type: 'select', form_default: 'desc' },
 ]
 
 export default function SearchWidgetSettings({
@@ -118,9 +119,9 @@ export default function SearchWidgetSettings({
   useEffect(() => {
     if (!selectedMapping) return
     const merged = getMergedFields(selectedMapping)
-    const withDefaults = merged.find((f) => f.id === 'limit')
-      ? merged
-      : [...merged, ...DEFAULT_FIELDS]
+    const mergedIds = new Set(merged.map((f) => f.id))
+    const missingDefaults = DEFAULT_FIELDS.filter((f) => !mergedIds.has(f.id))
+    const withDefaults = missingDefaults.length > 0 ? [...merged, ...missingDefaults] : merged
 
     const activeIds = (config.fields ?? []).map((f) => f.id)
     // Preserve active selection from saved config if protocol matches

--- a/src/ui/src/dashboard/flow-utils.ts
+++ b/src/ui/src/dashboard/flow-utils.ts
@@ -151,11 +151,11 @@ export function getHighContrastColor(
 
   const hue = index === 0 ? baseComponents.hue : baseComponents.hue + offsetStep * index
   const saturation = index === 0 ? baseComponents.saturation + 10 : 60
-  const lightness = index === 0 ? baseComponents.lightness - 20 : 70
+  const lightness = index === 0 ? baseComponents.lightness - 20 : 55
 
   return {
-    color: `hsla(${hue}, ${saturation}%, ${lightness}%, 0.2)`,
+    color: `hsla(${hue}, ${saturation}%, ${lightness}%, 0.35)`,
     tabColor: `hsla(${hue}, ${saturation}%, ${lightness}%, 1)`,
-    arrowColor: `hsla(${hue}, ${saturation}%, ${lightness}%, 0.55)`,
+    arrowColor: `hsla(${hue}, ${saturation}%, ${lightness}%, 0.9)`,
   }
 }

--- a/src/ui/src/dashboard/widgets/SearchPanel.tsx
+++ b/src/ui/src/dashboard/widgets/SearchPanel.tsx
@@ -476,7 +476,10 @@ export default function SearchPanel({ config, onConfigChange, widgetId }) {
 
     const searchData = {
       filter,
-      param: { limit: Number(limit) || 50 },
+      param: {
+        limit: Number(limit) || 50,
+        order_by: form.sort_order === 'asc' ? 'timestamp ASC' : 'timestamp DESC',
+      },
       // AI / MCP: do not send the dashboard time window — the server infers
       // range from natural language (and LLM fallbacks). Sending the previous
       // range here pinned "last two hours" to the old 1h window after the
@@ -660,6 +663,25 @@ export default function SearchPanel({ config, onConfigChange, widgetId }) {
       )
     }
     if (id === 'results_container') return null // handled by target widget selector
+    if (id === 'sort_order') {
+      return (
+        <div className="grid gap-1" key={id}>
+          <Label htmlFor="sp-sort_order" className="text-[11px] text-muted-foreground">Sort Order</Label>
+          <Select
+            value={form.sort_order || 'desc'}
+            onValueChange={(v) => handleChange('sort_order', v)}
+          >
+            <SelectTrigger id="sp-sort_order" className="h-7 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="desc">Newest first</SelectItem>
+              <SelectItem value="asc">Oldest first</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      )
+    }
 
     // multiselect (selector / form_default) or input_multi_select (form_default) → chips + custom
     if (form_type === 'multiselect' || form_type === 'input_multi_select') {


### PR DESCRIPTION
These are small UX changes found while migrating a real HOMER7 deployment to HOMER11. None of them are required for HOMER11 to function — the goal is to reduce the number of "wait, this behaves differently" moments for teams making the same transition. Some of these directly match HOMER7/HOMER5 habits; others just add an option where HOMER11 was missing one, without necessarily changing HOMER11's existing default.

- **Call Flow contrast**: non-primary call legs were hard to distinguish in light mode, especially noticeable coming from HOMER7's higher-contrast flow view.
- ~~**Default to the Call Flow tab**: HOMER7 users' first instinct when opening a transaction is to look at the flow, not the raw message list.~~ -> *will be done in a separate PR as requested.*
- **Color-matched transaction header**: HOMER7 colors the transaction header to match the session, which HOMER11's neutral header didn't.
- **Search sort order**: HOMER7 defaults to oldest-first chronological search results, which some users found themselves relying on; HOMER11 had no way to switch order at all. This adds a per-widget Sort Order control (defaulting to HOMER11's existing newest-first behavior, so this is a missing option rather than a default change) — also fixes a latent bug where new default fields silently didn't backfill into existing widget configs.
