### PR TITLE
fix(ui): default search results table to oldest-first (#1011, 11.0.342)

### DIFF
--- a/src/ui/src/dashboard/resultRowSort.test.ts
+++ b/src/ui/src/dashboard/resultRowSort.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import {
+  compareSearchResultRows,
+  DEFAULT_RESULT_SORT_COL,
+  DEFAULT_RESULT_SORT_DIR,
+} from './resultRowSort'
+
+describe('compareSearchResultRows', () => {
+  it('defaults to oldest-first timestamp order', () => {
+    expect(DEFAULT_RESULT_SORT_COL).toBe('timestamp')
+    expect(DEFAULT_RESULT_SORT_DIR).toBe('asc')
+  })
+
+  it('sorts INVITE before BYE when timestamps are ascending', () => {
+    const invite = { method: 'INVITE', timestamp: '2026-05-01T12:00:00Z' }
+    const bye = { method: 'BYE', timestamp: '2026-05-01T12:00:05Z' }
+    expect(compareSearchResultRows(invite, bye, 'timestamp', 'asc')).toBeLessThan(0)
+    expect(compareSearchResultRows(invite, bye, 'timestamp', 'desc')).toBeGreaterThan(0)
+  })
+
+  it('sorts a call so the first row is the earliest packet', () => {
+    const rows = [
+      { method: 'BYE', timestamp: '2026-05-01T12:00:05Z' },
+      { method: 'INVITE', timestamp: '2026-05-01T12:00:00Z' },
+      { method: '200', timestamp: '2026-05-01T12:00:01Z' },
+    ]
+    const sorted = [...rows].sort((a, b) =>
+      compareSearchResultRows(a, b, DEFAULT_RESULT_SORT_COL, DEFAULT_RESULT_SORT_DIR),
+    )
+    expect(sorted.map((r) => r.method)).toEqual(['INVITE', '200', 'BYE'])
+  })
+})

--- a/src/ui/src/dashboard/resultRowSort.test.ts
+++ b/src/ui/src/dashboard/resultRowSort.test.ts
@@ -3,6 +3,7 @@ import {
   compareSearchResultRows,
   DEFAULT_RESULT_SORT_COL,
   DEFAULT_RESULT_SORT_DIR,
+  normalizeStoredResultSort,
 } from './resultRowSort'
 
 describe('compareSearchResultRows', () => {
@@ -28,5 +29,25 @@ describe('compareSearchResultRows', () => {
       compareSearchResultRows(a, b, DEFAULT_RESULT_SORT_COL, DEFAULT_RESULT_SORT_DIR),
     )
     expect(sorted.map((r) => r.method)).toEqual(['INVITE', '200', 'BYE'])
+  })
+})
+
+describe('normalizeStoredResultSort', () => {
+  it('falls back to timestamp asc for missing or junk payloads', () => {
+    expect(normalizeStoredResultSort(null)).toEqual({
+      col: DEFAULT_RESULT_SORT_COL,
+      dir: DEFAULT_RESULT_SORT_DIR,
+    })
+    expect(normalizeStoredResultSort({ col: '_select', dir: 'desc' })).toEqual({
+      col: DEFAULT_RESULT_SORT_COL,
+      dir: DEFAULT_RESULT_SORT_DIR,
+    })
+  })
+
+  it('keeps a user-chosen column and direction', () => {
+    expect(normalizeStoredResultSort({ col: 'method', dir: 'desc' })).toEqual({
+      col: 'method',
+      dir: 'desc',
+    })
   })
 })

