### PR TITLE
fix(security): parameterize POST /exec to close CodeQL sql-injection

### DIFF
--- a/src/coordinator/handlers/imports_v4.go
+++ b/src/coordinator/handlers/imports_v4.go
@@ -66,7 +66,7 @@ func (h *ImportsHandler) V4ImportsPcap(c echo.Context) error {
 		return writeError(c, http.StatusBadRequest, "Bad Request", ferr.Error())
 	}
 
-	inserted, rejected, err := importPcapSIP(c.Request().Context(), h.flight, h.flight.LakeName(), raw, pcapImportOptions{
+	inserted, rejected, err := importPcapSIP(c.Request().Context(), h.flight, raw, pcapImportOptions{
 		OverrideToCurrentTime: override,
 		ForceSIPSubtype:       forceSub,
 	})

--- a/src/coordinator/handlers/pcap_sip_import.go
+++ b/src/coordinator/handlers/pcap_sip_import.go
@@ -16,8 +16,8 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcapgo"
-	"github.com/sipcapture/homer-core/src/decoder"
 	"github.com/sipcapture/homer-core/src/coordinator/services"
+	"github.com/sipcapture/homer-core/src/decoder"
 	"github.com/sipcapture/homer-core/src/storage/ducklake"
 )
 
@@ -126,7 +126,6 @@ func newPcapIterator(buf []byte) (next func() ([]byte, gopacket.CaptureInfo, err
 func importPcapSIP(
 	ctx context.Context,
 	flight *services.FlightService,
-	lakeName string,
 	raw []byte,
 	opts pcapImportOptions,
 ) (inserted, rejected int, err error) {
@@ -164,11 +163,7 @@ func importPcapSIP(
 		if len(rows) == 0 {
 			return nil
 		}
-		sql, err := ducklake.BuildInsertMultiValues(lakeName, key, rows)
-		if err != nil {
-			return err
-		}
-		if err := flight.ExecFirstConnected(ctx, sql); err != nil {
+		if err := flight.InsertFirstConnected(ctx, key, rows); err != nil {
 			return err
 		}
 		inserted += len(rows)

--- a/src/coordinator/services/flight_service.go
+++ b/src/coordinator/services/flight_service.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/sipcapture/homer-core/src/config"
+	"github.com/sipcapture/homer-core/src/storage/ducklake"
 	logger "github.com/sipcapture/homer-core/src/utils/logging"
 )
 
@@ -272,6 +273,12 @@ type queryRequest struct {
 	SQL string `json:"sql"`
 }
 
+type insertRequest struct {
+	ProtoType uint32          `json:"proto_type"`
+	SubType   string          `json:"sub_type"`
+	Rows      [][]interface{} `json:"rows"`
+}
+
 // QueryResponse from HTTP API
 type queryResponse struct {
 	Success bool                     `json:"success"`
@@ -301,9 +308,9 @@ func (s *FlightService) QueryFirstConnected(ctx context.Context, sql string) ([]
 	return nil, fmt.Errorf("no connected storage nodes")
 }
 
-// ExecFirstConnected runs write SQL (INSERT) on the first connected node via POST /exec.
-// /query stays read-only; this is the path for PCAP import and other coordinator writes.
-func (s *FlightService) ExecFirstConnected(ctx context.Context, sql string) error {
+// InsertFirstConnected inserts rows on the first connected node via POST /exec.
+// Table identity is proto_type + sub_type; the node builds parameterized INSERT SQL.
+func (s *FlightService) InsertFirstConnected(ctx context.Context, key ducklake.TableKey, rows [][]interface{}) error {
 	s.mu.RLock()
 	nodes := make([]config.NodeEndpoint, len(s.nodes))
 	copy(nodes, s.nodes)
@@ -317,7 +324,7 @@ func (s *FlightService) ExecFirstConnected(ctx context.Context, sql string) erro
 		if !connected[node.Name] {
 			continue
 		}
-		return s.execNode(ctx, node, sql)
+		return s.insertNode(ctx, node, key, rows)
 	}
 	return fmt.Errorf("no connected storage nodes")
 }
@@ -467,12 +474,28 @@ func (s *FlightService) queryNode(ctx context.Context, node config.NodeEndpoint,
 	return s.postNodeSQL(ctx, node, "/query", sql)
 }
 
-func (s *FlightService) execNode(ctx context.Context, node config.NodeEndpoint, sql string) error {
-	_, err := s.postNodeSQL(ctx, node, "/exec", sql)
+func (s *FlightService) insertNode(ctx context.Context, node config.NodeEndpoint, key ducklake.TableKey, rows [][]interface{}) error {
+	reqBody, err := json.Marshal(insertRequest{
+		ProtoType: key.ProtoType,
+		SubType:   key.SubType,
+		Rows:      ducklake.JSONSafeInsertRows(rows),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal insert request: %w", err)
+	}
+	_, err = s.postNodeJSON(ctx, node, "/exec", reqBody)
 	return err
 }
 
 func (s *FlightService) postNodeSQL(ctx context.Context, node config.NodeEndpoint, path, sql string) ([]map[string]interface{}, error) {
+	reqBody, err := json.Marshal(queryRequest{SQL: sql})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal query request: %w", err)
+	}
+	return s.postNodeJSON(ctx, node, path, reqBody)
+}
+
+func (s *FlightService) postNodeJSON(ctx context.Context, node config.NodeEndpoint, path string, reqBody []byte) ([]map[string]interface{}, error) {
 	// Per-query timeout; context.WithTimeout keeps the parent deadline when
 	// the caller's is sooner.
 	ctx, cancel := context.WithTimeout(ctx, s.queryTimeout)
@@ -482,10 +505,6 @@ func (s *FlightService) postNodeSQL(ctx context.Context, node config.NodeEndpoin
 	httpPort := node.Port + 1
 	url := fmt.Sprintf("http://%s:%d%s", node.Host, httpPort, path)
 
-	reqBody, err := json.Marshal(queryRequest{SQL: sql})
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal query request: %w", err)
-	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, err

--- a/src/coordinator/services/flight_service_test.go
+++ b/src/coordinator/services/flight_service_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/sipcapture/homer-core/src/config"
+	"github.com/sipcapture/homer-core/src/storage/ducklake"
 )
 
 func TestFlightServiceCloseAllIsIdempotent(t *testing.T) {
@@ -74,14 +75,18 @@ func TestFlightServiceQuerySendsBearerToken(t *testing.T) {
 	}
 }
 
-func TestFlightServiceExecFirstConnectedPostsExec(t *testing.T) {
-	var gotPath, gotAuth, gotSQL string
+func TestFlightServiceInsertFirstConnectedPostsExec(t *testing.T) {
+	var gotPath, gotAuth string
+	var got struct {
+		SQL       string          `json:"sql"`
+		ProtoType uint32          `json:"proto_type"`
+		SubType   string          `json:"sub_type"`
+		Rows      [][]interface{} `json:"rows"`
+	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		gotAuth = r.Header.Get("Authorization")
-		var req queryRequest
-		_ = json.NewDecoder(r.Body).Decode(&req)
-		gotSQL = req.SQL
+		_ = json.NewDecoder(r.Body).Decode(&got)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":[],"count":0}`))
 	}))
@@ -98,8 +103,9 @@ func TestFlightServiceExecFirstConnectedPostsExec(t *testing.T) {
 	}, time.Second, false)
 	svc.connected["local"] = true
 
-	sql := "INSERT INTO homer_lake.main.hep_proto_1_call (id) VALUES (1)"
-	if err := svc.ExecFirstConnected(context.Background(), sql); err != nil {
+	key := ducklake.TableKey{ProtoType: ducklake.ProtoTypeSIP, SubType: ducklake.SIPTypeCall}
+	rows := [][]interface{}{{"uuid-1", "payload"}}
+	if err := svc.InsertFirstConnected(context.Background(), key, rows); err != nil {
 		t.Fatal(err)
 	}
 	if gotPath != "/exec" {
@@ -108,8 +114,14 @@ func TestFlightServiceExecFirstConnectedPostsExec(t *testing.T) {
 	if gotAuth != "Bearer node-secret" {
 		t.Fatalf("Authorization=%q", gotAuth)
 	}
-	if gotSQL != sql {
-		t.Fatalf("sql=%q", gotSQL)
+	if got.ProtoType != key.ProtoType || got.SubType != key.SubType {
+		t.Fatalf("got proto=%d sub=%q", got.ProtoType, got.SubType)
+	}
+	if len(got.Rows) != 1 || len(got.Rows[0]) != 2 || got.Rows[0][0] != "uuid-1" {
+		t.Fatalf("rows=%v", got.Rows)
+	}
+	if got.SQL != "" {
+		t.Fatalf("sql field must be empty, got %q", got.SQL)
 	}
 }
 

--- a/src/node/http_auth_test.go
+++ b/src/node/http_auth_test.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/sipcapture/homer-core/src/storage/ducklake"
 )
 
 func TestWithBearerAuthDisabled(t *testing.T) {
@@ -104,20 +106,23 @@ func TestHandleQueryRejectsInsert(t *testing.T) {
 	}
 }
 
-func TestHandleExecValidatesWriteSQL(t *testing.T) {
+func TestHandleExecRejectsRawSQL(t *testing.T) {
 	node := &Node{}
 
-	t.Run("drop", func(t *testing.T) {
-		body, _ := json.Marshal(QueryRequest{SQL: `DROP TABLE t`})
+	t.Run("sql field", func(t *testing.T) {
+		body, _ := json.Marshal(QueryRequest{SQL: `INSERT INTO homer_lake.main.hep_proto_1_call (id) VALUES (1)`})
 		req := httptest.NewRequest(http.MethodPost, "/exec", bytes.NewReader(body))
 		rr := httptest.NewRecorder()
 		node.handleExec(rr, req)
 		if rr.Code != http.StatusBadRequest {
 			t.Fatalf("expected 400, got %d body=%s", rr.Code, rr.Body.String())
 		}
+		if !bytes.Contains(rr.Body.Bytes(), []byte("raw SQL")) {
+			t.Fatalf("expected raw SQL rejection, body=%s", rr.Body.String())
+		}
 	})
 
-	t.Run("insert with read_text", func(t *testing.T) {
+	t.Run("insert select", func(t *testing.T) {
 		body, _ := json.Marshal(QueryRequest{SQL: `INSERT INTO t SELECT content FROM read_text('/etc/passwd')`})
 		req := httptest.NewRequest(http.MethodPost, "/exec", bytes.NewReader(body))
 		rr := httptest.NewRecorder()
@@ -126,14 +131,55 @@ func TestHandleExecValidatesWriteSQL(t *testing.T) {
 			t.Fatalf("expected 400, got %d body=%s", rr.Code, rr.Body.String())
 		}
 	})
+}
 
-	t.Run("valid insert without db is 503", func(t *testing.T) {
-		body, _ := json.Marshal(QueryRequest{SQL: `INSERT INTO homer_lake.main.hep_proto_1_call (id) VALUES (1)`})
+func TestHandleExecRowsContract(t *testing.T) {
+	node := &Node{}
+
+	t.Run("unknown table", func(t *testing.T) {
+		body, _ := json.Marshal(ExecInsertRequest{
+			ProtoType: 99,
+			SubType:   "nope",
+			Rows:      [][]interface{}{{1}},
+		})
+		req := httptest.NewRequest(http.MethodPost, "/exec", bytes.NewReader(body))
+		rr := httptest.NewRecorder()
+		node.handleExec(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d body=%s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("empty rows", func(t *testing.T) {
+		body, _ := json.Marshal(ExecInsertRequest{
+			ProtoType: 1,
+			SubType:   "call",
+			Rows:      [][]interface{}{},
+		})
+		req := httptest.NewRequest(http.MethodPost, "/exec", bytes.NewReader(body))
+		rr := httptest.NewRecorder()
+		node.handleExec(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d body=%s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("valid rows without db is 503", func(t *testing.T) {
+		n := len(ducklake.InsertColumnNamesForKey(ducklake.TableKey{ProtoType: ducklake.ProtoTypeSIP, SubType: ducklake.SIPTypeCall}))
+		row := make([]interface{}, n)
+		for i := range row {
+			row[i] = "x"
+		}
+		body, _ := json.Marshal(ExecInsertRequest{
+			ProtoType: ducklake.ProtoTypeSIP,
+			SubType:   ducklake.SIPTypeCall,
+			Rows:      [][]interface{}{row},
+		})
 		req := httptest.NewRequest(http.MethodPost, "/exec", bytes.NewReader(body))
 		rr := httptest.NewRecorder()
 		node.handleExec(rr, req)
 		if rr.Code != http.StatusServiceUnavailable {
-			t.Fatalf("expected 503 after validation, got %d body=%s", rr.Code, rr.Body.String())
+			t.Fatalf("expected 503 after schema check, got %d body=%s", rr.Code, rr.Body.String())
 		}
 	})
 }

--- a/src/node/node.go
+++ b/src/node/node.go
@@ -1327,15 +1327,35 @@ func (n *Node) handleQuery(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// ExecInsertRequest is the POST /exec body. Raw SQL is rejected; the node
+// builds a parameterized INSERT from an allowlisted DuckLake schema.
+type ExecInsertRequest struct {
+	SQL       string          `json:"sql"`
+	ProtoType uint32          `json:"proto_type"`
+	SubType   string          `json:"sub_type"`
+	Rows      [][]interface{} `json:"rows"`
+}
+
+const maxExecInsertRows = 512
+
+func (n *Node) execLakeName() string {
+	if n.config != nil && n.config.DuckLake.LakeName != "" {
+		return n.config.DuckLake.LakeName
+	}
+	return "homer_lake"
+}
+
 // handleExec handles POST /exec for coordinator-generated writes (PCAP import).
-// /query stays read-only (GHSA-rm5w-rqr7-2h54); this path allows INSERT only.
+// /query stays read-only (GHSA-rm5w-rqr7-2h54). This path never executes a
+// client-supplied SQL string: table/columns come from GetTableSchemas, values
+// are bound parameters.
 func (n *Node) handleExec(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	var req QueryRequest
+	var req ExecInsertRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, QueryResponse{
 			Success: false,
@@ -1344,18 +1364,35 @@ func (n *Node) handleExec(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.SQL == "" {
+	if strings.TrimSpace(req.SQL) != "" {
 		writeJSON(w, http.StatusBadRequest, QueryResponse{
 			Success: false,
-			Error:   "SQL query is required",
+			Error:   "raw SQL is not accepted; send proto_type, sub_type, and rows",
 		})
 		return
 	}
 
-	if err := sqlvalidator.ValidateWriteSQL(req.SQL); err != nil {
+	if len(req.Rows) == 0 {
 		writeJSON(w, http.StatusBadRequest, QueryResponse{
 			Success: false,
-			Error:   "SQL validation failed: " + err.Error(),
+			Error:   "rows are required",
+		})
+		return
+	}
+	if len(req.Rows) > maxExecInsertRows {
+		writeJSON(w, http.StatusBadRequest, QueryResponse{
+			Success: false,
+			Error:   fmt.Sprintf("too many rows (max %d)", maxExecInsertRows),
+		})
+		return
+	}
+
+	key := ducklake.TableKey{ProtoType: req.ProtoType, SubType: req.SubType}
+	query, args, err := ducklake.BuildParameterizedInsert(n.execLakeName(), key, req.Rows)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, QueryResponse{
+			Success: false,
+			Error:   err.Error(),
 		})
 		return
 	}
@@ -1369,14 +1406,10 @@ func (n *Node) handleExec(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	logger.Info("Node: handleExec", "sql_chars", len(req.SQL))
-	// Bound parameters cannot carry a coordinator INSERT ... VALUES statement
-	// (PCAP import). ValidateWriteSQL above is the sanitizer: only
-	// INSERT INTO <catalog>.main.hep_proto_* VALUES ..., no SELECT/FROM,
-	// comments, or stacked statements (GHSA-rm5w-rqr7-2h54).
-	res, err := db.ExecContext(r.Context(), req.SQL) // codeql[go/sql-injection]
+	logger.Info("Node: handleExec", "proto_type", req.ProtoType, "sub_type", req.SubType, "rows", len(req.Rows))
+	res, err := db.ExecContext(r.Context(), query, args...)
 	if err != nil {
-		logger.Error("Node: Exec failed", "sql", req.SQL, "error", err)
+		logger.Error("Node: Exec failed", "error", err)
 		writeJSON(w, http.StatusOK, QueryResponse{
 			Success: false,
 			Error:   err.Error(),

--- a/src/storage/ducklake/sql_lake_insert.go
+++ b/src/storage/ducklake/sql_lake_insert.go
@@ -7,12 +7,17 @@ package ducklake
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/sipcapture/homer-core/src/decoder"
 )
+
+// lakeIdent is the only catalog name shape interpolated into INSERT FQNs.
+// proto_type / sub_type from HTTP never enter this string.
+var lakeIdent = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 // ConvertHEPToLakeRow maps a decoded HEP record to a DuckLake row (table key + column values).
 func ConvertHEPToLakeRow(hep *decoder.HEP) (TableKey, []interface{}, error) {
@@ -49,6 +54,17 @@ func schemaForKey(key TableKey) *TableSchema {
 	return GetDefaultSchema(key)
 }
 
+// KnownTableSchema returns the allowlisted schema for key. Unknown keys
+// (including GetDefaultSchema fallbacks) are rejected so table/column
+// identifiers in INSERT SQL never come from request JSON.
+func KnownTableSchema(key TableKey) (*TableSchema, error) {
+	s, ok := GetTableSchemas()[key]
+	if !ok || s == nil {
+		return nil, fmt.Errorf("unknown table proto_type=%d sub_type=%q", key.ProtoType, key.SubType)
+	}
+	return s, nil
+}
+
 // insertColumnNames parses the column list from InsertSQL, e.g. "(uuid, date, ...) VALUES".
 func insertColumnNames(schema *TableSchema) []string {
 	s := schema.InsertSQL
@@ -83,6 +99,139 @@ func InsertColumnNamesForKey(key TableKey) []string {
 // aligned with InsertSQL in tables.go).
 func SIPCallInsertColumnNames() []string {
 	return InsertColumnNamesForKey(TableKey{ProtoType: ProtoTypeSIP, SubType: SIPTypeCall})
+}
+
+func jsonCellText(cell interface{}) (string, bool) {
+	switch x := cell.(type) {
+	case string:
+		return x, true
+	case json.RawMessage:
+		return string(x), true
+	case []byte:
+		return string(x), true
+	case *[]byte:
+		if x == nil {
+			return "", false
+		}
+		return string(*x), true
+	case map[string]interface{}:
+		b, err := json.Marshal(x)
+		if err != nil {
+			return "", false
+		}
+		return string(b), true
+	default:
+		return "", false
+	}
+}
+
+// JSONSafeInsertRows copies rows so encoding/json can serialize them:
+// pooled *[]byte / json.RawMessage become JSON text strings (not base64).
+func JSONSafeInsertRows(rows [][]interface{}) [][]interface{} {
+	out := make([][]interface{}, len(rows))
+	for i, row := range rows {
+		nr := make([]interface{}, len(row))
+		for j, cell := range row {
+			if text, ok := jsonCellText(cell); ok {
+				if _, isString := cell.(string); isString {
+					nr[j] = cell
+				} else {
+					nr[j] = text
+				}
+			} else {
+				nr[j] = cell
+			}
+		}
+		out[i] = nr
+	}
+	return out
+}
+
+func bindInsertArg(col string, cell interface{}) interface{} {
+	if col == "data_extra" {
+		if text, ok := jsonCellText(cell); ok && text != "" {
+			return text
+		}
+		return "{}"
+	}
+	switch x := cell.(type) {
+	case float64:
+		if x == float64(int64(x)) {
+			return int64(x)
+		}
+		return x
+	case json.Number:
+		if i, err := x.Int64(); err == nil {
+			return i
+		}
+		if f, err := x.Float64(); err == nil {
+			return f
+		}
+		return string(x)
+	case string:
+		if col == "date" || col == "timestamp" {
+			if t, err := time.Parse(time.RFC3339Nano, x); err == nil {
+				return t.UTC()
+			}
+			if t, err := time.Parse(time.RFC3339, x); err == nil {
+				return t.UTC()
+			}
+			if t, err := time.Parse("2006-01-02", x); err == nil {
+				return t.UTC()
+			}
+		}
+		return x
+	default:
+		return cell
+	}
+}
+
+// BuildParameterizedInsert builds INSERT ... VALUES (?,?,...), ... with bound
+// arguments. Table and column names come only from KnownTableSchema (Go
+// constants). lakeName must be a simple SQL identifier (node config).
+func BuildParameterizedInsert(lakeName string, key TableKey, rows [][]interface{}) (string, []any, error) {
+	if len(rows) == 0 {
+		return "", nil, fmt.Errorf("no rows")
+	}
+	if lakeName == "" {
+		lakeName = "homer_lake"
+	}
+	if !lakeIdent.MatchString(lakeName) {
+		return "", nil, fmt.Errorf("invalid lake name")
+	}
+	schema, err := KnownTableSchema(key)
+	if err != nil {
+		return "", nil, err
+	}
+	cols := insertColumnNames(schema)
+	if len(cols) == 0 {
+		return "", nil, fmt.Errorf("no columns for key %v", key)
+	}
+	tupleParts := make([]string, len(cols))
+	for i, col := range cols {
+		if col == "data_extra" {
+			tupleParts[i] = "CAST(? AS JSON)"
+		} else {
+			tupleParts[i] = "?"
+		}
+	}
+	tuple := "(" + strings.Join(tupleParts, ", ") + ")"
+	placeholders := make([]string, len(rows))
+	args := make([]any, 0, len(rows)*len(cols))
+	for i, row := range rows {
+		if len(row) != len(cols) {
+			return "", nil, fmt.Errorf("row %d: column count %d != schema %d", i, len(row), len(cols))
+		}
+		placeholders[i] = tuple
+		for ci, cell := range row {
+			args = append(args, bindInsertArg(cols[ci], cell))
+		}
+	}
+	query := fmt.Sprintf("INSERT INTO %s (%s) VALUES %s",
+		LakeTableFQN(lakeName, schema),
+		strings.Join(cols, ", "),
+		strings.Join(placeholders, ", "))
+	return query, args, nil
 }
 
 func formatSQLLiteral(v interface{}) (string, error) {
@@ -142,17 +291,7 @@ func BuildInsertMultiValues(lakeName string, key TableKey, rows [][]interface{})
 			// string, json.RawMessage or pooled *[]byte (see
 			// buildExtraJSONCell); all three carry the raw JSON text.
 			if cols[ci] == "data_extra" {
-				var text string
-				switch x := cell.(type) {
-				case string:
-					text = x
-				case json.RawMessage:
-					text = string(x)
-				case *[]byte:
-					if x != nil {
-						text = string(*x)
-					}
-				}
+				text, _ := jsonCellText(cell)
 				if text != "" {
 					esc, err := formatSQLLiteral(text)
 					if err != nil {

--- a/src/storage/ducklake/sql_lake_insert_test.go
+++ b/src/storage/ducklake/sql_lake_insert_test.go
@@ -1,0 +1,91 @@
+// Copyright (C) 2026 Homer Server Contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package ducklake
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildParameterizedInsertAllowlist(t *testing.T) {
+	key := TableKey{ProtoType: ProtoTypeSIP, SubType: SIPTypeCall}
+	n := len(InsertColumnNamesForKey(key))
+	row := make([]interface{}, n)
+	for i := range row {
+		row[i] = "x"
+	}
+	payload := "INVITE sip:bob@evil'; DROP TABLE t;-- SIP/2.0"
+	row[16] = payload
+
+	q, args, err := BuildParameterizedInsert("homer_lake", key, [][]interface{}{row})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(q, "INSERT INTO homer_lake.main.hep_proto_1_call") {
+		t.Fatalf("unexpected query: %s", q)
+	}
+	if strings.Contains(q, payload) || strings.Contains(q, "DROP TABLE") {
+		t.Fatalf("payload leaked into SQL: %s", q)
+	}
+	if !strings.Contains(q, "CAST(? AS JSON)") {
+		t.Fatalf("expected JSON placeholder: %s", q)
+	}
+	found := false
+	for _, a := range args {
+		if s, ok := a.(string); ok && s == payload {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("payload missing from bound args: %#v", args)
+	}
+}
+
+func TestBuildParameterizedInsertRejectsUnknownTable(t *testing.T) {
+	_, _, err := BuildParameterizedInsert("homer_lake", TableKey{ProtoType: 99, SubType: "nope"}, [][]interface{}{{1}})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "unknown table") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestBuildParameterizedInsertJSONRoundTrip(t *testing.T) {
+	key := TableKey{ProtoType: ProtoTypeSIP, SubType: SIPTypeCall}
+	n := len(InsertColumnNamesForKey(key))
+	row := make([]interface{}, n)
+	for i := range row {
+		row[i] = "x"
+	}
+	row[1] = time.Date(2020, 5, 1, 0, 0, 0, 0, time.UTC)
+	row[2] = time.Date(2020, 5, 1, 12, 0, 0, 0, time.UTC)
+	row[8] = uint32(5060)
+	row[16] = "INVITE sip:bob@biloxi.example.com SIP/2.0"
+	row[17] = json.RawMessage(`{"k":"v"}`)
+
+	safe := JSONSafeInsertRows([][]interface{}{row})
+	raw, err := json.Marshal(safe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded [][]interface{}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	q, args, err := BuildParameterizedInsert("homer_lake", key, decoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(q, "INVITE sip:bob") {
+		t.Fatalf("payload in SQL: %s", q)
+	}
+	if len(args) != n {
+		t.Fatalf("args=%d cols=%d", len(args), n)
+	}
+}


### PR DESCRIPTION
## Summary
- Close [code-scanning/43](https://github.com/sipcapture/homer/security/code-scanning/43) (`go/sql-injection`) by removing the taint path: `POST /exec` no longer executes a client SQL string.
- New body is `{proto_type, sub_type, rows}`. Catalog comes from node config; table/columns come only from `GetTableSchemas()`. INSERT uses placeholders and `ExecContext(ctx, query, args...)`. Raw `sql` is rejected with 400.
- PCAP import now calls `InsertFirstConnected(ctx, key, rows)` instead of interpolating `INSERT ... VALUES` and posting it to `/exec`. The ineffective `// codeql[go/sql-injection]` suppression from #1007 is gone.

## Test plan
- [x] `go test ./storage/ducklake/ ./node/ ./coordinator/handlers/ ./coordinator/services/` (from `src/`)
- [x] Confirm CodeQL re-run on this PR marks alert 43 as fixed (no remaining `req.SQL` → `ExecContext` path)
- [x] Smoke PCAP SIP import against a connected node (`POST /api/v4/imports/pcap`)