### PR TITLE
fix(security): document allowlisted /exec INSERT for CodeQL

### DIFF
--- a/src/node/node.go
+++ b/src/node/node.go
@@ -1370,7 +1370,11 @@ func (n *Node) handleExec(w http.ResponseWriter, r *http.Request) {
 	}
 
 	logger.Info("Node: handleExec", "sql_chars", len(req.SQL))
-	res, err := db.ExecContext(r.Context(), req.SQL)
+	// Bound parameters cannot carry a coordinator INSERT ... VALUES statement
+	// (PCAP import). ValidateWriteSQL above is the sanitizer: only
+	// INSERT INTO <catalog>.main.hep_proto_* VALUES ..., no SELECT/FROM,
+	// comments, or stacked statements (GHSA-rm5w-rqr7-2h54).
+	res, err := db.ExecContext(r.Context(), req.SQL) // codeql[go/sql-injection]
 	if err != nil {
 		logger.Error("Node: Exec failed", "sql", req.SQL, "error", err)
 		writeJSON(w, http.StatusOK, QueryResponse{


### PR DESCRIPTION
## Summary
- Closes [code scanning alert #42](https://github.com/sipcapture/homer/security/code-scanning/42) (\`go/sql-injection\` on \`POST /exec\`).
- The sink is not a free-form query: \`ValidateWriteSQL\` already allowlists \`INSERT INTO <catalog>.main.hep_proto_* VALUES ...\` only (no SELECT/FROM, comments, stacked statements, filesystem table functions — GHSA-rm5w-rqr7-2h54). Bound parameters cannot carry that coordinator INSERT.
- Annotate the sink with \`codeql[go/sql-injection]\` so CodeQL treats the remaining taint as the documented allowlist, not an unfixed injection.

## Test plan
- [x] \`go test ./node/ -run 'TestHandleExec|TestHandleQueryRejectsInsert|TestWithBearer'\`
- [ ] CodeQL on this PR: alert #42 should not re-open