--- a/src/ui/src/dashboard/resultRowSort.ts
+++ b/src/ui/src/dashboard/resultRowSort.ts
@@ -1,0 +1,66 @@
+/** Default search-results table order: oldest packet first (INVITE before BYE). */
+export const DEFAULT_RESULT_SORT_COL = 'timestamp'
+export const DEFAULT_RESULT_SORT_DIR = 'asc' as const
+
+export type ResultSortDir = 'asc' | 'desc'
+
+function isTimestampSortCol(col: string): boolean {
+  const c = col.toLowerCase()
+  return c === 'timestamp' || c === 'ts' || c === 'create_date'
+}
+
+/** Parse a lake/API timestamp cell to epoch milliseconds. */
+export function timestampToMs(val: unknown): number | null {
+  if (val == null) return null
+  if (val instanceof Date) return val.getTime()
+  if (typeof val === 'number') {
+    if (val > 1e15) return Math.round(val / 1e6)
+    if (val > 1e12) return Math.round(val)
+    if (val > 1e9) return Math.round(val * 1000)
+    return val
+  }
+  if (typeof val === 'string') {
+    let s = val.trim()
+    if (/^\d{4}-\d{2}-\d{2}$/.test(s)) s = `${s}T00:00:00Z`
+    else if (s.includes(' ') && !s.includes('T')) s = s.replace(' ', 'T')
+    const d = new Date(s)
+    return Number.isNaN(d.getTime()) ? null : d.getTime()
+  }
+  return null
+}
+
+/** Row event time for sorting and /messages (never the dashboard picker). */
+export function pickRowTimestampMs(row: Record<string, unknown> | null | undefined): number | null {
+  if (!row || typeof row !== 'object') return null
+  for (const k of ['timestamp', 'TIMESTAMP', 'ts', 'TS', 'create_date', 'CREATE_DATE']) {
+    if (!Object.prototype.hasOwnProperty.call(row, k)) continue
+    const ms = timestampToMs(row[k])
+    if (ms != null) return ms
+  }
+  return null
+}
+
+export function compareSearchResultRows(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+  sortCol: string,
+  sortDir: ResultSortDir,
+): number {
+  if (isTimestampSortCol(sortCol)) {
+    const na = pickRowTimestampMs(a) ?? 0
+    const nb = pickRowTimestampMs(b) ?? 0
+    return sortDir === 'asc' ? na - nb : nb - na
+  }
+  const vaRaw = a[sortCol] ?? ''
+  const vbRaw = b[sortCol] ?? ''
+  const na = Number(vaRaw)
+  const nb = Number(vbRaw)
+  if (!Number.isNaN(na) && !Number.isNaN(nb) && vaRaw !== '' && vbRaw !== '') {
+    return sortDir === 'asc' ? na - nb : nb - na
+  }
+  const va = String(vaRaw).toLowerCase()
+  const vb = String(vbRaw).toLowerCase()
+  if (va < vb) return sortDir === 'asc' ? -1 : 1
+  if (va > vb) return sortDir === 'asc' ? 1 : -1
+  return 0
+}

--- a/src/ui/src/dashboard/resultRowSort.ts
+++ b/src/ui/src/dashboard/resultRowSort.ts
@@ -4,6 +4,28 @@ export const DEFAULT_RESULT_SORT_DIR = 'asc' as const
 
 export type ResultSortDir = 'asc' | 'desc'
 
