### PR TITLE
fix: include otlp_* in CLI and tiering table discovery

### DIFF
--- a/docs/RETENTION.md
+++ b/docs/RETENTION.md
@@ -122,9 +122,11 @@ capture — an `otlp_logs` override is the usual case:
 }
 ```
 
-For datasets that are in neither discovery set (for example Line Protocol
-tables), use separate volumes/tiering or external lifecycle rules on object
-storage.
+The same discovery set is used by the writer compaction cycle, the one-off
+`homer-core system --compaction-retention-days` / `--compaction-force` CLI,
+and `TieredStorageManager` (hot→cold moves and final-volume expiry). Line
+Protocol tables are in neither set; use a non-empty `table_prefix` plus
+external lifecycle rules on object storage, or a dedicated volume.
 
 OTLP and Line Protocol docs point here: [OTLP.md](OTLP.md), [LINE_PROTOCOL.md](LINE_PROTOCOL.md).
 

--- a/src/cli/system_cmd.go
+++ b/src/cli/system_cmd.go
@@ -403,15 +403,14 @@ func runCompaction(f SystemFlags) error {
 }
 
 func discoverDuckLakeTables(db *sql.DB, lakeName string) ([]string, error) {
-	query := fmt.Sprintf(`
+	query := `
 		SELECT table_name 
 		FROM information_schema.tables 
-		WHERE table_catalog = '%s' 
+		WHERE table_catalog = ?
 		  AND table_schema = 'main'
-		  AND table_name LIKE 'hep_proto_%%'
-	`, lakeName)
+		  AND ` + ducklake.ManagedLakeTablePredicate
 
-	rows, err := db.Query(query)
+	rows, err := db.Query(query, lakeName)
 	if err != nil {
 		return nil, err
 	}

--- a/src/cli/system_cmd_otlp_test.go
+++ b/src/cli/system_cmd_otlp_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+	_ "modernc.org/sqlite"
+)
+
+func newCLIDiscoveryFixture(t *testing.T) *sql.DB {
+	t.Helper()
+	dir := t.TempDir()
+	data := filepath.Join(dir, "data")
+	if err := os.MkdirAll(data, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	catalog := filepath.Join(dir, "catalog.sqlite")
+
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Skipf("duckdb unavailable: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	db.SetMaxOpenConns(1)
+	for _, stmt := range []string{"LOAD ducklake;", "LOAD sqlite;"} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Skipf("extension unavailable (%q): %v", stmt, err)
+		}
+	}
+	if _, err := db.Exec(fmt.Sprintf(
+		"ATTACH 'ducklake:sqlite:%s' AS lake (DATA_PATH '%s');", catalog, data)); err != nil {
+		t.Skipf("ATTACH failed: %v", err)
+	}
+	for _, stmt := range []string{
+		`CREATE TABLE lake.hep_proto_1_call (date DATE, timestamp TIMESTAMP)`,
+		`CREATE TABLE lake.otlp_logs (date DATE, timestamp TIMESTAMP, body VARCHAR)`,
+		`CREATE TABLE lake.otlp_traces (date DATE, timestamp TIMESTAMP, name VARCHAR)`,
+		`CREATE TABLE lake.cpu (date DATE, timestamp TIMESTAMP, usage DOUBLE)`,
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("%s: %v", stmt, err)
+		}
+	}
+	return db
+}
+
+func TestDiscoverDuckLakeTablesIncludesOTLP(t *testing.T) {
+	db := newCLIDiscoveryFixture(t)
+
+	tables, err := discoverDuckLakeTables(db, "lake")
+	if err != nil {
+		t.Fatalf("discoverDuckLakeTables: %v", err)
+	}
+
+	saw := map[string]bool{}
+	for _, tbl := range tables {
+		saw[tableNameFromFQN(tbl)] = true
+	}
+	for _, want := range []string{"hep_proto_1_call", "otlp_logs", "otlp_traces"} {
+		if !saw[want] {
+			t.Errorf("%s missing from CLI discovery set: %v", want, tables)
+		}
+	}
+	if saw["cpu"] {
+		t.Errorf("Line Protocol table cpu should not be in CLI discovery set: %v", tables)
+	}
+}

--- a/src/storage/ducklake/managed_tables.go
+++ b/src/storage/ducklake/managed_tables.go
@@ -1,0 +1,14 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package ducklake
+
+// ManagedLakeTablePredicate is the information_schema.tables filter for
+// tables that compaction (retention + merge), CLI one-off maintenance, and
+// tiered storage all operate on. Keep this in one place so a new prefix
+// cannot fall out of one scanner while remaining in another (#1002, #1003).
+const ManagedLakeTablePredicate = `(table_name LIKE 'hep_proto_%' OR table_name LIKE 'otlp_%')`

--- a/src/storage/ducklake/managed_tables_test.go
+++ b/src/storage/ducklake/managed_tables_test.go
@@ -1,0 +1,73 @@
+package ducklake
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+	_ "modernc.org/sqlite"
+)
+
+func newManagedTableFixture(t *testing.T) *sql.DB {
+	t.Helper()
+	dir := t.TempDir()
+	data := filepath.Join(dir, "data")
+	if err := os.MkdirAll(data, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	catalog := filepath.Join(dir, "catalog.sqlite")
+
+	db, err := sql.Open("duckdb", "")
+	if err != nil {
+		t.Skipf("duckdb unavailable: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	db.SetMaxOpenConns(1)
+	for _, stmt := range []string{"LOAD ducklake;", "LOAD sqlite;"} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Skipf("extension unavailable (%q): %v", stmt, err)
+		}
+	}
+	if _, err := db.Exec(fmt.Sprintf(
+		"ATTACH 'ducklake:sqlite:%s' AS lake (DATA_PATH '%s');", catalog, data)); err != nil {
+		t.Skipf("ATTACH failed: %v", err)
+	}
+	for _, stmt := range []string{
+		`CREATE TABLE lake.hep_proto_1_call (date DATE, timestamp TIMESTAMP)`,
+		`CREATE TABLE lake.otlp_logs (date DATE, timestamp TIMESTAMP, body VARCHAR)`,
+		`CREATE TABLE lake.otlp_metrics (date DATE, timestamp TIMESTAMP, name VARCHAR)`,
+		`CREATE TABLE lake.cpu (date DATE, timestamp TIMESTAMP, usage DOUBLE)`,
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("%s: %v", stmt, err)
+		}
+	}
+	return db
+}
+
+func TestGetTableNamesIncludesOTLP(t *testing.T) {
+	db := newManagedTableFixture(t)
+	tsm := &TieredStorageManager{db: db}
+	vol := &Volume{LakeName: "lake"}
+
+	tables, err := tsm.GetTableNames(vol)
+	if err != nil {
+		t.Fatalf("GetTableNames: %v", err)
+	}
+
+	saw := map[string]bool{}
+	for _, tbl := range tables {
+		saw[tbl] = true
+	}
+	for _, want := range []string{"hep_proto_1_call", "otlp_logs", "otlp_metrics"} {
+		if !saw[want] {
+			t.Errorf("%s missing from tiering discovery set: %v", want, tables)
+		}
+	}
+	if saw["cpu"] {
+		t.Errorf("Line Protocol table cpu should not be in tiering discovery set: %v", tables)
+	}
+}

--- a/src/storage/ducklake/tiered_query.go
+++ b/src/storage/ducklake/tiered_query.go
@@ -114,7 +114,7 @@ func (tr *TieredReader) QueryAll(whereClause string, limit int) ([]map[string]in
 	var allResults []map[string]interface{}
 
 	for _, vol := range volumes {
-		// Get all HEP tables in this volume
+		// Get HEP and OTLP tables in this volume
 		tables, err := tr.tieredStorage.GetTableNames(vol)
 		if err != nil {
 			continue

--- a/src/storage/ducklake/tiered_storage.go
+++ b/src/storage/ducklake/tiered_storage.go
@@ -876,15 +876,14 @@ func (tsm *TieredStorageManager) GetPartitionsOlderThan(vol *Volume, tableName s
 	return partitions, nil
 }
 
-// GetTableNames returns all table names in a volume
+// GetTableNames returns HEP and OTLP table names in a volume.
 func (tsm *TieredStorageManager) GetTableNames(vol *Volume) ([]string, error) {
 	query := `
 		SELECT table_name
 		FROM information_schema.tables
 		WHERE table_catalog = ?
 		  AND table_schema = 'main'
