### PR TITLE
fix(docker): pin golang 1.27.1 so GHCR builds match go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # rebuilding: docker buildx imagetools inspect <image>:<tag>
 FROM node:22-bookworm-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436 AS nodejs
 
-FROM golang:bookworm@sha256:484ef6066fa69acb059fdfeda7ba2b8f7391f2ef6abc6f9b8411e669ebd56466 AS devbase
+FROM golang:1.27.1-bookworm@sha256:648f440f42a0958804efb24df176f806f9d353b41f1c0627f666428e40310f6b AS devbase
 
 # Base build deps (no Debian nodejs — bookworm ships Node 18; Vite 7 needs 20.19+ / 22.12+).
 # Node comes from the official image above — do not curl|bash NodeSource as root.


### PR DESCRIPTION
## Summary
- #996 bumped `src/go.mod` to 1.27.1 but left the Dockerfile on `golang:bookworm` digest `484ef606…`, which is still Go 1.27.0.
- Official `golang` images set `GOTOOLCHAIN=local`, so the builder cannot auto-download 1.27.1.
- That is why [Docker GHCR publish for 11.0.338](https://github.com/sipcapture/homer/actions/runs/34145841811) failed on both amd64 and arm64:

```
go: go.mod requires go >= 1.27.1 (running go 1.27.0; GOTOOLCHAIN=local)
```

- Pin `golang:1.27.1-bookworm@sha256:648f440f42a0958804efb24df176f806f9d353b41f1c0627f666428e40310f6b` (verified via `docker buildx imagetools inspect`).
- Deb/rpm for 11.0.338 are fine (`setup-go` pulled 1.27.1). Only GHCR images are missing.

## Test plan
- [ ] Merge to `homer11`
- [ ] Re-run Docker GHCR publish (or cut 11.0.339) so `ghcr.io/sipcapture/homer:11.0.338` / `:latest` actually exist