### PR TITLE
chore: bump version to 11.0.338

### DIFF
--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.337"
+	VERSION_APPLICATION = "11.0.338"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Bump `VERSION_APPLICATION` to 11.0.338 for the Call Flow contrast, colored transaction header, and Search sort-order control that landed in #995 (plus the Go 1.27.1 bump in #996) after 11.0.337.

## Test plan
- [x] Merge to `homer11`
- [x] Release `11.0.338` from `homer11`