### PR TITLE
chore: bump version to 11.0.340

### DIFF
--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.339"
+	VERSION_APPLICATION = "11.0.340"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Bump `VERSION_APPLICATION` to 11.0.340 for the OTLP discovery fixes that landed in #1003 (compaction) and #1004 (CLI + tiering).

## Test plan
- [ ] Merge to `homer11`
- [ ] Release `11.0.340` from `homer11`