### PR TITLE
fix(search): restore semicolon-separated multi-value search

### DIFF
--- a/docs/SEARCH.md
+++ b/docs/SEARCH.md
@@ -106,9 +106,9 @@ Supported time formats:
 | `--proto` | Protocol: name (`sip`, `otlp_traces`, …) or integer `proto_type` | `sip` (same as `1`) |
 | `--event-type <type>` | SIP: `call`/`registration`/`default`; OTLP: `default`; LP: `schema__table` | `call` (SIP only) |
 | `--method <method>` | SIP method filter | - |
-| `--call-id <id>` | Call-ID / session ID (partial match) | - |
-| `--from-user <user>` | Caller/from user (partial match) | - |
-| `--to-user <user>` | Callee/to user (partial match) | - |
+| `--call-id <id>` | Call-ID / session ID. Semicolon-separated values are OR-ed. `%` is a LIKE wildcard. | - |
+| `--from-user <user>` | Caller/from user. Semicolon-separated values are OR-ed (`110;112`). `%` is a LIKE wildcard. | - |
+| `--to-user <user>` | Callee/to user. Semicolon-separated values are OR-ed (`110;112`). `%` is a LIKE wildcard. | - |
 | `--src-ip <ip>` | Source IP (exact match) | - |
 | `--dst-ip <ip>` | Destination IP (exact match) | - |
 | `--node <name>` | Node name filter | - |

--- a/docs/SEARCH_MAPPINGS_AND_FIELDS.md
+++ b/docs/SEARCH_MAPPINGS_AND_FIELDS.md
@@ -140,7 +140,7 @@ Homer 11 **Protocol Search** (`SearchPanel` Form tab) supports:
 
 | `form_type` | UI control | Notes |
 |-------------|------------|--------|
-| `input` | Single-line text or number | Default. `type: integer` → `type="number"` input. |
+| `input` | Single-line text or number | Default. `type: integer` → `type="number"` input. Semicolon-separated text values (`110;112`) are OR-ed as SQL `IN` / `LIKE` (Homer 7). |
 | `input_multi_select` | Multi-select chips + custom values | Uses `form_default` as preset options. Sends `filter.<id>` or `filter.<id>s` (array → SQL `IN`). |
 | `multiselect` | Same as above when `selector` or `form_default` is set | Legacy alias; prefer `input_multi_select` in new JSON. |
 | `select` | Dropdown | Requires `selector: [{ "name", "value" }, ...]`. |
@@ -289,8 +289,8 @@ Multi-select with one value uses singular key (`method`); multiple values use pl
 | `id` | Column / source | Profile notes |
 |------|-----------------|---------------|
 | `call_id` | `session_id` (+ `cid` OR in default profile) | `sid_type: true` in call mapping |
-| `from_user` | `caller` | call |
-| `to_user` | `callee` | call |
+| `from_user` | `caller` | call; `;` separates OR values (`110;112`) |
+| `to_user` | `callee` | call; `;` separates OR values (`110;112`) |
 | `method` | `method` | multi-select → `IN` |
 | `response_code` | `response_code` | multi-select → `IN` |
 | `src_ip`, `dst_ip`, `src_port`, `dst_port` | same | |
@@ -338,6 +338,7 @@ No manual JSON file per measurement is required after ingest is enabled.
 | Field visible but search ignores it | No SQL branch for that `id`; use virtual or extend backend. |
 | Virtual filter no effect | Wrong `hepid`/`profile`; typo in `path`; OTLP/LP proto (virtual disabled). |
 | Multi-select ignored | Empty array; check plural key `methods` in network tab. |
