### PR TITLE
fix: let admins update shared dashboards

### DIFF
--- a/src/coordinator/handlers/dashboards_v4.go
+++ b/src/coordinator/handlers/dashboards_v4.go
@@ -9,6 +9,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"sort"
@@ -228,7 +229,11 @@ func (h *DashboardsHandler) V4DashboardsUpdate(c echo.Context) error {
 	}
 	merged["id"] = dashboardID
 	merged["param"] = dashboardID
-	if owner, ok := merged["owner"].(string); !ok || owner == "" {
+	// Keep the stored owner. An admin saving a shared dashboard must not
+	// rewrite the row onto their own username (issue #1017).
+	if setting.UserName != "" {
+		merged["owner"] = setting.UserName
+	} else if owner, ok := merged["owner"].(string); !ok || owner == "" {
 		merged["owner"] = username
 	}
 
@@ -237,8 +242,11 @@ func (h *DashboardsHandler) V4DashboardsUpdate(c echo.Context) error {
 		return writeError(c, http.StatusBadRequest, "Bad Request", "Invalid dashboard payload")
 	}
 
-	guid, err := h.service.UpdateDashboard(c.Request().Context(), username, dashboardID, payload)
+	guid, err := h.service.UpdateDashboard(c.Request().Context(), username, dashboardID, payload, isAdmin(c))
 	if err != nil {
+		if errors.Is(err, services.ErrDashboardNotWritable) {
+			return writeError(c, http.StatusForbidden, "Forbidden", "Only the owner or an admin can update this dashboard")
+		}
 		return writeError(c, http.StatusInternalServerError, "Server Error", "Failed to update dashboard")
 	}
 	if guid == "" {

--- a/src/coordinator/handlers/dashboards_v4_test.go
+++ b/src/coordinator/handlers/dashboards_v4_test.go
@@ -1,0 +1,105 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/labstack/echo/v4"
+	"github.com/sipcapture/homer-core/src/config"
+	"github.com/sipcapture/homer-core/src/coordinator/services"
+)
+
+func newTestDashboardsHandler(t *testing.T) *DashboardsHandler {
+	t.Helper()
+	db, err := services.OpenSettingsDB(filepath.Join(t.TempDir(), "settings.duckdb"))
+	if err != nil {
+		t.Fatalf("OpenSettingsDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := services.EnsureSettingsSchema(db); err != nil {
+		t.Fatalf("EnsureSettingsSchema: %v", err)
+	}
+	return NewDashboardsHandler(services.NewDashboardService(db, config.DefaultWidgetControl()))
+}
+
+func setDashboardJWT(c echo.Context, username string, admin bool) {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, &JWTClaims{
+		Username: username,
+		Admin:    admin,
+	})
+	c.Set("user", token)
+}
+
+func putDashboard(t *testing.T, h *DashboardsHandler, username string, admin bool, dashboardID, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPut, "/api/v4/dashboards/"+dashboardID, strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("dashboardId")
+	c.SetParamValues(dashboardID)
+	setDashboardJWT(c, username, admin)
+	if err := h.V4DashboardsUpdate(c); err != nil {
+		t.Fatal(err)
+	}
+	return rec
+}
+
+func TestV4DashboardsUpdate_AdminCanSaveSharedDashboard(t *testing.T) {
+	h := newTestDashboardsHandler(t)
+	ctx := context.Background()
+	if _, err := h.service.CreateDashboard(ctx, "alice", "ops", json.RawMessage(`{"name":"Before","owner":"alice","shared":true}`)); err != nil {
+		t.Fatalf("CreateDashboard: %v", err)
+	}
+
+	rec := putDashboard(t, h, "bob", true, "ops", `{"name":"After","owner":"bob","shared":true}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200 body=%s", rec.Code, rec.Body.String())
+	}
+
+	got, err := h.service.GetDashboard(ctx, "carol", "ops")
+	if err != nil || got == nil {
+		t.Fatalf("GetDashboard: err=%v got=%v", err, got)
+	}
+	if !strings.EqualFold(got.UserName, "alice") {
+		t.Errorf("username column: got %q want alice", got.UserName)
+	}
+	var data map[string]interface{}
+	if err := json.Unmarshal(got.Data, &data); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if data["name"] != "After" {
+		t.Errorf("name: got %#v", data["name"])
+	}
+	if data["owner"] != "alice" {
+		t.Errorf("JSON owner: got %#v want alice", data["owner"])
+	}
+}
+
+func TestV4DashboardsUpdate_NonAdminGets403OnSharedDashboard(t *testing.T) {
+	h := newTestDashboardsHandler(t)
+	ctx := context.Background()
+	if _, err := h.service.CreateDashboard(ctx, "alice", "ops", json.RawMessage(`{"name":"Before","shared":true}`)); err != nil {
+		t.Fatalf("CreateDashboard: %v", err)
+	}
+
+	rec := putDashboard(t, h, "bob", false, "ops", `{"name":"After","shared":true}`)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status: got %d want 403 body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestV4DashboardsUpdate_MissingDashboardIs404(t *testing.T) {
+	h := newTestDashboardsHandler(t)
+	rec := putDashboard(t, h, "bob", true, "missing", `{"name":"Nope"}`)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404 body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/src/coordinator/services/dashboard_service.go
+++ b/src/coordinator/services/dashboard_service.go
@@ -11,11 +11,16 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/sipcapture/homer-core/src/config"
 )
+
+// ErrDashboardNotWritable is returned when the dashboard is visible (typically
+// shared) but the caller is not the owner and is not allowed to change it.
+var ErrDashboardNotWritable = errors.New("dashboard not writable")
 
 // DashboardService provides dashboard operations backed by dashboard_settings.
 type DashboardService struct {
@@ -131,19 +136,35 @@ func (s *DashboardService) CreateDashboard(ctx context.Context, username, dashbo
 	return guid, nil
 }
 
-func (s *DashboardService) UpdateDashboard(ctx context.Context, username, dashboardID string, data json.RawMessage) (string, error) {
+func (s *DashboardService) UpdateDashboard(ctx context.Context, username, dashboardID string, data json.RawMessage, isAdmin bool) (string, error) {
 	if s.db == nil {
 		return "", fmt.Errorf("settings db not available")
 	}
 
+	target, err := s.GetDashboard(ctx, username, dashboardID)
+	if err != nil {
+		return "", err
+	}
+	if target == nil {
+		return "", nil
+	}
+	if !canWriteDashboard(*target, username, isAdmin) {
+		return "", ErrDashboardNotWritable
+	}
+
+	data, err = pinDashboardOwner(data, target.UserName)
+	if err != nil {
+		return "", err
+	}
+
+	// Key by guid so a shared id like "home" cannot clobber another user's row.
 	sqlUpdate := fmt.Sprintf(
 		`UPDATE dashboard_settings
 		 SET data = '%s'
-		 WHERE username = '%s' AND dashboard_id = '%s'
+		 WHERE guid = '%s'
 		 RETURNING guid`,
 		escapeJSONData(string(data)),
-		escapeSQL(username),
-		escapeSQL(dashboardID),
+		escapeSQL(target.GUID),
 	)
 	var guid string
 	if err := s.db.QueryRowContext(ctx, sqlUpdate).Scan(&guid); err != nil {
@@ -153,6 +174,29 @@ func (s *DashboardService) UpdateDashboard(ctx context.Context, username, dashbo
 		return "", err
 	}
 	return guid, nil
+}
+
+func canWriteDashboard(setting UserSetting, username string, isAdmin bool) bool {
+	if strings.EqualFold(setting.UserName, username) {
+		return true
+	}
+	return isAdmin && isDashboardShared(setting.Data)
+}
+
+func pinDashboardOwner(data json.RawMessage, owner string) (json.RawMessage, error) {
+	if owner == "" || len(data) == 0 {
+		return data, nil
+	}
+	merged := map[string]interface{}{}
+	if err := json.Unmarshal(data, &merged); err != nil {
+		return nil, err
+	}
+	merged["owner"] = owner
+	out, err := json.Marshal(merged)
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(out), nil
 }
 
 func (s *DashboardService) DeleteDashboard(ctx context.Context, username, dashboardID string) (bool, error) {

--- a/src/coordinator/services/dashboard_service_test.go
+++ b/src/coordinator/services/dashboard_service_test.go
@@ -229,7 +229,8 @@ func TestResetDashboards_SeedsIndependentDefaultsPerUser(t *testing.T) {
 	}
 }
 
-func TestCreateDashboard_AllowsSameIDForDifferentUsers(t *testing.T) {
+func newTestDashboardService(t *testing.T) *DashboardService {
+	t.Helper()
 	dir := t.TempDir()
 	db, err := OpenSettingsDB(filepath.Join(dir, "settings.duckdb"))
 	if err != nil {
@@ -239,8 +240,11 @@ func TestCreateDashboard_AllowsSameIDForDifferentUsers(t *testing.T) {
 	if err := EnsureSettingsSchema(db); err != nil {
 		t.Fatalf("EnsureSettingsSchema: %v", err)
 	}
+	return NewDashboardService(db, config.DefaultWidgetControl())
+}
 
-	svc := NewDashboardService(db, config.DefaultWidgetControl())
+func TestCreateDashboard_AllowsSameIDForDifferentUsers(t *testing.T) {
+	svc := newTestDashboardService(t)
 	ctx := context.Background()
 	payload := json.RawMessage(`{"name":"Custom","param":"custom","shared":false}`)
 
@@ -253,6 +257,162 @@ func TestCreateDashboard_AllowsSameIDForDifferentUsers(t *testing.T) {
 	if _, err := svc.CreateDashboard(ctx, "alice", "custom", payload); err == nil {
 		t.Fatal("expected error creating duplicate dashboard for same user")
 	}
+}
+
+func TestUpdateDashboard_OwnerCanUpdateOwnShared(t *testing.T) {
+	svc := newTestDashboardService(t)
+	ctx := context.Background()
+	if _, err := svc.CreateDashboard(ctx, "alice", "ops", json.RawMessage(`{"name":"Before","shared":true}`)); err != nil {
+		t.Fatalf("CreateDashboard: %v", err)
+	}
+
+	guid, err := svc.UpdateDashboard(ctx, "alice", "ops", json.RawMessage(`{"name":"After","shared":true}`), false)
+	if err != nil {
+		t.Fatalf("UpdateDashboard: %v", err)
+	}
+	if guid == "" {
+		t.Fatal("owner update returned empty guid")
+	}
+
+	got, err := svc.GetDashboard(ctx, "alice", "ops")
+	if err != nil {
+		t.Fatalf("GetDashboard: %v", err)
+	}
+	if got == nil || !strings.Contains(string(got.Data), `"After"`) {
+		t.Fatalf("owner update did not persist: %#v", got)
+	}
+}
+
+func TestUpdateDashboard_AdminCanUpdateSharedDashboard(t *testing.T) {
+	svc := newTestDashboardService(t)
+	ctx := context.Background()
+	if _, err := svc.CreateDashboard(ctx, "alice", "ops", json.RawMessage(`{"name":"Before","owner":"alice","shared":true}`)); err != nil {
+		t.Fatalf("CreateDashboard: %v", err)
+	}
+
+	guid, err := svc.UpdateDashboard(ctx, "bob", "ops", json.RawMessage(`{"name":"After","owner":"bob","shared":true}`), true)
+	if err != nil {
+		t.Fatalf("UpdateDashboard: %v", err)
+	}
+	if guid == "" {
+		t.Fatal("admin update of shared dashboard returned empty guid")
+	}
+
+	got, err := svc.GetDashboard(ctx, "carol", "ops")
+	if err != nil {
+		t.Fatalf("GetDashboard: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetDashboard: nil")
+	}
+	if !strings.EqualFold(got.UserName, "alice") {
+		t.Errorf("admin update stole username column: got %q", got.UserName)
+	}
+	if dashboardJSONField(t, got.Data, "owner") != "alice" {
+		t.Errorf("admin update stole JSON owner: %s", got.Data)
+	}
+	if dashboardJSONField(t, got.Data, "name") != "After" {
+		t.Fatalf("shared dashboard was not updated: %s", got.Data)
+	}
+}
+
+func TestUpdateDashboard_NonAdminCannotUpdateSharedDashboard(t *testing.T) {
+	svc := newTestDashboardService(t)
+	ctx := context.Background()
+	if _, err := svc.CreateDashboard(ctx, "alice", "ops", json.RawMessage(`{"name":"Before","shared":true}`)); err != nil {
+		t.Fatalf("CreateDashboard: %v", err)
+	}
+
+	guid, err := svc.UpdateDashboard(ctx, "bob", "ops", json.RawMessage(`{"name":"After","shared":true}`), false)
+	if guid != "" {
+		t.Fatalf("non-admin update returned guid %q", guid)
+	}
+	if err != ErrDashboardNotWritable {
+		t.Fatalf("UpdateDashboard err=%v want ErrDashboardNotWritable", err)
+	}
+
+	got, err := svc.GetDashboard(ctx, "bob", "ops")
+	if err != nil {
+		t.Fatalf("GetDashboard: %v", err)
+	}
+	if got == nil || strings.Contains(string(got.Data), `"After"`) {
+		t.Fatalf("non-admin must not mutate shared dashboard: %#v", got)
+	}
+}
+
+func TestUpdateDashboard_AdminCannotUpdatePrivateDashboard(t *testing.T) {
+	svc := newTestDashboardService(t)
+	ctx := context.Background()
+	if _, err := svc.CreateDashboard(ctx, "alice", "private", json.RawMessage(`{"name":"Before","shared":false}`)); err != nil {
+		t.Fatalf("CreateDashboard: %v", err)
+	}
+
+	guid, err := svc.UpdateDashboard(ctx, "bob", "private", json.RawMessage(`{"name":"After","shared":false}`), true)
+	if err != nil {
+		t.Fatalf("UpdateDashboard: %v", err)
+	}
+	if guid != "" {
+		t.Fatal("admin must not update another user's private dashboard")
+	}
+
+	got, err := svc.GetDashboard(ctx, "alice", "private")
+	if err != nil {
+		t.Fatalf("GetDashboard: %v", err)
+	}
+	if got == nil || strings.Contains(string(got.Data), `"After"`) {
+		t.Fatalf("private dashboard was mutated: %#v", got)
+	}
+}
+
+func TestUpdateDashboard_SameIDDoesNotClobberOtherUser(t *testing.T) {
+	svc := newTestDashboardService(t)
+	ctx := context.Background()
+	if _, err := svc.CreateDashboard(ctx, "alice", "home", json.RawMessage(`{"name":"Alice Home","shared":false}`)); err != nil {
+		t.Fatalf("CreateDashboard alice: %v", err)
+	}
+	if _, err := svc.CreateDashboard(ctx, "bob", "home", json.RawMessage(`{"name":"Bob Home","shared":true}`)); err != nil {
+		t.Fatalf("CreateDashboard bob: %v", err)
+	}
+
+	guid, err := svc.UpdateDashboard(ctx, "carol", "home", json.RawMessage(`{"name":"Admin Edit","shared":true}`), true)
+	if err != nil {
+		t.Fatalf("UpdateDashboard: %v", err)
+	}
+	if guid == "" {
+		t.Fatal("admin update of shared home returned empty guid")
+	}
+
+	alice, err := svc.GetDashboard(ctx, "alice", "home")
+	if err != nil {
+		t.Fatalf("GetDashboard alice: %v", err)
+	}
+	if alice == nil || !strings.Contains(string(alice.Data), `"Alice Home"`) {
+		t.Fatalf("alice private home was clobbered: %#v", alice)
+	}
+	if strings.Contains(string(alice.Data), `"Admin Edit"`) {
+		t.Fatal("alice private home picked up admin edit")
+	}
+
+	bob, err := svc.GetDashboard(ctx, "bob", "home")
+	if err != nil {
+		t.Fatalf("GetDashboard bob: %v", err)
+	}
+	if bob == nil || !strings.Contains(string(bob.Data), `"Admin Edit"`) {
+		t.Fatalf("bob shared home was not updated: %#v", bob)
+	}
+	if !strings.EqualFold(bob.UserName, "bob") {
+		t.Errorf("bob home owner drifted to %q", bob.UserName)
+	}
+}
+
+func dashboardJSONField(t *testing.T, raw json.RawMessage, key string) string {
+	t.Helper()
+	var data map[string]interface{}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		t.Fatalf("decode dashboard data: %v", err)
+	}
+	v, _ := data[key].(string)
+	return v
 }
 
 func decodeWidgets(t *testing.T, raw json.RawMessage) []string {

--- a/src/version.go
+++ b/src/version.go
@@ -24,7 +24,7 @@ import (
 // Version information for homer-core
 var (
 	// VERSION_APPLICATION is the application version
-	VERSION_APPLICATION = "11.0.342"
+	VERSION_APPLICATION = "11.0.343"
 
 	// BuildDate is the build date
 	BuildDate = ""


### PR DESCRIPTION
## Summary
- Fixes #1017: `PUT /api/v4/dashboards/:id` no longer 404s when an admin saves a shared dashboard owned by someone else (SSO included).
- Updates are keyed by dashboard `guid`, so a shared `home` cannot clobber another user's private `home`.
- Ownership is preserved; non-owner non-admins get 403 instead of a false 404.

## Test plan
- [x] `go test ./coordinator/services/ ./coordinator/handlers/`
- [x] Owner saves their own shared dashboard → 200
- [x] Second admin saves that shared dashboard → 200, owner unchanged
- [x] Non-admin saves a shared dashboard they do not own → 403
- [x] Admin cannot save another user's private dashboard