### PR TITLE
Add a per-user preference for TransactionModal's default tab

### DIFF
--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -29,6 +29,7 @@ import DashboardHeader from './dashboard/DashboardHeader'
 import { fetchMeAvatarObjectUrl, handleUnauthorized } from './api'
 import { ThemeProvider } from "@/components/theme/theme-provider"
 import { LocaleProvider } from "@/components/locale/locale-provider"
+import { DetailsTabProvider } from "@/components/details-tab/details-tab-provider"
 import { WindowDock } from "@/components/ui/window-dock"
 import { useConfirm } from "@/components/ui/confirm-dialog"
 import { LoginPage } from './LoginPage'
@@ -594,6 +595,7 @@ function App() {
   return (
     <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
       <LocaleProvider defaultLocale="auto" storageKey="vite-ui-locale">
+      <DetailsTabProvider defaultTab="messages" storageKey="vite-ui-default-details-tab">
       <div className="app">
         <main className="content">
           {!authReady ? (
@@ -670,6 +672,7 @@ function App() {
         </main>
         <WindowDock />
       </div>
+      </DetailsTabProvider>
       </LocaleProvider>
     </ThemeProvider>
   )

--- a/src/ui/src/components/details-tab/details-tab-provider.tsx
+++ b/src/ui/src/components/details-tab/details-tab-provider.tsx
@@ -1,0 +1,83 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react"
+
+/** Only these two tabs make sense as an initial landing tab; conditional
+ * tabs (QoS, Events, ...) aren't valid choices here. */
+export type DefaultDetailsTab = "flow" | "messages"
+
+type DetailsTabProviderProps = {
+  children: React.ReactNode
+  defaultTab?: DefaultDetailsTab
+  storageKey?: string
+}
+
+type DetailsTabProviderState = {
+  defaultDetailsTab: DefaultDetailsTab
+  setDefaultDetailsTab: (tab: DefaultDetailsTab) => void
+}
+
+function isValidTab(value: string): value is DefaultDetailsTab {
+  return value === "flow" || value === "messages"
+}
+
+/** Read+validate the stored pref. Falls back to `fallback` on missing/invalid/inaccessible storage. */
+function readStoredPref(storageKey: string, fallback: DefaultDetailsTab): DefaultDetailsTab {
+  try {
+    const stored = localStorage.getItem(storageKey)
+    if (stored && isValidTab(stored)) return stored
+  } catch {
+    // localStorage can throw when disabled (e.g. private mode, security policy).
+  }
+  return fallback
+}
+
+/** Best-effort persist. Storage failures are silently ignored so the in-memory state still works. */
+function writeStoredPref(storageKey: string, value: DefaultDetailsTab): void {
+  try {
+    localStorage.setItem(storageKey, value)
+  } catch {
+    // Quota exceeded / storage disabled — preference will be session-only.
+  }
+}
+
+const DetailsTabProviderContext = createContext<DetailsTabProviderState | undefined>(undefined)
+
+export function DetailsTabProvider({
+  children,
+  defaultTab = "messages",
+  storageKey = "vite-ui-default-details-tab",
+  ...props
+}: DetailsTabProviderProps) {
+  const [defaultDetailsTab, setDefaultDetailsTabState] = useState<DefaultDetailsTab>(() =>
+    readStoredPref(storageKey, defaultTab),
+  )
+
+  useEffect(() => {
+    writeStoredPref(storageKey, defaultDetailsTab)
+  }, [defaultDetailsTab, storageKey])
+
+  const setDefaultDetailsTab = useCallback(
+    (next: DefaultDetailsTab) => {
+      setDefaultDetailsTabState(isValidTab(next) ? next : defaultTab)
+    },
+    [defaultTab],
+  )
+
+  const value = useMemo<DetailsTabProviderState>(
+    () => ({ defaultDetailsTab, setDefaultDetailsTab }),
+    [defaultDetailsTab, setDefaultDetailsTab],
+  )
+
+  return (
+    <DetailsTabProviderContext.Provider {...props} value={value}>
+      {children}
+    </DetailsTabProviderContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useDefaultDetailsTab = () => {
+  const context = useContext(DetailsTabProviderContext)
+  if (context === undefined)
+    throw new Error("useDefaultDetailsTab must be used within a DetailsTabProvider")
+  return context
+}

--- a/src/ui/src/dashboard/TransactionModal.tsx
+++ b/src/ui/src/dashboard/TransactionModal.tsx
@@ -32,6 +32,7 @@ import {
 import { cn } from '@/lib/utils'
 import { newModalKey } from '@/lib/modalKey'
 import { useLocale } from '@/components/locale/locale-provider'
+import { useDefaultDetailsTab } from '@/components/details-tab/details-tab-provider'
 import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react'
 import { getMethodColor } from './flow-utils'
 import { resolveTimeRange } from './utils/resolveTimeRange'
@@ -602,7 +603,8 @@ function OtlpLogsTab({
 
 export default function TransactionModal({ modal, onClose, timeZone }) {
   const { resolved: locale } = useLocale()
-  const [activeTab, setActiveTab] = React.useState('messages')
+  const { defaultDetailsTab } = useDefaultDetailsTab()
+  const [activeTab, setActiveTab] = React.useState(defaultDetailsTab)
   const [qosData, setQosData] = React.useState(null)
   const [qosLoading, setQosLoading] = React.useState(false)
   const [qosError, setQosError] = React.useState('')
@@ -625,7 +627,7 @@ export default function TransactionModal({ modal, onClose, timeZone }) {
 
   // reset per-tab state whenever a new transaction is opened
   React.useEffect(() => {
-    setActiveTab('messages')
+    setActiveTab(defaultDetailsTab)
     setQosData(null); setQosError(''); setQosLoading(false)
     setCallInfoData(null); setCallInfoError(''); setCallInfoLoading(false)
     setEventsData(null); setEventsError(''); setEventsLoading(false)

--- a/src/ui/src/settings/ProfilePanel.tsx
+++ b/src/ui/src/settings/ProfilePanel.tsx
@@ -25,6 +25,7 @@ import { SettingsPageHeader } from './SettingsPageHeader'
 import UserAvatar from '@/components/UserAvatar'
 import { apiPatch } from '../api'
 import { useLocale } from '@/components/locale/locale-provider'
+import { useDefaultDetailsTab } from '@/components/details-tab/details-tab-provider'
 
 const LOCALE_TAGS = [
   'ar-EG', 'ar-SA', 'bg-BG', 'ca-ES', 'cs-CZ', 'da-DK',
@@ -103,6 +104,7 @@ export default function ProfilePanel({
   const [error, setError] = useState('')
   const [saving, setSaving] = useState(false)
   const { locale, setLocale, resolved, auto } = useLocale()
+  const { defaultDetailsTab, setDefaultDetailsTab } = useDefaultDetailsTab()
   const localeChoices = useMemo(() => {
     const collator = new Intl.Collator(resolved)
     return LOCALE_TAGS
@@ -273,6 +275,29 @@ export default function ProfilePanel({
           <div className="text-sm">
             <span className="text-muted-foreground">Sample: </span>
             <span className="font-mono">{sample}</span>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Transaction view</CardTitle>
+          <CardDescription>
+            Controls which tab a transaction opens on by default. Stored in this browser only.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-2 sm:max-w-md">
+            <Label htmlFor="profile-default-details-tab">Default tab</Label>
+            <Select value={defaultDetailsTab} onValueChange={(v) => setDefaultDetailsTab(v as 'flow' | 'messages')}>
+              <SelectTrigger id="profile-default-details-tab" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="messages">Messages</SelectItem>
+                <SelectItem value="flow">Call Flow</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
TransactionModal always opens on the Messages tab, with no way to change that.

This adds a "Default tab" preference under Settings → Profile → Transaction view (Messages / Call Flow), following the same pattern as the existing Locale preference.
A `DetailsTabProvider` / `useDefaultDetailsTab` hook mirrors `LocaleProvider` — same `vite-ui-*` localStorage-key convention, same Context+hook shape, client-side only.
Only Flow/Messages are valid choices.
Conditional tabs like QoS aren't selectable.

Defaults to Messages, so nobody's experience changes unless they explicitly opt in.