### PR TITLE
fix(security): bump hono 4.13.7 and js-yaml 4.3.2

### DIFF
--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -6367,9 +6367,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.34",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
-      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -6756,9 +6756,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -65,8 +65,8 @@
   "overrides": {
     "express-rate-limit": "8.5.1",
     "ip-address": "10.3.1",
-    "hono": "4.12.34",
-    "js-yaml": "4.3.1",
+    "hono": "4.13.7",
+    "js-yaml": "4.3.2",
     "nanoid": "3.3.18",
     "@hono/node-server": "2.0.11",
     "fast-uri": "3.1.6",


### PR DESCRIPTION
## Summary
- Pin npm overrides: `hono` **4.12.34 → 4.13.7**, `js-yaml` **4.3.1 → 4.3.2**.
- Closes the remaining open Dependabot alerts on `src/ui/package-lock.json`:
  - [#90](https://github.com/sipcapture/homer/security/dependabot/90) `js-yaml` [CVE-2026-84375](https://github.com/advisories/GHSA-2883-xcg3-v3hh) (high)
  - [#87](https://github.com/sipcapture/homer/security/dependabot/87)–[#89](https://github.com/sipcapture/homer/security/dependabot/89) `hono` [CVE-2026-84363](https://github.com/advisories/GHSA-crvj-82cr-hjcx) / [84364](https://github.com/advisories/GHSA-g6gw-c38x-mqfc) / [84365](https://github.com/advisories/GHSA-gqvv-2mrq-wpjv) (medium)
- `vitest` / `@vitest/mocker` alerts [#85](https://github.com/sipcapture/homer/security/dependabot/85)–[#86](https://github.com/sipcapture/homer/security/dependabot/86) are already patched by **5.0.0** in #1012 (`npm audit` is clean for them). They should auto-close after GitHub rescans `homer11`.

## Test plan
- [x] `npm audit` in `src/ui` → **0 vulnerabilities**
- [x] `npm test` — 229 passed; 1 pre-existing fail (`ProfilePanel` / `DetailsTabProvider`) from the vitest 5 bump in #1012, not this lockfile pin
- [ ] Compile Check on this PR
- [ ] After merge, Dependabot #87–#90 auto-close