### PR TITLE
fix: include otlp_* tables in compaction discovery so retention and merge reach them

### DIFF
--- a/docs/RETENTION.md
+++ b/docs/RETENTION.md
@@ -95,7 +95,7 @@ Failures are logged per table; missing Parquet files are skipped and cleaned up 
 
 ### Applies to lake tables
 
-Retention runs on **every HEP table** discovered in the writer DuckLake catalog (`hep_proto_*`). Use `retention_days_by_table` when different datasets need different windows — for example keep calls longer than REGISTERs:
+Retention runs on **every HEP table** (`hep_proto_*`) and **every OTLP signal table** (`otlp_traces`, `otlp_metrics`, `otlp_logs`) discovered in the writer DuckLake catalog. Use `retention_days_by_table` when different datasets need different windows — for example keep calls longer than REGISTERs:
 
 ```json
 "compaction": {
@@ -109,7 +109,22 @@ Retention runs on **every HEP table** discovered in the writer DuckLake catalog 
 
 Keys must match the **bare** catalog table name (not a fully-qualified `lake.main.*` name). Unknown keys are ignored.
 
-For datasets that are not part of the HEP discovery set, use separate volumes/tiering or external lifecycle rules on object storage.
+OTLP tables are high-volume and often want a much shorter window than call
+capture — an `otlp_logs` override is the usual case:
+
+```json
+"compaction": {
+  "enable": true,
+  "retention_days": 30,
+  "retention_days_by_table": {
+    "otlp_logs": 1
+  }
+}
+```
+
+For datasets that are in neither discovery set (for example Line Protocol
+tables), use separate volumes/tiering or external lifecycle rules on object
+storage.
 
 OTLP and Line Protocol docs point here: [OTLP.md](OTLP.md), [LINE_PROTOCOL.md](LINE_PROTOCOL.md).
 

--- a/src/writer/compaction.go
+++ b/src/writer/compaction.go
@@ -548,7 +548,7 @@ func (c *CompactionService) discoverTables() error {
 		FROM information_schema.tables
 		WHERE table_catalog = ?
 		  AND table_schema = 'main'
-		  AND table_name LIKE 'hep_proto_%'
+		  AND (table_name LIKE 'hep_proto_%' OR table_name LIKE 'otlp_%')
 	`
 
 	rows, err := c.queryWithRetry(query, c.lakeName)