+| `SQL contains forbidden comment or statement separator` | Search value still contains `;` as a literal. Text fields split on `;` into OR/`IN` (#1008). |
 | Homer 7 “protosearch” feel missing | Homer 11 uses generic **Protocol Search** + **Results** table; configure mapping + selected fields ([issue #763](https://github.com/sipcapture/homer/issues/763)). |
 
 ---

--- a/src/coordinator/handlers/transactions_sql_test.go
+++ b/src/coordinator/handlers/transactions_sql_test.go
@@ -560,6 +560,70 @@ func TestBuildSearchSQLV4_FormExactMatchUnlessPercent(t *testing.T) {
 	}
 }
 
+func TestBuildSearchSQLV4_SemicolonSeparatedOR(t *testing.T) {
+	// Homer 7 / HEPIC: "110;112" means callee IN ('110', '112'), not a literal
+	// that the node SQL validator then rejects as a statement separator (#1008).
+	req := SearchObjectV4{}
+	req.Filter.ProtoType = 1
+	req.Filter.EventType = "call"
+	req.Filter.ToUser = "112;110"
+
+	sql, err := buildSearchSQLV4("homer_lake", &req, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(sql, ";") {
+		t.Fatalf("generated SQL must not contain semicolon (node validator), got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "callee IN ('112', '110')") {
+		t.Fatalf("expected callee IN for semicolon-separated numbers, got:\n%s", sql)
+	}
+
+	req.Filter.ToUser = ""
+	req.Filter.FromUser = "00492111234567;+492111234567;02111234567"
+	sql2, err := buildSearchSQLV4("homer_lake", &req, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(sql2, ";") {
+		t.Fatalf("generated SQL must not contain semicolon, got:\n%s", sql2)
+	}
+	if !strings.Contains(sql2, "caller IN ('00492111234567', '+492111234567', '02111234567')") {
+		t.Fatalf("expected caller IN for alternate number formats, got:\n%s", sql2)
+	}
+
+	req.Filter.FromUser = ""
+	req.Filter.ToUser = "112%;110"
+	sql3, err := buildSearchSQLV4("homer_lake", &req, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(sql3, "(callee LIKE '112%' OR callee = '110')") {
+		t.Fatalf("expected mixed LIKE/= OR for wildcard tokens, got:\n%s", sql3)
+	}
+
+	req.Filter.ToUser = " 112 ; ; 110 "
+	sql4, err := buildSearchSQLV4("homer_lake", &req, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(sql4, "callee IN ('112', '110')") {
+		t.Fatalf("expected empty tokens skipped, got:\n%s", sql4)
+	}
+}
+
+func TestSqlFormMatchClause_Helpers(t *testing.T) {
+	if got := sqlFormMatchClause("callee", "112"); got != "callee = '112'" {
+		t.Fatalf("single exact: %s", got)
+	}
+	if got := sqlFormMatchClauseOr("session_id", "cid", "a;b"); got != "(session_id IN ('a', 'b') OR cid IN ('a', 'b'))" {
+		t.Fatalf("or IN: %s", got)
+	}
+	if got := sqlFormMatchClauseAny([]string{"body", "CAST(raw AS VARCHAR)"}, "x"); got != "(body = 'x' OR CAST(raw AS VARCHAR) = 'x')" {
+		t.Fatalf("any single: %s", got)
+	}
+}
+
 func TestBuildSearchSQLV4_VirtualDataExtraEquals(t *testing.T) {
 	req := SearchObjectV4{}
 	req.Filter.ProtoType = 1

--- a/src/coordinator/handlers/transactions_v4.go
+++ b/src/coordinator/handlers/transactions_v4.go
@@ -40,23 +40,81 @@ func stripB2BSuffix(sid string) string {
 	return b2bSuffixRe.ReplaceAllString(sid, "")
 }
 
-// sqlFormMatchClause builds a dashboard/form string filter: exact equality by
-// default; SQL LIKE only when rawValue contains '%' (user-supplied wildcards).
-func sqlFormMatchClause(columnExpr, rawValue string) string {
-	esc := sqlvalidator.SafeString(rawValue)
-	if strings.Contains(rawValue, "%") {
+// maxFormMatchValues caps semicolon-separated search tokens (Homer 7 OR/IN).
+const maxFormMatchValues = 64
+
+// splitFormMatchValues splits a dashboard/form value on ';' (Homer 7 / HEPIC).
+// Empty tokens are dropped. Tokens beyond maxFormMatchValues are ignored.
+func splitFormMatchValues(rawValue string) []string {
+	if !strings.Contains(rawValue, ";") {
+		v := strings.TrimSpace(rawValue)
+		if v == "" {
+			return nil
+		}
+		return []string{v}
+	}
+	parts := strings.Split(rawValue, ";")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		out = append(out, p)
+		if len(out) >= maxFormMatchValues {
+			break
+		}
+	}
+	return out
+}
+
+func sqlFormMatchOne(columnExpr, value string) string {
+	esc := sqlvalidator.SafeString(value)
+	if strings.Contains(value, "%") {
 		return fmt.Sprintf("%s LIKE '%s'", columnExpr, esc)
 	}
 	return fmt.Sprintf("%s = '%s'", columnExpr, esc)
 }
 
+func sqlFormMatchJoin(columnExpr string, values []string) string {
+	if len(values) == 0 {
+		return "TRUE"
+	}
+	if len(values) == 1 {
+		return sqlFormMatchOne(columnExpr, values[0])
+	}
+	allExact := true
+	for _, v := range values {
+		if strings.Contains(v, "%") {
+			allExact = false
+			break
+		}
+	}
+	if allExact {
+		quoted := make([]string, len(values))
+		for i, v := range values {
+			quoted[i] = "'" + sqlvalidator.SafeString(v) + "'"
+		}
+		return fmt.Sprintf("%s IN (%s)", columnExpr, strings.Join(quoted, ", "))
+	}
+	parts := make([]string, len(values))
+	for i, v := range values {
+		parts[i] = sqlFormMatchOne(columnExpr, v)
+	}
+	return "(" + strings.Join(parts, " OR ") + ")"
+}
+
+// sqlFormMatchClause builds a dashboard/form string filter: exact equality by
+// default; SQL LIKE only when a token contains '%' (user-supplied wildcards).
+// Semicolon-separated tokens are OR-ed (IN when every token is exact), matching
+// Homer 7 / HEPIC "110;112" multi-number search (#1008).
+func sqlFormMatchClause(columnExpr, rawValue string) string {
+	return sqlFormMatchJoin(columnExpr, splitFormMatchValues(rawValue))
+}
+
 // sqlFormMatchClauseOr applies sqlFormMatchClause across two columns (OR).
 func sqlFormMatchClauseOr(leftExpr, rightExpr, rawValue string) string {
-	esc := sqlvalidator.SafeString(rawValue)
-	if strings.Contains(rawValue, "%") {
-		return fmt.Sprintf("(%s LIKE '%s' OR %s LIKE '%s')", leftExpr, esc, rightExpr, esc)
-	}
-	return fmt.Sprintf("(%s = '%s' OR %s = '%s')", leftExpr, esc, rightExpr, esc)
+	return sqlFormMatchClauseAny([]string{leftExpr, rightExpr}, rawValue)
 }
 
 // sipCallIDMatchClause builds a Call-ID / session_id filter for a SIP profile.
@@ -77,16 +135,18 @@ func sipCIDMatchClause(txType, rawValue string) string {
 	return sqlFormMatchClause("cid", rawValue)
 }
 
-// sqlFormMatchClauseAny ORs the same value across multiple column expressions.
+// sqlFormMatchClauseAny ORs the same value(s) across multiple column expressions.
 func sqlFormMatchClauseAny(columnExprs []string, rawValue string) string {
-	esc := sqlvalidator.SafeString(rawValue)
-	op := "="
-	if strings.Contains(rawValue, "%") {
-		op = "LIKE"
+	values := splitFormMatchValues(rawValue)
+	if len(columnExprs) == 0 || len(values) == 0 {
+		return "TRUE"
+	}
+	if len(columnExprs) == 1 {
+		return sqlFormMatchJoin(columnExprs[0], values)
 	}
 	parts := make([]string, len(columnExprs))
 	for i, col := range columnExprs {
-		parts[i] = fmt.Sprintf("%s %s '%s'", col, op, esc)
+		parts[i] = sqlFormMatchJoin(col, values)
 	}
 	return "(" + strings.Join(parts, " OR ") + ")"
 }

--- a/src/mcp/mcp.go
+++ b/src/mcp/mcp.go
@@ -641,14 +641,13 @@ func buildSQL(payload searchPayload) string {
 		parts = append(parts, fmt.Sprintf("method = '%s'", escapeSQL(payload.Filter.Method)))
 	}
 	if payload.Filter.CallID != "" {
-		callID := escapeSQL(payload.Filter.CallID)
-		parts = append(parts, fmt.Sprintf("(session_id LIKE '%%%s%%' OR cid LIKE '%%%s%%')", callID, callID))
+		parts = append(parts, mcpLikeAny([]string{"session_id", "cid"}, payload.Filter.CallID))
 	}
 	if payload.Filter.FromUser != "" {
-		parts = append(parts, fmt.Sprintf("caller LIKE '%%%s%%'", escapeSQL(payload.Filter.FromUser)))
+		parts = append(parts, mcpLikeAny([]string{"caller"}, payload.Filter.FromUser))
 	}
 	if payload.Filter.ToUser != "" {
-		parts = append(parts, fmt.Sprintf("callee LIKE '%%%s%%'", escapeSQL(payload.Filter.ToUser)))
+		parts = append(parts, mcpLikeAny([]string{"callee"}, payload.Filter.ToUser))
 	}
 	if payload.Filter.SrcIP != "" {
 		parts = append(parts, fmt.Sprintf("src_ip = '%s'", escapeSQL(payload.Filter.SrcIP)))
@@ -667,6 +666,37 @@ func buildSQL(payload searchPayload) string {
 
 func escapeSQL(v string) string {
 	return strings.ReplaceAll(v, "'", "''")
+}
+
+// mcpLikeAny builds substring LIKE clauses. Semicolon-separated tokens are
+// OR-ed so "110;112" does not embed ';' (rejected by validateSQL, #1008).
+func mcpLikeAny(columns []string, raw string) string {
+	tokens := strings.Split(raw, ";")
+	var values []string
+	for _, t := range tokens {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		values = append(values, t)
+		if len(values) >= 64 {
+			break
+		}
+	}
+	if len(values) == 0 || len(columns) == 0 {
+		return "TRUE"
+	}
+	var parts []string
+	for _, col := range columns {
+		for _, v := range values {
+			esc := escapeSQL(v)
+			parts = append(parts, fmt.Sprintf("%s LIKE '%%%s%%'", col, esc))
+		}
+	}
+	if len(parts) == 1 {
+		return parts[0]
+	}
+	return "(" + strings.Join(parts, " OR ") + ")"
 }
 
 func validateSQL(sql string) error {

--- a/src/mcp/mcp_test.go
+++ b/src/mcp/mcp_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -71,6 +72,30 @@ func TestValidateSQLRejectsSemicolon(t *testing.T) {
 	if err := validateSQL(sql); err == nil {
 		t.Fatalf("expected semicolon SQL to be rejected")
 	}
+}
+
+func TestBuildSQL_SemicolonSeparatedOR(t *testing.T) {
+	payload := searchPayload{}
+	payload.Timestamp.From = 1
+	payload.Timestamp.To = 2
+	payload.Filter.ToUser = "112;110"
+	payload.Param.Limit = 10
+	sql := buildSQL(payload)
+	if err := validateSQL(sql); err != nil {
+		t.Fatalf("generated SQL rejected: %v\n%s", err, sql)
+	}
+	if !containsAll(sql, "callee LIKE '%112%'", "callee LIKE '%110%'") {
+		t.Fatalf("expected OR of LIKE tokens, got:\n%s", sql)
+	}
+}
+
+func containsAll(s string, parts ...string) bool {
+	for _, p := range parts {
+		if !strings.Contains(s, p) {
+			return false
+		}
+	}
+	return true
 }
 
 func TestValidateSQLRejectsDropToken(t *testing.T) {

--- a/src/ui/src/dashboard/widgets/SearchPanel.tsx
+++ b/src/ui/src/dashboard/widgets/SearchPanel.tsx
@@ -543,6 +543,7 @@ export default function SearchPanel({ config, onConfigChange, widgetId }) {
         id={`sp-${id}`}
         type={type}
         placeholder={placeholder}
+        title={type === 'text' ? 'Separate multiple values with semicolon (;). Use % as a wildcard.' : undefined}
         value={form[id] || ''}
         onChange={(e) => handleChange(id, e.target.value)}
         className="h-7 text-xs"
@@ -773,8 +774,8 @@ export default function SearchPanel({ config, onConfigChange, widgetId }) {
               : (
                 <>
                   {textField('call_id', 'Call-ID', 'text', 'SIP Call-ID')}
-                  {textField('from_user', 'From', 'text', 'Caller')}
-                  {textField('to_user', 'To', 'text', 'Callee')}
+                  {textField('from_user', 'From', 'text', 'alice;+49211…')}
+                  {textField('to_user', 'To', 'text', '110;112')}
                   {selectField('method', 'Method', METHOD_OPTIONS)}
                   {selectField('event_type', 'Event', EVENT_OPTIONS)}
                   {selectField('proto_type', 'Protocol', PROTO_OPTIONS)}

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.340"
+	VERSION_APPLICATION = "11.0.341"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Restore Homer 7 / HEPIC behavior: Protocol Search text fields treat `;` as an OR separator (`110;112` → `callee IN ('110', '112')`).
- Fixes [#1008](https://github.com/sipcapture/homer/issues/1008): Homer 11 interpolated the literal (`callee = '112;110'`) and the node SQL validator then rejected `;` as a statement separator.
- Tokens with `%` stay LIKE; mixed lists become `(col LIKE '112%' OR col = '110')`. Empty tokens are skipped. Same split applies to MCP/AI SQL.
- Bump version to **11.0.341**.

Closes #1008

## Test plan
- [x] `go test ./coordinator/handlers/ ./mcp/` (includes `110;112` and alternate number-format cases)
- [x] Dashboard Protocol Search: `to_user=110;112` returns both, no SQL error
- [x] `from_user=00492111234567;+492111234567;02111234567` matches any format
- [x] Single values and `%` wildcards unchanged (`alice`, `ali%`)
- [x] Compile Check on this PR