-		  AND table_name LIKE 'hep_proto_%'
-	`
+		  AND ` + ManagedLakeTablePredicate
 
 	rows, err := tsm.db.Query(query, vol.LakeName)
 	if err != nil {

--- a/src/writer/compaction.go
+++ b/src/writer/compaction.go
@@ -541,15 +541,14 @@ func (c *CompactionService) runCompaction() {
 		"rows_deleted", totalRowsDeleted)
 }
 
-// discoverTables finds all HEP tables in the DuckLake catalog
+// discoverTables finds HEP and OTLP tables in the DuckLake catalog
 func (c *CompactionService) discoverTables() error {
 	query := `
 		SELECT table_name
 		FROM information_schema.tables
 		WHERE table_catalog = ?
 		  AND table_schema = 'main'
-		  AND (table_name LIKE 'hep_proto_%' OR table_name LIKE 'otlp_%')
-	`
+		  AND ` + ducklake.ManagedLakeTablePredicate
 
 	rows, err := c.queryWithRetry(query, c.lakeName)
 	if err != nil {

--- a/src/writer/tiering.go
+++ b/src/writer/tiering.go
@@ -330,7 +330,7 @@ func (ts *TieringService) moveOldPartitions(srcVol, dstVol *ducklake.Volume) (in
 		return 0, fmt.Errorf("failed to get table names: %w", err)
 	}
 	if len(tables) == 0 {
-		logger.Info("TieringService: No hep_proto* tables on tiered source volume — nothing to move by age",
+		logger.Info("TieringService: No hep_proto*/otlp_* tables on tiered source volume — nothing to move by age",
 			"source", srcVol.Name,
 			"lake", srcVol.LakeName,
 			"hint", "Tiering runs on the TieredStorageManager DuckDB; if that catalog has no tables while ingest uses the writer DuckLake only, hot tier stays empty until writer and tiered paths share the same catalog data.")
@@ -434,7 +434,7 @@ func (ts *TieringService) expireOldPartitions(vol *ducklake.Volume) (int64, erro
 		return 0, fmt.Errorf("failed to get table names: %w", err)
 	}
 	if len(tables) == 0 {
-		logger.Info("TieringService: No hep_proto* tables on final volume — nothing to expire by age",
+		logger.Info("TieringService: No hep_proto*/otlp_* tables on final volume — nothing to expire by age",
 			"source", vol.Name,
 			"lake", vol.LakeName)
 		return 0, nil


### PR DESCRIPTION
## Summary
- Follow-up to #1003: the writer compaction cycle now sees `otlp_*`, but `discoverDuckLakeTables` (one-off `homer-core system --compaction-retention-days` / `--compaction-force` / `--compaction-merge` / catalog recover) and `TieredStorageManager.GetTableNames` (hot→cold moves, final-volume expiry, volume stats) were still `LIKE 'hep_proto_%'`.
- One shared predicate `ManagedLakeTablePredicate` so the three scanners cannot drift again. Compaction already used the widened filter; it now reads the same constant.
- Global `retention_days` / `max_data_age_days` apply to OTLP the same way they do to HEP. Opt-out remains `retention_days_by_table` with `0`. Line Protocol stays out of the set.

Fixes the remaining discovery holes called out in #1002.

## Test plan
- [x] `go test ./cli/ ./storage/ducklake/ ./writer/`
- [ ] After merge: `homer-core system --compaction-force` on a lake with `otlp_logs` should log merge for that table
- [ ] With storage policy enabled, an old `otlp_logs` date partition should move/expire like HEP