--- a/src/writer/otlp_retention_test.go
+++ b/src/writer/otlp_retention_test.go
@@ -1,0 +1,168 @@
+package writer
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+	_ "modernc.org/sqlite"
+)
+
+// newOTLPRetentionFixture builds a real DuckLake holding one HEP table and one
+// OTLP table, both with the retention-relevant shape the writers give them:
+// a date partition column and a `timestamp` column. Each table gets `days`
+// rows, one per day, ending today.
+//
+// The OTLP shape mirrors storage/ducklake/otlp_storage.go (otlpLogsTableSQL +
+// SET PARTITIONED BY (date) / SET SORTED BY (timestamp ASC)).
+func newOTLPRetentionFixture(t *testing.T, cfg CompactionConfig, days int) (*CompactionService, *sql.DB) {
+	t.Helper()
+	dir := t.TempDir()
+	data := filepath.Join(dir, "data")
+	if err := os.MkdirAll(data, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	catalog := filepath.Join(dir, "catalog.sqlite")
+
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Skipf("duckdb unavailable: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	db.SetMaxOpenConns(1)
+	for _, stmt := range []string{"LOAD ducklake;", "LOAD sqlite;"} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Skipf("extension unavailable (%q): %v", stmt, err)
+		}
+	}
+	if _, err := db.Exec(fmt.Sprintf(
+		"ATTACH 'ducklake:sqlite:%s' AS lake (DATA_PATH '%s');", catalog, data)); err != nil {
+		t.Skipf("ATTACH failed: %v", err)
+	}
+
+	for _, stmt := range []string{
+		`CREATE TABLE lake.hep_proto_1_call (date DATE, timestamp TIMESTAMP, id BIGINT)`,
+		`CREATE TABLE lake.otlp_logs (date DATE, timestamp TIMESTAMP, body VARCHAR)`,
+		`ALTER TABLE lake.hep_proto_1_call SET PARTITIONED BY (date)`,
+		`ALTER TABLE lake.otlp_logs SET PARTITIONED BY (date)`,
+		`ALTER TABLE lake.otlp_logs SET SORTED BY (timestamp ASC)`,
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("%s: %v", stmt, err)
+		}
+	}
+
+	for d := 0; d < days; d++ {
+		ts := time.Now().AddDate(0, 0, -d).UTC().Format("2006-01-02 15:04:05")
+		for _, stmt := range []string{
+			fmt.Sprintf(`INSERT INTO lake.hep_proto_1_call VALUES (DATE '%s', TIMESTAMP '%s', %d)`, ts[:10], ts, d),
+			fmt.Sprintf(`INSERT INTO lake.otlp_logs VALUES (DATE '%s', TIMESTAMP '%s', 'kamailio line %d')`, ts[:10], ts, d),
+		} {
+			if _, err := db.Exec(stmt); err != nil {
+				t.Fatalf("%s: %v", stmt, err)
+			}
+		}
+	}
+
+	svc := NewCompactionService(db, "lake", data, catalog, cfg, nil, nil, nil)
+	return svc, db
+}
+
+func rowCount(t *testing.T, db *sql.DB, table string) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow("SELECT count(*) FROM " + table).Scan(&n); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	return n
+}
+
+// TestDiscoverTablesIncludesOTLPTables asserts the discovery set contains the
+// OTLP signal tables, so both the retention and the merge phase can reach them.
+//
+// Before the predicate was widened this failed: discovery was scoped to
+// hep_proto_%, so OTLP tables in the same catalog were invisible to both.
+func TestDiscoverTablesIncludesOTLPTables(t *testing.T) {
+	svc, _ := newOTLPRetentionFixture(t, CompactionConfig{Enable: true}, 3)
+
+	if err := svc.discoverTables(); err != nil {
+		t.Fatalf("discoverTables: %v", err)
+	}
+
+	svc.mu.Lock()
+	tables := append([]string(nil), svc.tables...)
+	svc.mu.Unlock()
+
+	t.Logf("discovered: %v", tables)
+	var sawHEP, sawOTLP bool
+	for _, tbl := range tables {
+		switch tableNameFromFQN(tbl) {
+		case "hep_proto_1_call":
+			sawHEP = true
+		case "otlp_logs":
+			sawOTLP = true
+		}
+	}
+	if !sawHEP {
+		t.Errorf("hep_proto_1_call missing from discovery set: %v", tables)
+	}
+	if !sawOTLP {
+		t.Errorf("otlp_logs missing from discovery set: %v", tables)
+	}
+}
+
+// TestRetentionOverrideAppliesToOTLPTable is the regression test for the bug.
+//
+// The config is exactly what docs/RETENTION.md describes for per-table TTL, and
+// what docs/OTLP.md tells operators to use for capacity planning on otlp_*:
+// keep HEP 7 days, keep OTLP logs 1 day.
+//
+// Today this FAILS: the override resolves, retentionEnabled() returns true and
+// the cycle reports success, but otlp_logs is never iterated, so nothing is
+// deleted from it.
+func TestRetentionOverrideAppliesToOTLPTable(t *testing.T) {
+	cfg := CompactionConfig{
+		Enable:               true,
+		RetentionDays:        7,
+		RetentionDaysByTable: map[string]int{"otlp_logs": 1},
+	}
+	svc, db := newOTLPRetentionFixture(t, cfg, 30)
+
+	// Sanity: the override does resolve, and it does arm the retention phase.
+	if got := svc.retentionValueForTable("lake.main.otlp_logs"); got != 1 {
+		t.Fatalf("retentionValueForTable(otlp_logs) = %d, want 1", got)
+	}
+	if !svc.retentionEnabled() {
+		t.Fatal("retentionEnabled() = false, want true")
+	}
+
+	beforeHEP := rowCount(t, db, "lake.hep_proto_1_call")
+	beforeOTLP := rowCount(t, db, "lake.otlp_logs")
+
+	svc.runCompaction()
+
+	afterHEP := rowCount(t, db, "lake.hep_proto_1_call")
+	afterOTLP := rowCount(t, db, "lake.otlp_logs")
+
+	t.Logf("hep_proto_1_call: %d -> %d rows", beforeHEP, afterHEP)
+	t.Logf("otlp_logs:        %d -> %d rows", beforeOTLP, afterOTLP)
+
+	// The HEP table proves the cycle really ran and retention really works.
+	if afterHEP >= beforeHEP {
+		t.Fatalf("HEP retention did not run: %d -> %d rows", beforeHEP, afterHEP)
+	}
+
+	// The OTLP table is the bug.
+	if afterOTLP >= beforeOTLP {
+		t.Errorf("retention_days_by_table{\"otlp_logs\": 1} was a silent no-op: "+
+			"otlp_logs still has %d of %d rows after a cycle in which the override "+
+			"resolved to 1 day and retention was enabled", afterOTLP, beforeOTLP)
+	}
+	if afterOTLP > 2 {
+		t.Errorf("otlp_logs has %d rows, want <= 2 for a 1-day TTL over 30 days of data", afterOTLP)
+	}
+}