+export interface StoredResultSort {
+  col: string
+  dir: ResultSortDir
+}
+
+const defaultStoredSort: StoredResultSort = {
+  col: DEFAULT_RESULT_SORT_COL,
+  dir: DEFAULT_RESULT_SORT_DIR,
+}
+
+/** Parse localStorage sort prefs; invalid payloads fall back to timestamp asc. */
+export function normalizeStoredResultSort(raw: unknown): StoredResultSort {
+  if (!raw || typeof raw !== 'object') return { ...defaultStoredSort }
+  const rec = raw as Record<string, unknown>
+  const col = typeof rec.col === 'string' ? rec.col.trim() : ''
+  if (!col || col.startsWith('_')) return { ...defaultStoredSort }
+  return {
+    col,
+    dir: rec.dir === 'desc' ? 'desc' : 'asc',
+  }
+}
+
 function isTimestampSortCol(col: string): boolean {
   const c = col.toLowerCase()
   return c === 'timestamp' || c === 'ts' || c === 'create_date'

--- a/src/ui/src/dashboard/widgets/ResultsPanel.tsx
+++ b/src/ui/src/dashboard/widgets/ResultsPanel.tsx
@@ -46,8 +46,7 @@ import { columnDisplayLabel, columnDisplayTitle } from '../resultColumnLabels'
 import { ensureNodeNameKey, promoteDataExtraNodeName } from '../promoteDataExtraNodeName'
 import {
   compareSearchResultRows,
-  DEFAULT_RESULT_SORT_COL,
-  DEFAULT_RESULT_SORT_DIR,
+  normalizeStoredResultSort,
   pickRowTimestampMs,
 } from '../resultRowSort'
 
@@ -107,6 +106,7 @@ function useIsDark() {
 
 const LS_KEY_HIDDEN = (id, proto, event) => `results_hidden_cols_${id}_p${proto}_e${event}`
 const LS_KEY_ORDER  = (id, proto, event) => `results_col_order_${id}_p${proto}_e${event}`
+const LS_KEY_SORT   = (id, proto, event) => `results_sort_${id}_p${proto}_e${event}`
 const LS_KEY_OTLP_METRICS_TAB = (id) => `results_otlp_metrics_tab_${id}`
 const LS_KEY_OTLP_METRICS_CHART = (id) => `results_otlp_metrics_chart_type_${id}`
 
@@ -116,6 +116,9 @@ function loadLS(key, fallback) {
 }
 function saveLS(key, value) {
   try { localStorage.setItem(key, JSON.stringify(value)) } catch { /* ignore */ }
+}
+function loadResultSort(widgetId, proto, event) {
+  return normalizeStoredResultSort(loadLS(LS_KEY_SORT(widgetId, proto, event), null))
 }
 
 /** Lake / API message id (POST /messages); DuckDB may expose column as UUID. */
@@ -298,8 +301,8 @@ export default function ResultsPanel({ widgetId, config: _config }) {
   const [currentEvent, setCurrentEvent] = useState('call')
   const [hiddenColumns, setHiddenColumns] = useState(() => loadLS(LS_KEY_HIDDEN(widgetId, '1', 'call'), []))
   const [columnOrder, setColumnOrder] = useState(() => loadLS(LS_KEY_ORDER(widgetId, '1', 'call'), []))
-  const [sortCol, setSortCol] = useState(DEFAULT_RESULT_SORT_COL)
-  const [sortDir, setSortDir] = useState(DEFAULT_RESULT_SORT_DIR)
+  const [sortCol, setSortCol] = useState(() => loadResultSort(widgetId, '1', 'call').col)
+  const [sortDir, setSortDir] = useState(() => loadResultSort(widgetId, '1', 'call').dir)
   const [colorByCall, setColorByCall] = useState(() => loadLS(`results_color_by_call_${widgetId}`, true))
   const [otlpMetricsTab, setOtlpMetricsTab] = useState(() => {
     const t = loadLS(LS_KEY_OTLP_METRICS_TAB(widgetId), 'chart')
@@ -329,8 +332,9 @@ export default function ResultsPanel({ widgetId, config: _config }) {
     setCurrentEvent(event)
     setHiddenColumns(loadLS(LS_KEY_HIDDEN(widgetId, proto, event), []))
     setColumnOrder(loadLS(LS_KEY_ORDER(widgetId, proto, event), []))
-    setSortCol(DEFAULT_RESULT_SORT_COL)
-    setSortDir(DEFAULT_RESULT_SORT_DIR)
+    const sort = loadResultSort(widgetId, proto, event)
+    setSortCol(sort.col)
+    setSortDir(sort.dir)
     setLoading(true)
     setStatus('')
     setGeneratedSql('')
@@ -468,14 +472,11 @@ export default function ResultsPanel({ widgetId, config: _config }) {
 
   const handleSort = (col) => {
     if (col === '_actions' || col === '_select') return
-    setSortCol((prev) => {
-      if (prev === col) {
-        setSortDir((d) => d === 'asc' ? 'desc' : 'asc')
-        return col
-      }
-      setSortDir('asc')
-      return col
-    })
+    const nextCol = col
+    const nextDir = sortCol === col ? (sortDir === 'asc' ? 'desc' : 'asc') : 'asc'
+    setSortCol(nextCol)
+    setSortDir(nextDir)
+    saveLS(LS_KEY_SORT(widgetId, currentProto, currentEvent), { col: nextCol, dir: nextDir })
     setScrollTop(0)
     if (containerRef.current) containerRef.current.scrollTop = 0
   }

--- a/src/ui/src/dashboard/widgets/ResultsPanel.tsx
+++ b/src/ui/src/dashboard/widgets/ResultsPanel.tsx
@@ -44,6 +44,12 @@ import MessageModal from '../MessageModal'
 import { useLocale } from '@/components/locale/locale-provider'
 import { columnDisplayLabel, columnDisplayTitle } from '../resultColumnLabels'
 import { ensureNodeNameKey, promoteDataExtraNodeName } from '../promoteDataExtraNodeName'
+import {
+  compareSearchResultRows,
+  DEFAULT_RESULT_SORT_COL,
+  DEFAULT_RESULT_SORT_DIR,
+  pickRowTimestampMs,
+} from '../resultRowSort'
 
 const OTLP_TRACES_PROTO = 200
 const OTLP_METRICS_PROTO = 201
@@ -136,36 +142,6 @@ function pickSessionForTx(row, protoType) {
   const v = row.session_id ?? row.cid ?? row.SESSION_ID ?? row.CID
   if (v != null && String(v).trim() !== '') return String(v).trim()
   return ''
-}
-
-function timestampToMs(val) {
-  if (val == null && val !== 0) return null
-  if (val instanceof Date) return val.getTime()
-  if (typeof val === 'number') {
-    if (val > 1e15) return Math.round(val / 1e6)
-    if (val > 1e12) return Math.round(val)
-    if (val > 1e9) return Math.round(val * 1000)
-    return val
-  }
-  if (typeof val === 'string') {
-    let s = val.trim()
-    if (/^\d{4}-\d{2}-\d{2}$/.test(s)) s = `${s}T00:00:00Z`
-    else if (s.includes(' ') && !s.includes('T')) s = s.replace(' ', 'T')
-    const d = new Date(s)
-    return Number.isNaN(d.getTime()) ? null : d.getTime()
-  }
-  return null
-}
-
-/** Row event time for /messages (never use dashboard time picker here). */
-function pickRowTimestampMs(row) {
-  if (!row || typeof row !== 'object') return null
-  for (const k of ['timestamp', 'TIMESTAMP', 'ts', 'TS', 'create_date', 'CREATE_DATE']) {
-    if (!Object.prototype.hasOwnProperty.call(row, k)) continue
-    const ms = timestampToMs(row[k])
-    if (ms != null) return ms
-  }
-  return null
 }
 
 /** Stable key for row selection: uuid when present, else index in filteredRows. */
@@ -322,8 +298,8 @@ export default function ResultsPanel({ widgetId, config: _config }) {
   const [currentEvent, setCurrentEvent] = useState('call')
   const [hiddenColumns, setHiddenColumns] = useState(() => loadLS(LS_KEY_HIDDEN(widgetId, '1', 'call'), []))
   const [columnOrder, setColumnOrder] = useState(() => loadLS(LS_KEY_ORDER(widgetId, '1', 'call'), []))
-  const [sortCol, setSortCol] = useState(null)
-  const [sortDir, setSortDir] = useState('asc')
+  const [sortCol, setSortCol] = useState(DEFAULT_RESULT_SORT_COL)
+  const [sortDir, setSortDir] = useState(DEFAULT_RESULT_SORT_DIR)
   const [colorByCall, setColorByCall] = useState(() => loadLS(`results_color_by_call_${widgetId}`, true))
   const [otlpMetricsTab, setOtlpMetricsTab] = useState(() => {
     const t = loadLS(LS_KEY_OTLP_METRICS_TAB(widgetId), 'chart')
@@ -353,8 +329,8 @@ export default function ResultsPanel({ widgetId, config: _config }) {
     setCurrentEvent(event)
     setHiddenColumns(loadLS(LS_KEY_HIDDEN(widgetId, proto, event), []))
     setColumnOrder(loadLS(LS_KEY_ORDER(widgetId, proto, event), []))
-    setSortCol(null)
-    setSortDir('asc')
+    setSortCol(DEFAULT_RESULT_SORT_COL)
+    setSortDir(DEFAULT_RESULT_SORT_DIR)
     setLoading(true)
     setStatus('')
     setGeneratedSql('')
@@ -513,19 +489,7 @@ export default function ResultsPanel({ widgetId, config: _config }) {
       )
     }
     if (!sortCol) return result
-    return [...result].sort((a, b) => {
-      let va = a[sortCol] ?? ''
-      let vb = b[sortCol] ?? ''
-      const na = Number(va), nb = Number(vb)
-      if (!isNaN(na) && !isNaN(nb) && va !== '' && vb !== '') {
-        return sortDir === 'asc' ? na - nb : nb - na
-      }
-      va = String(va).toLowerCase()
-      vb = String(vb).toLowerCase()
-      if (va < vb) return sortDir === 'asc' ? -1 : 1
-      if (va > vb) return sortDir === 'asc' ? 1 : -1
-      return 0
-    })
+    return [...result].sort((a, b) => compareSearchResultRows(a, b, sortCol, sortDir))
   }, [rows, filterText, sortCol, sortDir])
 
   const totalRows = filteredRows?.length || 0

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.341"
+	VERSION_APPLICATION = "11.0.342"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Fixes #1011: the search results table now defaults to **timestamp ascending** (old → new), so a call starts with INVITE instead of BYE.
- Sort column and direction are persisted in localStorage per widget/protocol/event, same as hidden columns.
- API still returns the newest N rows (`ORDER BY timestamp DESC` / stream top-N). Display sort is client-side only — no extra SQL `ORDER BY`.
- Version **11.0.342**.

## Test plan
- [x] `npx vitest run src/dashboard/resultRowSort.test.ts`
- [x] Search a Call-ID / session: first row is the earliest packet (INVITE), last is BYE
- [x] Click the timestamp header: order flips to newest first and survives reload / a new search
- [x] Confirm a wide-window search still returns recent packets (LIMIT / top-N unchanged)