### PR TITLE
chore: bump version to 11.0.339

### DIFF
--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.338"
+	VERSION_APPLICATION = "11.0.339"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Bump `VERSION_APPLICATION` to 11.0.339 for the Dockerfile golang 1.27.1 pin that landed in #999, so GHCR can build after 11.0.338 Docker failed on Go 1.27.0.

## Test plan
- [ ] Merge to `homer11`
- [ ] Release `11.0.339` from `homer11`