### PR DESCRIPTION
Fixes #1002.

## What was wrong

`discoverTables` scoped the catalog scan to `hep_proto_%`, and that one result set feeds **both** phases of a compaction cycle — retention (`compaction.go:509`) and merge (`compaction.go:527`). The OTLP signal tables live in the same catalog but matched neither, so `otlp_logs` was never trimmed *and* never compacted. It grew without bound in rows and, because the receiver writes one file per export request with nothing ever merging them, in Parquet file count.

On one collector taking Kamailio's stdout over OTLP that reached **148,621 Parquet files and 99.93% of the DuckLake catalog**, at which point `ATTACH` took 53.9s and every UI query — HEP included — ran 2.4–6.4s. Full numbers in #1002.

`retention_days_by_table` made it silent rather than merely absent: `retentionValueForTable` resolves a bare-name override for any table and `retentionEnabled` returns true for a positive one, so `{"otlp_logs": 1}` armed the retention phase and logged a successful cycle while deleting nothing from that table.

## The change

One predicate:

```diff
-  AND table_name LIKE 'hep_proto_%'
+  AND (table_name LIKE 'hep_proto_%' OR table_name LIKE 'otlp_%')
```

Nothing else needed changing. `EnsureOTLPSchema` already gives the OTLP tables `date DATE` + `timestamp TIMESTAMP` with `PARTITIONED BY (date)` and `SORTED BY (timestamp ASC)`, explicitly matching the HEP tables — so `runRetention`'s `DELETE ... WHERE timestamp <` and `buildMergeSQL` work on them as-is.

Plus a `RETENTION.md` update, since that doc described the old scope. `OTLP.md` already documented the behaviour this restores under *Capacity planning*, so it needs no change — it becomes accurate.

## One decision for you

This makes the **global** `retention_days` apply to `otlp_*` as well. That is what `OTLP.md` documents, but it is a behaviour change for anyone storing OTLP today: after upgrading, OTLP rows older than the global TTL start getting deleted.

If you would rather not move that default, the alternative is to include `otlp_*` in discovery so **merge** always runs — pure win, nothing deleted, file count stops exploding — and have retention touch `otlp_*` only on an explicit `retention_days_by_table` entry. Say which you prefer and I will push it; it is a small change on top of this.

## Tests

`src/writer/otlp_retention_test.go`, using the same real-DuckLake fixture style as `compaction_invariants_test.go`:

- `TestRetentionOverrideAppliesToOTLPTable` drives the real `runCompaction()` over 30 days of rows in both a HEP and an OTLP table with `retention_days: 7` + `retention_days_by_table: {"otlp_logs": 1}`. Before this change: `hep_proto_1_call` 30 → 8 rows, `otlp_logs` 30 → **30**. After: `otlp_logs` 30 → 2. It asserts the override resolves and `retentionEnabled()` is true first, so a regression shows up as the no-op rather than as a config problem.
- `TestDiscoverTablesIncludesOTLPTables` pins the discovery set directly.

`go test ./writer/` is otherwise unchanged by this PR. Heads up on two pre-existing conditions I ran into and deliberately left alone:

- `TestRunRetentionRespectsUnit` fails on unmodified `homer11` (`094f59e`) on any non-UTC machine — it seeds rows with DuckDB `now()` (local time) while `runRetention` builds its cutoff in UTC, so it over-deletes by the local offset. Test-only; the writers store UTC, so production cutoffs are correct. Happy to file it separately.
- `gofmt` flags `writer/retention_days_test.go` on `homer11`; untouched here to keep the diff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
